### PR TITLE
Cleanup main services.

### DIFF
--- a/config/mash_credentials.service
+++ b/config/mash_credentials.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-credentials-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_deprecation.service
+++ b/config/mash_deprecation.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-deprecation-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_job_creator.service
+++ b/config/mash_job_creator.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-job-creator-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_logger.service
+++ b/config/mash_logger.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-logger-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_obs.service
+++ b/config/mash_obs.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-obs-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_publisher.service
+++ b/config/mash_publisher.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-publisher-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_replication.service
+++ b/config/mash_replication.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-replication-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_testing.service
+++ b/config/mash_testing.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-testing-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/config/mash_uploader.service
+++ b/config/mash_uploader.service
@@ -6,7 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mash-uploader-service
-StandardOutput=null
+StandardOutput=journal
 Restart=always
 
 [Install]

--- a/mash/services/credentials_service.py
+++ b/mash/services/credentials_service.py
@@ -17,13 +17,14 @@
 #
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
 from mash.services.credentials.service import CredentialsService
 
 
-def main(event_loop=True):
+def main():
     """
     mash - credentials service application entry point
     """
@@ -38,13 +39,15 @@ def main(event_loop=True):
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/deprecation_service.py
+++ b/mash/services/deprecation_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
@@ -40,11 +41,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('%s: %s', type(e).__name__, format(e))
+        traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
     except SystemExit as e:
         # user exception, program aborted by user
         sys.exit(e)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/job_creator_service.py
+++ b/mash/services/job_creator_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 from mash.mash_exceptions import MashException
 from mash.services.jobcreator.service import JobCreatorService
@@ -38,11 +39,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/logger_service.py
+++ b/mash/services/logger_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
@@ -39,13 +40,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/obs_service.py
+++ b/mash/services/obs_service.py
@@ -17,13 +17,14 @@
 #
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
 from mash.services.obs.service import OBSImageBuildResultService
 
 
-def main(event_loop=True):
+def main():
     """
     mash - obs service application entry point
     """
@@ -38,13 +39,15 @@ def main(event_loop=True):
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/publisher_service.py
+++ b/mash/services/publisher_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 from mash.mash_exceptions import MashException
 from mash.services.publisher.service import PublisherService
@@ -39,11 +40,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/replication_service.py
+++ b/mash/services/replication_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
@@ -40,11 +41,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('%s: %s', type(e).__name__, format(e))
+        traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
     except SystemExit as e:
         # user exception, program aborted by user
         sys.exit(e)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/testing_service.py
+++ b/mash/services/testing_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
@@ -40,11 +41,15 @@ def main():
     except MashException as e:
         # known exception
         log.error('%s: %s', type(e).__name__, format(e))
+        traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
     except SystemExit as e:
         # user exception, program aborted by user
         sys.exit(e)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/uploader_service.py
+++ b/mash/services/uploader_service.py
@@ -17,13 +17,14 @@
 #
 import logging
 import sys
+import traceback
 
 # project
 from mash.mash_exceptions import MashException
 from mash.services.uploader.service import UploadImageService
 
 
-def main(event_loop=True):
+def main():
     """
     mash - uploader service application entry point
     """
@@ -38,13 +39,15 @@ def main(event_loop=True):
     except MashException as e:
         # known exception
         log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
     except SystemExit:
         # user exception, program aborted by user
         sys.exit(0)
-    except Exception:
+    except Exception as e:
         # exception we did no expect, show python backtrace
-        log.error('Unexpected error:')
-        raise
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/test/unit/services/credentials/main_test.py
+++ b/test/unit/services/credentials/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashException
@@ -8,7 +7,7 @@ from mash.services.credentials_service import main
 class TestCredentials(object):
     @patch('mash.services.credentials_service.CredentialsService')
     def test_main(self, mock_CredentialsService):
-        main(event_loop=False)
+        main()
         mock_CredentialsService.assert_called_once_with(
             host='localhost', service_exchange='credentials'
         )
@@ -19,7 +18,7 @@ class TestCredentials(object):
         self, mock_exit, mock_CredentialsService
     ):
         mock_CredentialsService.side_effect = MashException('error')
