### PR TITLE
Remove duplicate job doc logging.

### DIFF
--- a/mash/services/deprecation/service.py
+++ b/mash/services/deprecation/service.py
@@ -127,8 +127,8 @@ class DeprecationService(BaseService):
 
             self.bind_listener_queue(job.id)
             self.log.info(
-                'Job queued, awaiting publisher result: {0}'.format(
-                    json.dumps(job_config, indent=2)
+                'Job {0} queued, awaiting publisher result.'.format(
+                    job.id
                 ),
                 extra=job.get_metadata()
             )

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -120,8 +120,8 @@ class PublisherService(BaseService):
 
             self.bind_listener_queue(job.id)
             self.log.info(
-                'Job queued, awaiting replication result: {0}'.format(
-                    json.dumps(job_config, indent=2)
+                'Job {0} queued, awaiting replication result.'.format(
+                    job.id
                 ),
                 extra=job.get_metadata()
             )

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -121,8 +121,8 @@ class ReplicationService(BaseService):
 
             self.bind_listener_queue(job.id)
             self.log.info(
-                'Job queued, awaiting testing result: {0}'.format(
-                    json.dumps(job_config, indent=2)
+                'Job {0} queued, awaiting testing result.'.format(
+                    job.id
                 ),
                 extra=job.get_metadata()
             )

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -142,8 +142,8 @@ class TestingService(BaseService):
 
             self.bind_listener_queue(job.id)
             self.log.info(
-                'Job queued, awaiting uploader result: {0}'.format(
-                    json.dumps(job_config, indent=2)
+                'Job {0} queued, awaiting uploader result.'.format(
+                    job.id
                 ),
                 extra=job.get_metadata()
             )

--- a/test/unit/services/deprecation/service_test.py
+++ b/test/unit/services/deprecation/service_test.py
@@ -1,5 +1,3 @@
-import json
-
 from pytest import raises
 from unittest.mock import call, MagicMock, Mock, patch
 
@@ -169,9 +167,7 @@ class TestDeprecationService(object):
         assert job.job_file == 'temp-config.json'
         mock_bind_listener_queue.assert_called_once_with('1')
         self.deprecation.log.info.assert_called_once_with(
-            'Job queued, awaiting publisher result: {0}'.format(
-                json.dumps(job_config, indent=2)
-            ),
+            'Job 1 queued, awaiting publisher result.',
             extra={'job_id': '1'}
         )
 

--- a/test/unit/services/publisher/service_test.py
+++ b/test/unit/services/publisher/service_test.py
@@ -1,5 +1,3 @@
-import json
-
 from pytest import raises
 from unittest.mock import call, MagicMock, Mock, patch
 
@@ -162,9 +160,7 @@ class TestPublisherService(object):
         assert job.job_file == 'temp-config.json'
         mock_bind_listener_queue.assert_called_once_with('1')
         self.publisher.log.info.assert_called_once_with(
-            'Job queued, awaiting replication result: {0}'.format(
-                json.dumps(job_config, indent=2)
-            ),
+            'Job 1 queued, awaiting replication result.',
             extra={'job_id': '1'}
         )
 

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -1,5 +1,3 @@
-import json
-
 from pytest import raises
 
 from unittest.mock import call, MagicMock, Mock, patch
@@ -165,9 +163,7 @@ class TestReplicationService(object):
         assert job.job_file == 'temp-config.json'
         mock_bind_listener_queue.assert_called_once_with('1')
         self.replication.log.info.assert_called_once_with(
-            'Job queued, awaiting testing result: {0}'.format(
-                json.dumps(job_config, indent=2)
-            ),
+            'Job 1 queued, awaiting testing result.',
             extra={'job_id': '1'}
         )
 

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -1,5 +1,4 @@
 import io
-import json
 
 from pytest import raises
 from unittest.mock import call, MagicMock, Mock, patch
@@ -148,9 +147,7 @@ class TestIPATestingService(object):
         assert job.job_file == 'temp-config.json'
         mock_bind_listener_queue.assert_called_once_with(job.id)
         self.testing.log.info.assert_called_once_with(
-            'Job queued, awaiting uploader result: {0}'.format(
-                json.dumps(job_config, indent=2)
-            ),
+            'Job 1 queued, awaiting uploader result.',
             extra={'job_id': '1'}
         )
 


### PR DESCRIPTION
Job docs are now logged by job creator so only log job id.