### PR TITLE
Add download_root option to message examples.

### DIFF
--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -15,6 +15,7 @@
     {"package": ["name", "and", "constraints"]},
     {"image": "version"}
   ],
+  "download_root": "http://download.opensuse.org/repositories/",
   "share_with": "all",
   "allow_copy": false,
   "image_description": "New Image #123",

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -2,7 +2,7 @@
     "obs_job": {
         "id": "123",
         "image": "test_image_oem",
-        "project": "Virtualization:Appliances:Images:Testing_x86",
+        "project": "Virtualization:/Appliances:/Images:/Testing_x86",
         "utctime": "now",
         "conditions": [
             {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -27,7 +27,7 @@ class AzureJob(BaseJob):
         self, job_id, accounts_info, provider_data, provider,
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
-        image_description, distro, tests, conditions=None,
+        image_description, distro, tests, conditions=None, download_root=None,
         instance_type=None
     ):
         self.target_account_info = {}
@@ -36,7 +36,8 @@ class AzureJob(BaseJob):
             job_id, accounts_info, provider_data, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
-            image_description, distro, tests, conditions, instance_type
+            image_description, distro, tests, conditions, download_root,
+            instance_type
         )
 
     def _get_account_info(self):

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -30,7 +30,7 @@ class BaseJob(object):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
         image_description, distro, tests,
-        conditions=None, instance_type=None
+        conditions=None, download_root=None, instance_type=None
     ):
         self.id = job_id
         self.accounts_info = accounts_info
@@ -48,6 +48,7 @@ class BaseJob(object):
         self.distro = distro
         self.tests = tests
         self.conditions = conditions
+        self.download_root = download_root
         self.instance_type = instance_type
         self.utctime = utctime
 
@@ -126,6 +127,9 @@ class BaseJob(object):
 
         if self.conditions:
             obs_message['obs_job']['conditions'] = self.conditions
+
+        if self.download_root:
+            obs_message['obs_job']['download_root'] = self.download_root
 
         return json.dumps(obs_message, sort_keys=True)
 

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -33,7 +33,7 @@ class EC2Job(BaseJob):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
         share_with, allow_copy, image_description, distro,
-        tests, conditions=None, instance_type=None
+        tests, conditions=None, download_root=None, instance_type=None
     ):
         self.share_with = share_with
         self.allow_copy = allow_copy
@@ -43,7 +43,8 @@ class EC2Job(BaseJob):
             job_id, accounts_info, provider_data, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
-            image_description, distro, tests, conditions, instance_type
+            image_description, distro, tests, conditions, download_root,
+            instance_type
         )
 
     def _get_account_info(self):

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -140,6 +140,7 @@ base_job_message = {
             },
             'minItems': 1
         },
+        'download_root': {'$ref': '#/definitions/non_empty_string'},
         'image_description': {'$ref': '#/definitions/non_empty_string'},
         'distro': {'$ref': '#/definitions/non_empty_string'},
         'instance_type': {'$ref': '#/definitions/non_empty_string'},

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -15,6 +15,7 @@
     {"package": ["name", "and", "constraints"]},
     {"image": "version"}
   ],
+  "download_root": "http://download.opensuse.org/repositories/",
   "share_with": "all",
   "allow_copy": false,
   "image_description": "New Image #123",

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -137,6 +137,7 @@ class TestJobCreatorService(object):
             '{"obs_job": {'
             '"conditions": [{"package": ["name", "and", "constraints"]}, '
             '{"image": "version"}], '
+            '"download_root": "http://download.opensuse.org/repositories/", '
             '"id": "12345678-1234-1234-1234-123456789012", '
             '"image": "test_image_oem", '
             '"project": "Cloud:Tools", '


### PR DESCRIPTION
Process download_root in job creator obs messages.

Closes #253 