-        main(event_loop=False)
+        main()
         mock_exit.assert_called_once_with(1)
 
     @patch('mash.services.credentials_service.CredentialsService')
@@ -41,9 +40,10 @@ class TestCredentials(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.credentials_service.CredentialsService')
+    @patch('sys.exit')
     def test_main_unexpected_error(
-        self, mock_CredentialsService
+        self, mock_exit, mock_CredentialsService
     ):
         mock_CredentialsService.side_effect = Exception
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/deprecation/main_test.py
+++ b/test/unit/services/deprecation/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashDeprecationException
@@ -31,6 +30,15 @@ class TestDeprecationServiceMain(object):
 
     @patch('mash.services.deprecation_service.DeprecationService')
     @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+        self, mock_exit, mock_deprecation_service
+    ):
+        mock_deprecation_service.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.deprecation_service.DeprecationService')
+    @patch('sys.exit')
     def test_deprecation_main_system_exit(
         self, mock_exit, mock_deprecation_service
     ):
@@ -40,8 +48,11 @@ class TestDeprecationServiceMain(object):
         mock_exit.assert_called_once_with(mock_deprecation_service.side_effect)
 
     @patch('mash.services.deprecation_service.DeprecationService')
-    def test_deprecation_main_unexpected_error(self, mock_deprecation_service):
+    @patch('sys.exit')
+    def test_deprecation_main_unexpected_error(
+        self, mock_exit, mock_deprecation_service
+    ):
         mock_deprecation_service.side_effect = Exception('Error!')
 
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/jobcreator/main_test.py
+++ b/test/unit/services/jobcreator/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashJobCreatorException
@@ -28,6 +27,15 @@ class TestJobCreatorServiceMain(object):
 
     @patch('mash.services.job_creator_service.JobCreatorService')
     @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+        self, mock_exit, mock_job_creator_service
+    ):
+        mock_job_creator_service.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.job_creator_service.JobCreatorService')
+    @patch('sys.exit')
     def test_job_creator_main_system_exit(
         self, mock_exit, mock_job_creator_service
     ):
@@ -37,8 +45,11 @@ class TestJobCreatorServiceMain(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.job_creator_service.JobCreatorService')
-    def test_job_creator_main_unexpected_error(self, mock_job_creator_service):
+    @patch('sys.exit')
+    def test_job_creator_main_unexpected_error(
+        self, mock_exit, mock_job_creator_service
+    ):
         mock_job_creator_service.side_effect = Exception('Error!')
 
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/logger/main_test.py
+++ b/test/unit/services/logger/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashLoggerException
@@ -44,8 +43,11 @@ class TestLogger(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.logger_service.LoggerService')
-    def test_logger_main_unexpected_error(self, mock_logger_service):
+    @patch('sys.exit')
+    def test_logger_main_unexpected_error(
+        self, mock_exit, mock_logger_service
+    ):
         mock_logger_service.side_effect = Exception('Error!')
 
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/obs/main_test.py
+++ b/test/unit/services/obs/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 from unittest.mock import Mock
 
@@ -14,7 +13,7 @@ class TestOBS(object):
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
     def test_main(self, mock_OBSImageBuildResultService):
-        main(event_loop=False)
+        main()
         mock_OBSImageBuildResultService.assert_called_once_with(
             host='localhost', service_exchange='obs'
         )
@@ -25,7 +24,7 @@ class TestOBS(object):
         self, mock_exit, mock_OBSImageBuildResultService
     ):
         mock_OBSImageBuildResultService.side_effect = MashException('error')
-        main(event_loop=False)
+        main()
         mock_exit.assert_called_once_with(1)
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
@@ -47,9 +46,10 @@ class TestOBS(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
+    @patch('sys.exit')
     def test_main_unexpected_error(
-        self, mock_OBSImageBuildResultService
+        self, mock_exit, mock_OBSImageBuildResultService
     ):
         mock_OBSImageBuildResultService.side_effect = Exception
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/publisher/main_test.py
+++ b/test/unit/services/publisher/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashPublisherException
@@ -28,6 +27,15 @@ class TestPublisherServiceMain(object):
 
     @patch('mash.services.publisher_service.PublisherService')
     @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+        self, mock_exit, mock_publisher_service
+    ):
+        mock_publisher_service.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.publisher_service.PublisherService')
+    @patch('sys.exit')
     def test_publisher_main_system_exit(
         self, mock_exit, mock_publisher_service
     ):
@@ -37,8 +45,11 @@ class TestPublisherServiceMain(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.publisher_service.PublisherService')
-    def test_publisher_main_unexpected_error(self, mock_publisher_service):
+    @patch('sys.exit')
+    def test_publisher_main_unexpected_error(
+        self, mock_exit, mock_publisher_service
+    ):
         mock_publisher_service.side_effect = Exception('Error!')
 
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/replication/main_test.py
+++ b/test/unit/services/replication/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashReplicationException
@@ -30,6 +29,15 @@ class TestReplicationServiceMain(object):
 
     @patch('mash.services.replication_service.ReplicationService')
     @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+            self, mock_exit, mock_replication_ervice
+    ):
+        mock_replication_ervice.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.replication_service.ReplicationService')
+    @patch('sys.exit')
     def test_replication_main_system_exit(
         self, mock_exit, mock_replication_service
     ):
@@ -41,8 +49,10 @@ class TestReplicationServiceMain(object):
         )
 
     @patch('mash.services.replication_service.ReplicationService')
