### PR TITLE
Handle special regions for ec2.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -25,7 +25,6 @@ provider:
       aws:
         - ap-northeast-1
         - ap-northeast-2
-        - ap-northeast-3
         - ap-south-1
         - ap-southeast-1
         - ap-southeast-2
@@ -47,7 +46,6 @@ provider:
     helper_images:
       ap-northeast-1: ami-383c1956
       ap-northeast-2: ami-249b554a
-      ap-northeast-3: ami-82444aff
       ap-southeast-1: ami-c9b572aa
       ap-southeast-2: ami-48d38c2b
       ap-south-1: ami-a6d1bac9

--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -7,9 +7,25 @@
     },
     "accounts": {
       "user2": {
-        "ACCOUNT_ONE": "aws-cn",
-        "ACCOUNT_TWO": "aws"
-      },
+        "ACCOUNT_ONE": {
+          "additional_regions": [
+            {
+              "name": "ap-northeast-4",
+              "helper_image": "ami-82444aff"
+            }
+          ],
+          "partition": "aws-us-gov"
+        },
+        "ACCOUNT_TWO": {
+          "additional_regions": [
+            {
+              "name": "ap-northeast-3",
+              "helper_image": "ami-82444aff"
+            }
+          ],
+          "partition": "aws"
+        }
+      }
     }
   },
   "azure": {

--- a/examples/messages/add_ec2_account.json
+++ b/examples/messages/add_ec2_account.json
@@ -1,5 +1,11 @@
 {
   "account_name": "test-aws",
+  "additional_regions": [
+    {
+      "name": "ap-northeast-3",
+      "helper_image": "ami-82444aff"
+    }
+  ],
   "credentials": {
     "access_key_id": "123456",
     "secret_access_key": "654321"

--- a/mash/services/credentials/ec2_account.py
+++ b/mash/services/credentials/ec2_account.py
@@ -31,6 +31,7 @@ class EC2Account(BaseAccount):
             message['provider'], message['requesting_user'],
             group_name=message.get('group')
         )
+        self.additional_regions = message.get('additional_regions')
         self.partition = message['partition']
 
     def add_account(self, accounts_file):
@@ -45,7 +46,10 @@ class EC2Account(BaseAccount):
             accounts[self.account_name] = self.partition
         else:
             accounts_file[self.provider]['accounts'][self.requesting_user] = {
-                self.account_name: self.partition
+                self.account_name: {
+                    'additional_regions': self.additional_regions,
+                    'partition': self.partition
+                }
             }
 
         # Add group if necessary

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -92,6 +92,16 @@ class EC2Job(BaseJob):
                     account, self.requesting_user
                 )
 
+            # Add additional regions for account
+            additional_regions = \
+                self.accounts_info['accounts'][self.requesting_user][account]\
+                    .get('additional_regions')
+
+            if additional_regions:
+                for region in additional_regions:
+                    helper_images[region['name']] = region['helper_image']
+                    target_regions.append(region['name'])
+
             # A random region is selected as source region.
             index = random.randint(0, len(target_regions) - 1)
             target = target_regions[index]
@@ -105,7 +115,7 @@ class EC2Job(BaseJob):
         """
         Return a list of regions based on account name.
         """
-        regions_key = self.accounts_info['accounts'][user][account]
+        regions_key = self.accounts_info['accounts'][user][account]['partition']
         return self.provider_data['regions'][regions_key]
 
     def _get_target_regions_list(self):

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -62,6 +62,19 @@ add_account_ec2 = {
     'type': 'object',
     'properties': {
         'account_name': {'$ref': '#/definitions/non_empty_string'},
+        'additional_regions': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'name': {'$ref': '#/definitions/non_empty_string'},
+                    'helper_image': {'$ref': '#/definitions/non_empty_string'}
+                },
+                'required': ['name', 'helper_image'],
+                'additionalProperties': False
+            },
+            'minItems': 1
+        },
         'credentials': {
             'type': 'object',
             'properties': {

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -10,8 +10,24 @@
     },
     "accounts": {
       "user2": {
-        "test-aws-gov": "aws-us-gov",
-        "test-aws": "aws"
+        "test-aws-gov": {
+          "additional_regions": [
+            {
+              "name": "ap-northeast-4",
+              "helper_image": "ami-82444aff"
+            }
+          ],
+          "partition": "aws-us-gov"
+        },
+        "test-aws": {
+          "additional_regions": [
+            {
+              "name": "ap-northeast-3",
+              "helper_image": "ami-82444aff"
+            }
+          ],
+          "partition": "aws"
+        }
       }
     }
   },

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -613,7 +613,8 @@ class TestCredentialsService(object):
             'acnt123', 'encryptedcreds', 'ec2', 'user1'
         )
 
