### PR TITLE
Add rest api with Flask.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -9,6 +9,7 @@ azure-mgmt-compute
 azure-mgmt-resource
 azure-mgmt-storage
 azure-storage-blob
+flask
 setuptools
 idna<2.7
 boto3
@@ -18,7 +19,6 @@ PyYAML
 PyJWT
 APScheduler
 python-dateutil>=2.6.0,<2.7.0
-strict-rfc3339
 amqpstorm
 ec2deprecateimg
 ec2publishimg

--- a/config/mash.conf
+++ b/config/mash.conf
@@ -1,0 +1,22 @@
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule wsgi_module modules/mod_wsgi.so
+
+Listen 443
+<VirtualHost *:443>
+    ServerName CHANGE_ME
+
+    WSGIDaemonProcess mash user=mash group=mash threads=5
+    WSGIScriptAlias / /var/lib/mash/wsgi.py
+
+    <Directory /var/lib/mash>
+        WSGIProcessGroup mash
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIScriptReloading On
+        Require ip JUMP_HOST_IP
+    </Directory>
+
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/server.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/server.key
+    SSLCACertificateFile /etc/apache2/ssl/intermediate.crt
+</VirtualHost>

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -1,4 +1,5 @@
 {
+  "job_id": "12345678-1234-1234-1234-123456789012",
   "provider": "azure",
   "provider_accounts": [
     {

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -1,4 +1,5 @@
 {
+  "job_id": "12345678-1234-1234-1234-123456789012",
   "provider": "ec2",
   "provider_accounts": [
     {"name": "test-aws-gov", "target_regions": ["us-gov-west-1"]}

--- a/mash/services/api/endpoints.py
+++ b/mash/services/api/endpoints.py
@@ -1,0 +1,139 @@
+import json
+import sys
+import uuid
+
+from amqpstorm import Connection
+from flask import Flask, jsonify, request, make_response
+from jsonschema import validate
+
+from mash.services.jobcreator import schema
+
+app = Flask(__name__, static_url_path='/static')
+module = sys.modules[__name__]
+
+connection = None
+channel = None
+
+schemas = {
+    'add_account': {
+        'azure': schema.add_account_azure,
+        'ec2': schema.add_account_ec2
+    },
+    'delete_account': {
+        'azure': schema.delete_account,
+        'ec2': schema.delete_account
+    },
+    'add_job': {
+        'azure': schema.azure_job_message,
+        'ec2': schema.ec2_job_message
+    }
+}
+
+
+def connect():
+    module.connection = Connection(
+        'localhost',
+        'guest',
+        'guest',
+        kwargs={'heartbeat': 600}
+    )
+    module.channel = connection.channel()
+    channel.confirm_deliveries()
+
+
+def publish(exchange, routing_key, message):
+    """
+    Publish message to the provided exchange with the routing key.
+    """
+    if not channel or channel.is_closed:
+        connect()
+
+    channel.basic.publish(
+        body=message,
+        routing_key=routing_key,
+        exchange=exchange,
+        properties={
+            'content_type': 'application/json',
+            'delivery_mode': 2
+        },
+        mandatory=True
+    )
+
+
+def validate_request(flask_request, endpoint):
+    # Python 3.4 + 3.5 json module requires string not bytes
+    flask_request.data = flask_request.data.decode()
+    message = json.loads(flask_request.data)
+    provider = message.get('provider')
+
+    if provider not in ['azure', 'ec2']:
+        raise Exception('{} is not a valid provider.'.format(provider))
+
+    validate(message, schemas[endpoint][provider])
+    return message
+
+
+def error_response(error):
+    return make_response(jsonify({'error': str(error)}), 400)
+
+
+def status_response(status_msg, status_code):
+    return make_response(jsonify({'status': status_msg}), status_code)
+
+
+@app.route("/add_account", methods=["POST"])
+def add_account():
+    try:
+        result = validate_request(request, 'add_account')
+    except Exception as error:
+        return error_response(error)
+
+    publish(
+        'jobcreator', 'add_account', json.dumps(result, sort_keys=True)
+    )
+    return status_response('Add account request submitted.', 200)
+
+
+@app.route("/delete_account", methods=["POST"])
+def delete_account():
+    try:
+        result = validate_request(request, 'delete_account')
+    except Exception as error:
+        return error_response(error)
+
+    publish(
+        'jobcreator', 'delete_account', json.dumps(result, sort_keys=True)
+    )
+    return status_response('Delete account request submitted.', 200)
+
+
+@app.route("/add_job", methods=["POST"])
+def add_job():
+    try:
+        result = validate_request(request, 'add_job')
+    except Exception as error:
+        return error_response(error)
+
+    job_id = str(uuid.uuid4())
+    result['job_id'] = job_id
+
+    publish(
+        'jobcreator', 'job_document', json.dumps(result, sort_keys=True)
+    )
+
+    msg = {
+        'job_id': job_id,
+        'status': 'Add job request submitted.'
+    }
+    # Cannot use jsonify with multiple keys, need sorted dump for py3.4
+    response = make_response(json.dumps(msg, sort_keys=True), 200)
+    response.headers['Content-Type'] = 'application/json; charset=utf-8'
+    response.headers['mimetype'] = 'application/json'
+    return response
+
+
+@app.route("/delete_job/<job_id>", methods=["POST"])
+def delete_job(job_id):
+    content = {'job_delete': job_id}
+    publish('jobcreator', 'job_document', json.dumps(content, sort_keys=True))
+    return status_response('Delete job request submitted.', 200)

--- a/mash/services/jobcreator/__init__.py
+++ b/mash/services/jobcreator/__init__.py
@@ -22,7 +22,7 @@ from mash.services.jobcreator.azure_job import AzureJob
 from mash.services.jobcreator.ec2_job import EC2Job
 
 
-def create_job(job_id, job_doc, accounts_info, provider_data):
+def create_job(job_doc, accounts_info, provider_data):
     csp_name = job_doc.get('provider')
     provider_data = provider_data.get(csp_name)
 
@@ -37,4 +37,4 @@ def create_job(job_id, job_doc, accounts_info, provider_data):
             )
         )
 
-    return job_class(job_id, accounts_info, provider_data, **job_doc)
+    return job_class(accounts_info, provider_data, **job_doc)

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -24,7 +24,7 @@ class AzureJob(BaseJob):
     Azure job message class.
     """
     def __init__(
-        self, job_id, accounts_info, provider_data, provider,
+        self, accounts_info, provider_data, job_id, provider,
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
         image_description, distro, tests, conditions=None, download_root=None,
@@ -33,7 +33,7 @@ class AzureJob(BaseJob):
         self.target_account_info = {}
 
         super(AzureJob, self).__init__(
-            job_id, accounts_info, provider_data, provider, provider_accounts,
+            accounts_info, provider_data, job_id, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
             image_description, distro, tests, conditions, download_root,

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -26,7 +26,7 @@ class BaseJob(object):
     Handles incoming job requests.
     """
     def __init__(
-        self, job_id, accounts_info, provider_data, provider,
+        self, accounts_info, provider_data, job_id, provider,
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
         image_description, distro, tests,

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -29,7 +29,7 @@ class EC2Job(BaseJob):
     Handles incoming job requests.
     """
     def __init__(
-        self, job_id, accounts_info, provider_data, provider,
+        self, accounts_info, provider_data, job_id, provider,
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, old_cloud_image_name, project,
         share_with, allow_copy, image_description, distro,
@@ -40,7 +40,7 @@ class EC2Job(BaseJob):
         self.target_account_info = {}
 
         super(EC2Job, self).__init__(
-            job_id, accounts_info, provider_data, provider, provider_accounts,
+            accounts_info, provider_data, job_id, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
             image_description, distro, tests, conditions, download_root,

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -135,7 +135,13 @@ base_job_message = {
                 {'enum': ['always', 'now']},
                 {
                     '$ref': '#/definitions/non_empty_string',
-                    'format': 'date-time'
+                    'description': 'An RFC3339 date-time string'
+                                   '(2019-04-28T06:44:50.142Z)',
+                    'format': 'regex',
+                    'pattern': '^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]'
+                               '|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):'
+                               '([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]'
+                               '([01][0-9]|2[0-3]):[0-5][0-9]))$'
                 }
             ]
         },

--- a/mash/wsgi.py
+++ b/mash/wsgi.py
@@ -1,0 +1,4 @@
+from mash.services.api.endpoints import app as application
+
+if __name__ == '__main__':
+    application.run(port=5000)

--- a/package/mash-spec-template
+++ b/package/mash-spec-template
@@ -41,13 +41,15 @@ Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 2.7.0
-Requires:       python3-strict-rfc3339
 Requires:       python3-ec2deprecateimg
 Requires:       python3-ec2publishimg
 Requires:       python3-ec2uploadimg
 Requires:       python3-ipa
 Requires:       python3-ipa-tests
 Requires:       python3-lxml
+Requires:       python3-flask
+Requires:       apache2
+Requires:       apache2-mod_wsgi-python3
 BuildArch:      noarch
 
 %description
@@ -66,6 +68,12 @@ python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 install -D -m 644 config/mash_config.yaml \
     %{buildroot}%{_sysconfdir}/%{name}/mash_config.yaml
+
+install -D -m 644 wsgi.py \
+    %{buildroot}%{_localstatedir}/lib/%{name}/wsgi.py
+
+install -D -m 644 config/mash.conf \
+    %{buildroot}%{_sysconfdir}/apache2/vhosts.d/mash.conf
 
 install -D -m 644 config/mash_obs.service \
     %{buildroot}%{_unitdir}/mash_obs.service
@@ -99,6 +107,8 @@ install -D -m 644 config/mash_deprecation.service \
 %{python3_sitelib}/*
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/mash_config.yaml
+%attr(640, mash, mash)%{_localstatedir}/%{name}/wsgi.py
+%attr(640, mash, mash)%{_sysconfdir}/apache2/vhosts.d/mash.conf
 
 %{_bindir}/mash-obs-service
 %{_unitdir}/mash_obs.service

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -1,4 +1,5 @@
 {
+  "job_id": "12345678-1234-1234-1234-123456789012",
   "provider": "azure",
   "provider_accounts": [
     {

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -1,4 +1,5 @@
- {
+{
+  "job_id": "12345678-1234-1234-1234-123456789012",
   "provider": "ec2",
   "provider_accounts": [
     {"name": "test-aws-gov", "target_regions": ["us-gov-west-1"]}

--- a/test/unit/.coveragerc
+++ b/test/unit/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     */version.py
+    */wsgi.py
+

--- a/test/unit/services/api/api_test.py
+++ b/test/unit/services/api/api_test.py
@@ -1,0 +1,218 @@
+import json
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from mash import wsgi
+
+
+@pytest.fixture(scope='module')
+def test_client():
+    testing_client = wsgi.application.test_client()
+
+    ctx = wsgi.application.app_context()
+    ctx.push()
+
+    yield testing_client
+    ctx.pop()
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_add_account(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    data = json.dumps({
+        'account_name': 'test',
+        'credentials': {
+            'access_key_id': '123456',
+            'secret_access_key': '654321'
+        },
+        'group': 'group1',
+        'partition': 'aws',
+        'provider': 'ec2',
+        'requesting_user': 'user1'
+    }, sort_keys=True)
+    response = test_client.post(
+        '/add_account',
+        content_type='application/json',
+        data=data
+    )
+
+    channel.basic.publish.assert_called_once_with(
+        body=data,
+        routing_key='add_account',
+        exchange='jobcreator',
+        properties={
+            'content_type': 'application/json',
+            'delivery_mode': 2
+        },
+        mandatory=True
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"status":"Add account request submitted."}\n'
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_add_account_error(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    data = json.dumps({
+        'account_name': 'test',
+        'credentials': {
+            'access_key_id': '123456',
+            'secret_access_key': '654321'
+        },
+        'group': 'group1',
+        'partition': 'aws',
+        'provider': 'fake',
+        'requesting_user': 'user1'
+    }, sort_keys=True)
+    response = test_client.post(
+        '/add_account',
+        content_type='application/json',
+        data=data
+    )
+    assert response.status_code == 400
+    assert b'fake is not a valid provider.' in response.data
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_delete_account(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    data = json.dumps({
+        'account_name': 'test',
+        'provider': 'ec2',
+        'requesting_user': 'user1'
+    }, sort_keys=True)
+    response = test_client.post(
+        '/delete_account',
+        content_type='application/json',
+        data=data
+    )
+
+    channel.basic.publish.assert_called_once_with(
+        body=data,
+        routing_key='delete_account',
+        exchange='jobcreator',
+        properties={
+            'content_type': 'application/json',
+            'delivery_mode': 2
+        },
+        mandatory=True
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"status":"Delete account request submitted."}\n'
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_delete_account_error(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    data = json.dumps({
+        'account_name': 'test',
+        'provider': 'fake',
+        'requesting_user': 'user1'
+    }, sort_keys=True)
+    response = test_client.post(
+        '/delete_account',
+        content_type='application/json',
+        data=data
+    )
+    assert response.status_code == 400
+    assert b"fake is not a valid provider." in response.data
+
+
+@patch('mash.services.api.endpoints.uuid')
+@patch('mash.services.api.endpoints.Connection')
+def test_api_add_job(mock_connection, mock_uuid, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    uuid = '12345678-1234-1234-1234-123456789012'
+    mock_uuid.uuid4.return_value = uuid
+
+    with open('../data/job.json', 'r') as job_doc:
+        data = json.load(job_doc)
+
+    del data['job_id']
+    response = test_client.post(
+        '/add_job',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+
+    data['job_id'] = uuid
+    channel.basic.publish.assert_called_once_with(
+        body=json.dumps(data, sort_keys=True),
+        routing_key='job_document',
+        exchange='jobcreator',
+        properties={
+            'content_type': 'application/json',
+            'delivery_mode': 2
+        },
+        mandatory=True
+    )
+    assert response.status_code == 200
+    assert response.data == \
+        b'{"job_id": "12345678-1234-1234-1234-123456789012", ' \
+        b'"status": "Add job request submitted."}'
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_add_job_error(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    with open('../data/job.json', 'r') as job_doc:
+        data = json.load(job_doc)
+
+    response = test_client.post(
+        '/add_job',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 400
+    assert b"Additional properties are not allowed " \
+        b"(\'job_id\' was unexpected" in response.data
+
+
+@patch('mash.services.api.endpoints.Connection')
+def test_api_delete_job(mock_connection, test_client):
+    channel = MagicMock()
+    connection = MagicMock()
+    connection.channel.return_value = channel
+    mock_connection.return_value = connection
+
+    response = test_client.post(
+        '/delete_job/12345678-1234-1234-1234-123456789012'
+    )
+
+    channel.basic.publish.assert_called_once_with(
+        body='{"job_delete": "12345678-1234-1234-1234-123456789012"}',
+        routing_key='job_document',
+        exchange='jobcreator',
+        properties={
+            'content_type': 'application/json',
+            'delivery_mode': 2
+        },
+        mandatory=True
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"status":"Delete job request submitted."}\n'

--- a/test/unit/services/jobcreator/factory_test.py
+++ b/test/unit/services/jobcreator/factory_test.py
@@ -9,7 +9,7 @@ from mash.services.jobcreator import create_job
 def test_job_creator_create_job():
     # invalid provider
     with raises(MashJobCreatorException) as error:
-        create_job('123', {'provider': 'fake'}, {}, {})
+        create_job({'provider': 'fake'}, {}, {})
 
     assert str(error.value) == \
         'Support for fake Cloud Service not implemented'


### PR DESCRIPTION
Add REST API using Flask:

- Add API and validate endpoints using existing schema.
- Add requirements on Apache and mod_wsgi.
- Add Apache conf file for mash.
- Update spec.
- Integrate API with MASH.
- Move job_id handling to API.
- Remove date-time validation package requirement and use regex instead.