### PR TITLE
Added uploader parameters for Azure

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -64,3 +64,7 @@ provider:
       us-gov-west-1: ami-c2b5d7e1
       us-west-1: ami-d5ea86b5
       us-west-2: ami-f0091d9
+uploader:
+  azure:
+    max_chunk_byte_size: 4096
+    max_chunk_retry_attempts: 5

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -21,7 +21,6 @@ class Defaults(object):
     """
     Default values
     """
-
     @classmethod
     def get_config(self):
         return '/etc/mash/mash_config.yaml'
@@ -52,3 +51,11 @@ class Defaults(object):
     @classmethod
     def get_non_credential_service_names(self):
         return ['obs']
+
+    @classmethod
+    def get_azure_max_chunk_byte_size(self):
+        return 4096
+
+    @classmethod
+    def get_azure_max_chunk_retry_attempts(self):
+        return 5

--- a/mash/services/uploader/cloud/azure_page_blob.py
+++ b/mash/services/uploader/cloud/azure_page_blob.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 from collections import OrderedDict
+from mash.services.base_defaults import Defaults
 
 from mash.mash_exceptions import (
     MashAzurePageBlobZeroPageError,
@@ -53,9 +54,13 @@ class PageBlob(object):
                 '{0}: {1}'.format(type(e).__name__, e)
             )
 
-    def next(self, data_stream, max_chunk_byte_size=None, max_attempts=5):
-        if not max_chunk_byte_size:
-            max_chunk_byte_size = self.blob_service.MAX_CHUNK_GET_SIZE
+    def next(self, data_stream, max_chunk_byte_size=None, max_attempts=None):
+        max_chunk_byte_size = max_chunk_byte_size or \
+            Defaults.get_azure_max_chunk_byte_size()
+
+        max_attempts = max_attempts or \
+            Defaults.get_azure_max_chunk_retry_attempts()
+
         max_chunk_byte_size = int(max_chunk_byte_size)
 
         requested_bytes = min(

--- a/mash/services/uploader/config.py
+++ b/mash/services/uploader/config.py
@@ -15,19 +15,35 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
-
 from mash.services.base_config import BaseConfig
+from mash.services.base_defaults import Defaults
 
 
 class UploaderConfig(BaseConfig):
     """
     Implements reading of uploader service configuration file:
 
-    * /etc/mash/uploader_config.yml
+    * /etc/mash/mash_config.yaml
 
     The mash configuration file for the uploader service is a yaml
     formatted file containing information to control the behavior
     of the uploader service.
+
+    uploader:
+      azure:
+        # chunk size in bytes, default value taken from azure SDK
+        max_chunk_byte_size: 4096
+        # max retries on block upload error
+        max_chunk_retry_attempts: 5
     """
     def __init__(self, config_file=None):
         super(UploaderConfig, self).__init__(config_file)
+        self.azure_uploader = self._get_attribute('azure', 'uploader') or dict()
+
+    def get_azure_max_chunk_byte_size(self):
+        return self.azure_uploader.get('max_chunk_byte_size') or \
+            Defaults.get_azure_max_chunk_byte_size()
+
+    def get_azure_max_chunk_retry_attempts(self):
+        return self.azure_uploader.get('max_chunk_retry_attempts') or \
+            Defaults.get_azure_max_chunk_retry_attempts()

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -26,3 +26,7 @@ provider:
       ap-northeast-2: ami-249b554a
       cn-north-1: ami-bcc45885
       us-gov-west-1: ami-c2b5d7e1
+uploader:
+  azure:
+    max_chunk_byte_size: 4096
+    max_chunk_retry_attempts: 5


### PR DESCRIPTION
Azure upload performance is highly dependent on bandwidth of the
originating network. Like in azurectl the performance attributes
with chunk_size and chunk retry should be configurable. This
patch adds the following optional sections to the mash config
file

```yaml
uploader:
  azure:
  # chunk size in bytes, default value taken from azure SDK
  max_chunk_byte_size: 4096

  # max retries on block upload error
  max_chunk_retry_attempts: 5
```

This Fixes #232