-        assert accounts['ec2']['accounts']['user1']['acnt123'] == 'aws'
+        assert accounts['ec2']['accounts']['user1']['acnt123'] == \
+            {'additional_regions': None, 'partition': 'aws'}
         assert accounts['ec2']['groups']['user1']['group123'] == ['acnt123']
 
     @patch.object(CredentialsService, '_store_encrypted_credentials')
@@ -704,7 +705,15 @@ class TestCredentialsService(object):
                 'ec2': {
                     'accounts': {
                         'user2': {
-                            'test-aws-gov': 'aws-us-gov'
+                            'test-aws-gov': {
+                                'additional_regions': [
+                                    {
+                                        'name': 'ap-northeast-4',
+                                        'helper_image': 'ami-82444aff'
+                                    }
+                                ],
+                                'partition': 'aws-us-gov'
+                            }
                         }
                     },
                     'groups': {

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -108,8 +108,18 @@ class TestJobCreatorService(object):
             },
             "accounts": {
                 "user1": {
-                    "test-aws-gov": "aws-us-gov",
-                    "test-aws": "aws"
+                    "test-aws-gov": {
+                        "partition": "aws-us-gov"
+                    },
+                    "test-aws": {
+                        "additional_regions": [
+                            {
+                                "name": "ap-northeast-3",
+                                "helper_image": "ami-82444aff"
+                            }
+                        ],
+                        "partition": "aws"
+                    }
                 }
             }
         }
@@ -143,22 +153,6 @@ class TestJobCreatorService(object):
             '"project": "Cloud:Tools", '
             '"utctime": "now"}}'
         )
-
-        msg = mock_publish.mock_calls[2][1][2]
-        data = json.loads(msg)['uploader_job']
-        assert data['cloud_image_name'] == 'new_image_123'
-        assert data['id'] == '12345678-1234-1234-1234-123456789012'
-        assert data['image_description'] == 'New Image #123'
-        assert data['provider'] == 'ec2'
-        assert data['target_regions']['ap-northeast-1']['account'] == \
-            'test-aws'
-        assert data['target_regions']['ap-northeast-1']['helper_image'] == \
-            'ami-383c1956'
-        assert data['target_regions']['us-gov-west-1']['account'] == \
-            'test-aws-gov'
-        assert data['target_regions']['us-gov-west-1']['helper_image'] == \
-            'ami-c2b5d7e1'
-        assert data['utctime'] == 'now'
 
         assert mock_publish.mock_calls[2] == call(
             'uploader', 'job_document',
@@ -196,11 +190,12 @@ class TestJobCreatorService(object):
             '"replication_source_regions": {'
             '"ap-northeast-1": {"account": "test-aws", '
             '"target_regions": ["ap-northeast-1", '
-            '"ap-northeast-2"]}, '
+            '"ap-northeast-2", "ap-northeast-3"]}, '
             '"us-gov-west-1": {"account": "test-aws-gov", '
             '"target_regions": ["us-gov-west-1"]}}, '
             '"utctime": "now"}}'
         )
+
         msg = mock_publish.mock_calls[5][1][2]
         data = json.loads(msg)['publisher_job']
         assert data['allow_copy'] is False
@@ -218,6 +213,7 @@ class TestJobCreatorService(object):
                 assert region['helper_image'] == 'ami-383c1956'
                 assert 'ap-northeast-1' in region['target_regions']
                 assert 'ap-northeast-2' in region['target_regions']
+                assert 'ap-northeast-3' in region['target_regions']
 
         msg = mock_publish.mock_calls[6][1][2]
         data = json.loads(msg)['deprecation_job']
@@ -235,6 +231,7 @@ class TestJobCreatorService(object):
                 assert region['helper_image'] == 'ami-383c1956'
                 assert 'ap-northeast-1' in region['target_regions']
                 assert 'ap-northeast-2' in region['target_regions']
+                assert 'ap-northeast-3' in region['target_regions']
 
         assert mock_publish.mock_calls[7] == call(
             'pint', 'job_document',


### PR DESCRIPTION
Accounts in EC2 may have access to special regions. The accounts can now be created with a list of dictionaries to map special region names with helper images.