### PR TITLE
Organize accounts and groups by requesting user.

### DIFF
--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -1,43 +1,37 @@
 {
   "ec2": {
     "groups": {
-      "GROUP_ONE": {
-        "accounts": ["ACCOUNT_ONE", "ACCOUNT_TWO"],
-        "requesting_user": "user2"
+      "user2": {
+        "GROUP_ONE": ["ACCOUNT_ONE", "ACCOUNT_TWO"]
       }
     },
     "accounts": {
-      "ACCOUNT_ONE": {
-        "partition": "aws-cn",
-        "requesting_user": "user2"
+      "user2": {
+        "ACCOUNT_ONE": "aws-cn",
+        "ACCOUNT_TWO": "aws"
       },
-      "ACCOUNT_TWO": {
-        "partition": "aws",
-        "requesting_user": "user2"
-      }
     }
   },
   "azure": {
     "groups": {
-      "group1": {
-        "accounts": ["azure-china", "azure"],
-        "requesting_user": "user1"
+      "user1": {
+        "group1": ["azure-china", "azure"]
       }
     },
     "accounts": {
-      "azure-china": {
-        "region": "China East",
-        "resource_group": "cn_res_group",
-        "requesting_user": "user1",
-        "container_name": "cncontainer1",
-        "storage_account": "cnstorage1"
-      },
-      "azure": {
-        "region": "East US 2",
-        "resource_group": "res_group_2",
-        "requesting_user": "user1",
-        "container_name": "container2",
-        "storage_account": "storage2"
+      "user1": {
+        "azure-china": {
+          "region": "China East",
+          "resource_group": "cn_res_group",
+          "container_name": "cncontainer1",
+          "storage_account": "cnstorage1"
+        },
+        "azure": {
+          "region": "East US 2",
+          "resource_group": "res_group_2",
+          "container_name": "container2",
+          "storage_account": "storage2"
+        }
       }
     }
   },

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -122,7 +122,9 @@ class CredentialsService(BaseService):
         """
         accounts = [account['name'] for account in provider_accounts]
         for group in provider_groups:
-            accounts += self._get_accounts_in_group(group, provider)
+            accounts += self._get_accounts_in_group(
+                group, provider, requesting_user
+            )
 
         for account in set(accounts):
             exists = self._check_credentials_exist(
@@ -212,12 +214,12 @@ class CredentialsService(BaseService):
 
         return accounts[provider]
 
-    def _get_accounts_in_group(self, group, provider):
+    def _get_accounts_in_group(self, group, provider, user):
         """
         Return a list of account names given the group name.
         """
         accounts_info = self._get_accounts_from_file(provider)
-        return accounts_info['groups'][group]['accounts']
+        return accounts_info['groups'][user][group]
 
     def _get_credentials_file_path(self, account, provider, user):
         """

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -63,11 +63,11 @@ class BaseJob(object):
         """
         pass
 
-    def _get_accounts_in_group(self, group):
+    def _get_accounts_in_group(self, group, user):
         """
         Return a list of account names given the group name.
         """
-        return self.accounts_info['groups'][group]['accounts']
+        return self.accounts_info['groups'][user][group]
 
     def get_credentials_message(self):
         """

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -75,7 +75,9 @@ class EC2Job(BaseJob):
 
         # Get all accounts from all groups
         for group in self.provider_groups:
-            group_accounts += self._get_accounts_in_group(group)
+            group_accounts += self._get_accounts_in_group(
+                group, self.requesting_user
+            )
 
         # Add accounts from groups that don't already exist
         for account in group_accounts:
@@ -85,7 +87,9 @@ class EC2Job(BaseJob):
         for account, target_regions in accounts.items():
             if not target_regions:
                 # Get default list of all available regions for account
-                target_regions = self._get_regions_for_account(account)
+                target_regions = self._get_regions_for_account(
+                    account, self.requesting_user
+                )
 
             # A random region is selected as source region.
             target = random.choice(target_regions)
@@ -95,11 +99,11 @@ class EC2Job(BaseJob):
                 'helper_image': helper_images[target]
             }
 
-    def _get_regions_for_account(self, account):
+    def _get_regions_for_account(self, account, user):
         """
         Return a list of regions based on account name.
         """
-        regions_key = self.accounts_info['accounts'][account]['partition']
+        regions_key = self.accounts_info['accounts'][user][account]
         return self.provider_data['regions'][regions_key]
 
     def _get_target_regions_list(self):

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -1,23 +1,17 @@
 {
   "ec2": {
     "groups": {
-      "test": {
-        "accounts": ["test-aws-gov", "test-aws"],
-        "requesting_user": "user2"
+      "user2": {
+        "test": ["test-aws-gov", "test-aws"]
       },
-      "test1": {
-        "accounts": [],
-        "requesting_user": "user1"
+      "user1": {
+        "test1": []
       }
     },
     "accounts": {
-      "test-aws-gov": {
-        "partition": "aws-us-gov",
-        "requesting_user": "user2"
-      },
-      "test-aws": {
-        "partition": "aws",
-        "requesting_user": "user2"
+      "user2": {
+        "test-aws-gov": "aws-us-gov",
+        "test-aws": "aws"
       }
     }
   }

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -248,10 +248,10 @@ class TestCredentialsService(object):
     def test_get_accounts_in_group(self, mock_get_accounts_from_file):
         mock_get_accounts_from_file.return_value = {
             'groups': {
-                'test': {'accounts': ['test-1', 'test-2']}
+                'user1': {'test': ['test-1', 'test-2']}
             }
         }
-        accounts = self.service._get_accounts_in_group('test', 'ec2')
+        accounts = self.service._get_accounts_in_group('test', 'ec2', 'user1')
         assert accounts == ['test-1', 'test-2']
 
     def test_get_encrypted_credentials(self):

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -104,19 +104,14 @@ class TestJobCreatorService(object):
 
         account_info = {
             "groups": {
-                "test": {
-                    "accounts": ["test-aws-gov", "test-aws"],
-                    "requesting_user": "user1"
+                "user1": {
+                    "test": ["test-aws-gov", "test-aws"]
                 }
             },
             "accounts": {
-                "test-aws-gov": {
-                    "partition": "aws-us-gov",
-                    "requesting_user": "user1"
-                },
-                "test-aws": {
-                    "partition": "aws",
-                    "requesting_user": "user1"
+                "user1": {
+                    "test-aws-gov": "aws-us-gov",
+                    "test-aws": "aws"
                 }
             }
         }


### PR DESCRIPTION
This allows for duplicate group and account names between requesting users as discussed.