-    def test_replication_main_unexpected_error(self, mock_replication_service):
+    @patch('sys.exit')
+    def test_replication_main_unexpected_error(
+        self, mock_exit, mock_replication_service
+    ):
         mock_replication_service.side_effect = Exception('Error!')
-
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/testing/main_test.py
+++ b/test/unit/services/testing/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 
 from mash.mash_exceptions import MashTestingException
@@ -27,6 +26,16 @@ class TestIPATestingServiceMain(object):
 
     @patch('mash.services.testing_service.TestingService')
     @patch('sys.exit')
+    def test_logger_main_keyboard_interrupt(
+            self, mock_exit, mock_testing_service
+    ):
+        mock_testing_service.side_effect = KeyboardInterrupt()
+
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.testing_service.TestingService')
+    @patch('sys.exit')
     def test_testing_main_system_exit(self, mock_exit, mock_testing_service):
         mock_testing_service.side_effect = SystemExit()
 
@@ -34,8 +43,11 @@ class TestIPATestingServiceMain(object):
         mock_exit.assert_called_once_with(mock_testing_service.side_effect)
 
     @patch('mash.services.testing_service.TestingService')
-    def test_testing_main_unexpected_error(self, mock_testing_service):
+    @patch('sys.exit')
+    def test_testing_main_unexpected_error(
+        self, mock_exit, mock_testing_service
+    ):
         mock_testing_service.side_effect = Exception('Error!')
 
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/uploader/main_test.py
+++ b/test/unit/services/uploader/main_test.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from unittest.mock import patch
 from unittest.mock import Mock
 
@@ -15,7 +14,7 @@ class TestUploader(object):
 
     @patch('mash.services.uploader_service.UploadImageService')
     def test_main(self, mock_UploadImageService):
-        main(event_loop=False)
+        main()
         mock_UploadImageService.assert_called_once_with(
             host='localhost', service_exchange='uploader'
         )
@@ -26,7 +25,7 @@ class TestUploader(object):
         self, mock_exit, mock_UploadImageService
     ):
         mock_UploadImageService.side_effect = MashException('error')
-        main(event_loop=False)
+        main()
         mock_exit.assert_called_once_with(1)
 
     @patch('mash.services.uploader_service.UploadImageService')
@@ -48,9 +47,10 @@ class TestUploader(object):
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.uploader_service.UploadImageService')
+    @patch('sys.exit')
     def test_main_unexpected_error(
-        self, mock_UploadImageService
+        self, mock_exit, mock_UploadImageService
     ):
         mock_UploadImageService.side_effect = Exception
-        with raises(Exception):
-            main()
+        main()
+        mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
- Log to journalctl instead of null.
- Print traceback in exceptions.
- Add missing keyboardinterrupt exception handling.
- Remove unused event_loop arg.

Resolves #180