### PR TITLE
Use the JsonFormat class for json dumps.

### DIFF
--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -36,6 +36,7 @@ from mash.mash_exceptions import (
     MashLogSetupException,
     MashValidationException
 )
+from mash.utils.json_format import JsonFormat
 
 
 class BaseService(object):
@@ -361,7 +362,7 @@ class BaseService(object):
         )
 
         with open(config['job_file'], 'w') as config_file:
-            config_file.write(json.dumps(config, sort_keys=True))
+            config_file.write(JsonFormat.json_message(config))
 
         return config['job_file']
 

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -34,6 +34,7 @@ from mash.services.credentials.azure_account import AzureAccount
 from mash.services.credentials.ec2_account import EC2Account
 from mash.services.credentials.key_rotate import clean_old_keys, rotate_key
 from mash.services.jobcreator.accounts import accounts_template
+from mash.utils.json_format import JsonFormat
 
 
 class CredentialsService(BaseService):
@@ -93,7 +94,7 @@ class CredentialsService(BaseService):
 
             self._send_control_response(
                 'Job queued, awaiting credentials requests: {0}'.format(
-                    json.dumps(job_document, indent=2, sort_keys=True)
+                    JsonFormat.json_message(job_document)
                 ),
                 job_id=job_id
             )
@@ -162,7 +163,7 @@ class CredentialsService(BaseService):
             }
             self._publish(
                 'jobcreator', self.job_document_key,
-                json.dumps(job_response, sort_keys=True)
+                JsonFormat.json_message(job_response)
             )
         else:
             self._send_control_response(
@@ -171,7 +172,7 @@ class CredentialsService(BaseService):
             job_response = {'invalid_job': job_id}
             self._publish(
                 'jobcreator', self.job_document_key,
-                json.dumps(job_response, sort_keys=True)
+                JsonFormat.json_message(job_response)
             )
 
     def _create_encryption_keys_file(self):
@@ -439,7 +440,7 @@ class CredentialsService(BaseService):
             credentials_response = self._get_credentials_response(
                 job_id, issuer
             )
-            message = json.dumps({'jwt_token': credentials_response.decode()})
+            message = JsonFormat.json_message({'jwt_token': credentials_response.decode()})
 
             self.log.info(
                 'Received credentials request from {0} for job: {1}.'.format(
@@ -514,7 +515,7 @@ class CredentialsService(BaseService):
         """
         Update accounts file with provided accounts dictionary.
         """
-        account_info = json.dumps(accounts, indent=4)
+        account_info = JsonFormat.json_message(accounts)
 
         with open(self.accounts_file, 'w') as account_file:
             account_file.write(account_info)

--- a/mash/services/deprecation/service.py
+++ b/mash/services/deprecation/service.py
@@ -27,6 +27,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.deprecation.ec2_job import EC2DeprecationJob
+from mash.utils.json_format import JsonFormat
 
 
 class DeprecationService(BaseService):
@@ -177,7 +178,7 @@ class DeprecationService(BaseService):
                 }
             }
 
-        return json.dumps(data, sort_keys=True)
+        return JsonFormat.json_message(data)
 
     def _handle_credentials_response(self, message):
         """

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -16,7 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import json
+from mash.utils.json_format import JsonFormat
 
 
 class BaseJob(object):
@@ -88,7 +88,7 @@ class BaseJob(object):
         }
         credentials_message['credentials_job'].update(self.base_message)
 
-        return json.dumps(credentials_message, sort_keys=True)
+        return JsonFormat.json_message(credentials_message)
 
     def get_deprecation_message(self):
         """
@@ -103,7 +103,7 @@ class BaseJob(object):
         }
         deprecation_message['deprecation_job'].update(self.base_message)
 
-        return json.dumps(deprecation_message, sort_keys=True)
+        return JsonFormat.json_message(deprecation_message)
 
     def get_deprecation_regions(self):
         """
@@ -131,7 +131,7 @@ class BaseJob(object):
         if self.download_root:
             obs_message['obs_job']['download_root'] = self.download_root
 
-        return json.dumps(obs_message, sort_keys=True)
+        return JsonFormat.json_message(obs_message)
 
     def get_pint_message(self):
         """
@@ -146,7 +146,7 @@ class BaseJob(object):
         }
         pint_message['pint_job'].update(self.base_message)
 
-        return json.dumps(pint_message, sort_keys=True)
+        return JsonFormat.json_message(pint_message)
 
     def get_publisher_message(self):
         """
@@ -170,7 +170,7 @@ class BaseJob(object):
         }
         replication_message['replication_job'].update(self.base_message)
 
-        return json.dumps(replication_message, sort_keys=True)
+        return JsonFormat.json_message(replication_message)
 
     def get_replication_source_regions(self):
         """
@@ -201,7 +201,7 @@ class BaseJob(object):
 
         testing_message['testing_job'].update(self.base_message)
 
-        return json.dumps(testing_message, sort_keys=True)
+        return JsonFormat.json_message(testing_message)
 
     def get_testing_regions(self):
         """
@@ -225,7 +225,7 @@ class BaseJob(object):
         }
         uploader_message['uploader_job'].update(self.base_message)
 
-        return json.dumps(uploader_message, sort_keys=True)
+        return JsonFormat.json_message(uploader_message)
 
     def get_uploader_regions(self):
         """

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -16,10 +16,10 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import json
 import random
 
 from mash.services.jobcreator.base_job import BaseJob
+from mash.utils.json_format import JsonFormat
 
 
 class EC2Job(BaseJob):
@@ -150,7 +150,7 @@ class EC2Job(BaseJob):
         }
         publisher_message['publisher_job'].update(self.base_message)
 
-        return json.dumps(publisher_message, sort_keys=True)
+        return JsonFormat.json_message(publisher_message)
 
     def get_publisher_regions(self):
         """

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -29,6 +29,7 @@ from mash.mash_exceptions import (
 from mash.services.base_service import BaseService
 from mash.services.jobcreator import create_job
 from mash.services.jobcreator import schema
+from mash.utils.json_format import JsonFormat
 
 
 class JobCreatorService(BaseService):
@@ -134,7 +135,7 @@ class JobCreatorService(BaseService):
         else:
             self._publish(
                 'credentials', self.add_account_key,
-                json.dumps(message, sort_keys=True)
+                JsonFormat.json_message(message)
             )
 
     def delete_account(self, message):
@@ -153,7 +154,7 @@ class JobCreatorService(BaseService):
         else:
             self._publish(
                 'credentials', self.delete_account_key,
-                json.dumps(message, sort_keys=True)
+                JsonFormat.json_message(message)
             )
 
     def process_new_job(self, job_doc):
@@ -193,7 +194,7 @@ class JobCreatorService(BaseService):
 
             self.publish_job_doc(
                 'credentials',
-                json.dumps(account_check_message, sort_keys=True)
+                JsonFormat.json_message(account_check_message)
             )
 
     def publish_delete_job_message(self, job_id):
@@ -211,14 +212,14 @@ class JobCreatorService(BaseService):
             "obs_job_delete": job_id
         }
         self._publish(
-            'obs', self.job_document_key, json.dumps(delete_message)
+            'obs', self.job_document_key, JsonFormat.json_message(delete_message)
         )
 
         delete_message = {
             "credentials_job_delete": job_id
         }
         self._publish(
-            'credentials', self.job_document_key, json.dumps(delete_message)
+            'credentials', self.job_document_key, JsonFormat.json_message(delete_message)
         )
 
     def publish_job_doc(self, service, job_doc):
@@ -240,7 +241,7 @@ class JobCreatorService(BaseService):
         job = create_job(job_id, job_doc, accounts_info, self.provider_data)
 
         self.log.info(
-            'Started a new job: {0}'.format(json.dumps(job_doc, indent=2)),
+            'Started a new job: {0}'.format(JsonFormat.json_message(job_doc)),
             extra={'job_id': job.id}
         )
 

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -27,6 +27,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.publisher.ec2_job import EC2PublisherJob
+from mash.utils.json_format import JsonFormat
 
 
 class PublisherService(BaseService):
@@ -170,7 +171,7 @@ class PublisherService(BaseService):
                 }
             }
 
-        return json.dumps(data, sort_keys=True)
+        return JsonFormat.json_message(data)
 
     def _handle_credentials_response(self, message):
         """

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -27,6 +27,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.replication.ec2_job import EC2ReplicationJob
+from mash.utils.json_format import JsonFormat
 
 
 class ReplicationService(BaseService):
@@ -171,7 +172,7 @@ class ReplicationService(BaseService):
                 }
             }
 
-        return json.dumps(data, sort_keys=True)
+        return JsonFormat.json_message(data)
 
     def _handle_credentials_response(self, message):
         """

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -35,6 +35,7 @@ from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.testing.azure_job import AzureTestingJob
 from mash.services.testing.ec2_job import EC2TestingJob
+from mash.utils.json_format import JsonFormat
 
 
 class TestingService(BaseService):
@@ -221,7 +222,7 @@ class TestingService(BaseService):
                 }
             }
 
-        return json.dumps(data, sort_keys=True)
+        return JsonFormat.json_message(data)
 
     def _handle_credentials_response(self, message):
         """

--- a/mash/utils/json_format.py
+++ b/mash/utils/json_format.py
@@ -23,16 +23,16 @@ class JsonFormat(object):
     Helper class to handle unicode characters
     in json formatted messages correctly
     """
-    @classmethod
-    def json_load(self, file_handle):
+    @staticmethod
+    def json_load(file_handle):
         return json.load(file_handle)
 
-    @classmethod
-    def json_loads(self, json_text):
+    @staticmethod
+    def json_loads(json_text):
         return json.loads(json_text)
 
-    @classmethod
-    def json_message(self, data_dict):
+    @staticmethod
+    def json_message(data_dict):
         return json.dumps(
             data_dict, sort_keys=True, indent=4, separators=(',', ': ')
         )

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -15,6 +15,7 @@ from mash.mash_exceptions import (
     MashLogSetupException,
     MashValidationException
 )
+from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
 
@@ -171,7 +172,10 @@ class TestBaseService(object):
             # Dict is mutable, mock compares the final value of Dict
             # not the initial value that was passed in.
             file_handle.write.assert_called_with(
-                u'{"id": "1", "job_file": "tmp-dir/job-1.json"}'
+                JsonFormat.json_message({
+                    "id": "1",
+                    "job_file": "tmp-dir/job-1.json"
+                })
             )
 
     @patch('mash.services.base_service.os.remove')

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -9,6 +9,7 @@ from mash.services.base_service import BaseService
 from mash.services.credentials.service import CredentialsService
 from mash.services.credentials.key_rotate import rotate_key
 from mash.services.jobcreator.accounts import accounts_template
+from mash.utils.json_format import JsonFormat
 
 
 class TestCredentialsService(object):
@@ -87,7 +88,7 @@ class TestCredentialsService(object):
 
         mock_send_control_response.assert_called_once_with(
             'Job queued, awaiting credentials requests: {0}'.format(
-                json.dumps(job_config, indent=2, sort_keys=True)
+                JsonFormat.json_message(job_config)
             ),
             job_id='1'
         )
@@ -175,8 +176,12 @@ class TestCredentialsService(object):
 
         mock_publish.assert_called_once_with(
             'jobcreator', 'job_document',
-            '{"start_job": {"accounts_info": {"accounts": "info"}, '
-            '"id": "123"}}'
+            JsonFormat.json_message({
+                "start_job": {
+                    "accounts_info": {"accounts": "info"},
+                    "id": "123"
+                }
+            })
         )
 
         # Invalid accounts
@@ -188,7 +193,8 @@ class TestCredentialsService(object):
             'User does not own requested accounts.', success=False
         )
         mock_publish.assert_called_once_with(
-            'jobcreator', 'job_document', '{"invalid_job": "123"}'
+            'jobcreator', 'job_document',
+            JsonFormat.json_message({"invalid_job": "123"})
         )
 
     @patch.object(CredentialsService, '_generate_encryption_key')
@@ -509,7 +515,7 @@ class TestCredentialsService(object):
             'Received credentials request from pint for job: 1.'
         )
         mock_publish_credentials_response.assert_called_once_with(
-            '{"jwt_token": "response"}', 'pint'
+            JsonFormat.json_message({"jwt_token": "response"}), 'pint'
         )
         mock_delete_job.assert_called_once_with('1')
 

--- a/test/unit/services/deprecation/service_test.py
+++ b/test/unit/services/deprecation/service_test.py
@@ -8,6 +8,7 @@ from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 from mash.services.base_service import BaseService
 from mash.services.deprecation.service import DeprecationService
 from mash.services.deprecation.ec2_job import EC2DeprecationJob
+from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
 
@@ -33,18 +34,33 @@ class TestDeprecationService(object):
             method=self.method,
         )
 
-        self.error_message = '{"deprecation_result": ' \
-            '{"id": "1", "status": "error"}}'
-        self.status_message = '{"deprecation_result": ' \
-            '{"cloud_image_name": "image123", "id": "1", ' \
-            '"status": "success"}}'
+        self.error_message = JsonFormat.json_message({
+            "deprecation_result": {
+                "id": "1",
+                "status": "error"
+            }
+        })
+        self.status_message = JsonFormat.json_message({
+            "deprecation_result": {
+                "cloud_image_name": "image123",
+                "id": "1",
+                "status": "success"
+            }
+        })
 
-        self.publisher_result = \
-            '{"publisher_result": {"id": "1", ' \
-            '"cloud_image_name": "image name", ' \
-            '"status": "success"}}'
-        self.publisher_result_fail = \
-            '{"publisher_result": {"id": "1", "status": "error"}}'
+        self.publisher_result = JsonFormat.json_message({
+            "publisher_result": {
+                "id": "1",
+                "cloud_image_name": "image name",
+                "status": "success"
+            }
+        })
+        self.publisher_result_fail = JsonFormat.json_message({
+            "publisher_result": {
+                "id": "1",
+                "status": "error"
+            }
+        })
 
         self.deprecation = DeprecationService()
         self.deprecation.jobs = {}

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -9,6 +9,7 @@ from mash.mash_exceptions import (
 )
 from mash.services.base_service import BaseService
 from mash.services.jobcreator.service import JobCreatorService
+from mash.utils.json_format import JsonFormat
 
 
 class TestJobCreatorService(object):
@@ -124,7 +125,7 @@ class TestJobCreatorService(object):
             }
         }
 
-        message.body = json.dumps({
+        message.body = JsonFormat.json_message({
             'start_job': {
                 'id': uuid_val,
                 'accounts_info': account_info
@@ -144,56 +145,84 @@ class TestJobCreatorService(object):
 
         assert mock_publish.mock_calls[1] == call(
             'obs', 'job_document',
-            '{"obs_job": {'
-            '"conditions": [{"package": ["name", "and", "constraints"]}, '
-            '{"image": "version"}], '
-            '"download_root": "http://download.opensuse.org/repositories/", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"image": "test_image_oem", '
-            '"project": "Cloud:Tools", '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "obs_job": {
+                    "conditions": [
+                        {"package": ["name", "and", "constraints"]},
+                        {"image": "version"}
+                    ],
+                    "download_root":
+                        "http://download.opensuse.org/repositories/",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image": "test_image_oem",
+                    "project": "Cloud:Tools",
+                    "utctime": "now"
+                }
+            })
         )
 
         assert mock_publish.mock_calls[2] == call(
             'uploader', 'job_document',
-            '{"uploader_job": {'
-            '"cloud_image_name": "new_image_123", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"image_description": "New Image #123", '
-            '"provider": "ec2", '
-            '"target_regions": {'
-            '"ap-northeast-1": {"account": "test-aws", '
-            '"helper_image": "ami-383c1956"}, '
-            '"us-gov-west-1": {"account": '
-            '"test-aws-gov", "helper_image": "ami-c2b5d7e1"}}, '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "uploader_job": {
+                    "cloud_image_name": "new_image_123",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image_description": "New Image #123",
+                    "provider": "ec2",
+                    "target_regions": {
+                        "ap-northeast-1": {
+                            "account": "test-aws",
+                            "helper_image": "ami-383c1956"
+                        },
+                        "us-gov-west-1": {
+                            "account": "test-aws-gov",
+                            "helper_image": "ami-c2b5d7e1"
+                        }
+                    },
+                    "utctime": "now"
+                }
+            })
         )
         assert mock_publish.mock_calls[3] == call(
             'testing', 'job_document',
-            '{"testing_job": {'
-            '"distro": "sles", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"instance_type": "t2.micro", '
-            '"provider": "ec2", '
-            '"test_regions": {'
-            '"ap-northeast-1": "test-aws", '
-            '"us-gov-west-1": "test-aws-gov"}, '
-            '"tests": ["test_stuff"], '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "testing_job": {
+                    "distro": "sles",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "instance_type": "t2.micro",
+                    "provider": "ec2",
+                    "test_regions": {
+                        "ap-northeast-1": "test-aws",
+                        "us-gov-west-1": "test-aws-gov"
+                    },
+                    "tests": ["test_stuff"],
+                    "utctime": "now"
+                }
+            })
         )
         assert mock_publish.mock_calls[4] == call(
             'replication', 'job_document',
-            '{"replication_job": {'
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"image_description": "New Image #123", '
-            '"provider": "ec2", '
-            '"replication_source_regions": {'
-            '"ap-northeast-1": {"account": "test-aws", '
-            '"target_regions": ["ap-northeast-1", '
-            '"ap-northeast-2", "ap-northeast-3"]}, '
-            '"us-gov-west-1": {"account": "test-aws-gov", '
-            '"target_regions": ["us-gov-west-1"]}}, '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "replication_job": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image_description": "New Image #123",
+                    "provider": "ec2",
+                    "replication_source_regions": {
+                        "ap-northeast-1": {
+                            "account": "test-aws",
+                            "target_regions": [
+                                "ap-northeast-1", "ap-northeast-2",
+                                "ap-northeast-3"
+                            ]
+                        },
+                        "us-gov-west-1": {
+                            "account": "test-aws-gov",
+                            "target_regions": ["us-gov-west-1"]
+                        }
+                    },
+                    "utctime": "now"
+                }
+            })
         )
 
         msg = mock_publish.mock_calls[5][1][2]
@@ -235,12 +264,15 @@ class TestJobCreatorService(object):
 
         assert mock_publish.mock_calls[7] == call(
             'pint', 'job_document',
-            '{"pint_job": {'
-            '"cloud_image_name": "new_image_123", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"old_cloud_image_name": "old_new_image_123", '
-            '"provider": "ec2", '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "pint_job": {
+                    "cloud_image_name": "new_image_123",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "old_cloud_image_name": "old_new_image_123",
+                    "provider": "ec2",
+                    "utctime": "now"
+                }
+            })
         )
 
     @patch('mash.services.jobcreator.service.uuid')
@@ -304,45 +336,63 @@ class TestJobCreatorService(object):
 
         assert mock_publish.mock_calls[1] == call(
             'obs', 'job_document',
-            '{"obs_job": {'
-            '"conditions": [{"package": ["name", "and", "constraints"]}, '
-            '{"image": "version"}], '
-            '"download_root": "http://download.opensuse.org/repositories/", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"image": "test_image_oem", '
-            '"project": "Cloud:Tools", '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "obs_job": {
+                    "conditions": [
+                        {"package": ["name", "and", "constraints"]},
+                        {"image": "version"}
+                    ],
+                    "download_root":
+                        "http://download.opensuse.org/repositories/",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image": "test_image_oem",
+                    "project": "Cloud:Tools",
+                    "utctime": "now"
+                }
+            })
         )
         assert mock_publish.mock_calls[2] == call(
             'uploader', 'job_document',
-            '{"uploader_job": {'
-            '"cloud_image_name": "new_image_123", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"image_description": "New Image #123", '
-            '"provider": "azure", '
-            '"target_regions": {'
-            '"centralus": {"account": "test-azure2", '
-            '"container_name": "ccontainer1", '
-            '"resource_group": "c_res_group", '
-            '"storage_account": "cstorage1"}, '
-            '"southcentralus": {"account": "test-azure", '
-            '"container_name": "sccontainer1", '
-            '"resource_group": "sc_res_group", '
-            '"storage_account": "scstorage1"}}, '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "uploader_job": {
+                    "cloud_image_name": "new_image_123",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image_description": "New Image #123",
+                    "provider": "azure",
+                    "target_regions": {
+                        "centralus": {
+                            "account": "test-azure2",
+                            "container_name": "ccontainer1",
+                            "resource_group": "c_res_group",
+                            "storage_account": "cstorage1"
+                        },
+                        "southcentralus": {
+                            "account": "test-azure",
+                            "container_name": "sccontainer1",
+                            "resource_group": "sc_res_group",
+                            "storage_account": "scstorage1"
+                        }
+                    },
+                    "utctime": "now"
+                }
+            })
         )
         assert mock_publish.mock_calls[3] == call(
             'testing', 'job_document',
-            '{"testing_job": {'
-            '"distro": "sles", '
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"instance_type": "t2.micro", '
-            '"provider": "azure", '
-            '"test_regions": {'
-            '"centralus": "test-azure2", '
-            '"southcentralus": "test-azure"}, '
-            '"tests": ["test_stuff"], '
-            '"utctime": "now"}}'
+            JsonFormat.json_message({
+                "testing_job": {
+                    "distro": "sles",
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "instance_type": "t2.micro",
+                    "provider": "azure",
+                    "test_regions": {
+                        "centralus": "test-azure2",
+                        "southcentralus": "test-azure"
+                    },
+                    "tests": ["test_stuff"],
+                    "utctime": "now"
+                }
+            })
         )
 
     def test_jobcreator_handle_invalid_service_message(self):
@@ -372,23 +422,23 @@ class TestJobCreatorService(object):
 
         # Test add ec2 account message
         message.method = {'routing_key': 'add_account'}
-        message.body = '''{
-              "account_name": "test-aws",
-              "credentials": {
+        message.body = JsonFormat.json_message({
+            "account_name": "test-aws",
+            "credentials": {
                 "access_key_id": "123456",
                 "secret_access_key": "654321"
-              },
-              "group": "group1",
-              "partition": "aws",
-              "provider": "ec2",
-              "requesting_user": "user1"
-        }'''
+            },
+            "group": "group1",
+            "partition": "aws",
+            "provider": "ec2",
+            "requesting_user": "user1"
+        })
 
         self.jobcreator._handle_listener_message(message)
 
         mock_publish.assert_called_once_with(
             'credentials', 'add_account',
-            json.dumps(json.loads(message.body), sort_keys=True)
+            JsonFormat.json_message(json.loads(message.body))
         )
         message.ack.assert_called_once_with()
 
@@ -397,28 +447,28 @@ class TestJobCreatorService(object):
 
         # Test add azure account message
         message.method = {'routing_key': 'add_account'}
-        message.body = '''{
-              "account_name": "test-azure",
-              "container_name": "container1",
-              "credentials": {
+        message.body = JsonFormat.json_message({
+            "account_name": "test-azure",
+            "container_name": "container1",
+            "credentials": {
                 "clientId": "123456",
                 "clientSecret": "654321",
                 "subscriptionId": "654321",
                 "tenantId": "654321"
-              },
-              "group": "group1",
-              "provider": "azure",
-              "region": "southcentralus",
-              "requesting_user": "user1",
-              "resource_group": "rg_123",
-              "storage_account": "sa_1"
-        }'''
+            },
+            "group": "group1",
+            "provider": "azure",
+            "region": "southcentralus",
+            "requesting_user": "user1",
+            "resource_group": "rg_123",
+            "storage_account": "sa_1"
+        })
 
         self.jobcreator._handle_listener_message(message)
 
         mock_publish.assert_called_once_with(
             'credentials', 'add_account',
-            json.dumps(json.loads(message.body), sort_keys=True)
+            JsonFormat.json_message(json.loads(message.body))
         )
         message.ack.assert_called_once_with()
 
@@ -428,17 +478,17 @@ class TestJobCreatorService(object):
     ):
         message = MagicMock()
         message.method = {'routing_key': 'delete_account'}
-        message.body = '''{
+        message.body = JsonFormat.json_message({
             "account_name": "test-aws",
             "provider": "ec2",
             "requesting_user": "user2"
-        }'''
+        })
 
         self.jobcreator._handle_listener_message(message)
 
         mock_publish.assert_called_once_with(
             'credentials', 'delete_account',
-            json.dumps(json.loads(message.body), sort_keys=True)
+            JsonFormat.json_message(json.loads(message.body))
         )
         message.ack.assert_called_once_with()
 
@@ -470,10 +520,13 @@ class TestJobCreatorService(object):
         message.body = '{"job_delete": "1"}'
         self.jobcreator._handle_service_message(message)
         mock_publish.assert_has_calls([
-            call('obs', 'job_document', '{"obs_job_delete": "1"}'),
+            call(
+                'obs', 'job_document',
+                JsonFormat.json_message({"obs_job_delete": "1"})
+            ),
             call(
                 'credentials', 'job_document',
-                '{"credentials_job_delete": "1"}'
+                JsonFormat.json_message({"credentials_job_delete": "1"})
             )
         ])
 
@@ -520,12 +573,20 @@ class TestJobCreatorService(object):
         assert self.jobcreator.jobs[uuid_val]
         mock_publish_doc.assert_called_once_with(
             'credentials',
-            '{"credentials_job_check": {'
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"provider": "ec2", '
-            '"provider_accounts": ['
-            '{"name": "test-aws-gov", "target_regions": ["us-gov-west-1"]}], '
-            '"provider_groups": ["test"], "requesting_user": "user1"}}'
+            JsonFormat.json_message({
+                "credentials_job_check": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "provider": "ec2",
+                    "provider_accounts": [
+                        {
+                            "name": "test-aws-gov",
+                            "target_regions": ["us-gov-west-1"]
+                        }
+                    ],
+                    "provider_groups": ["test"],
+                    "requesting_user": "user1"
+                }
+            })
         )
 
     @patch.object(JobCreatorService, 'publish_job_doc')
@@ -548,16 +609,23 @@ class TestJobCreatorService(object):
         assert self.jobcreator.jobs[uuid_val]
         mock_publish_doc.assert_called_once_with(
             'credentials',
-            '{"credentials_job_check": {'
-            '"id": "12345678-1234-1234-1234-123456789012", '
-            '"provider": "azure", '
-            '"provider_accounts": ['
-            '{"container_name": "sccontainer1", "name": "test-azure", '
-            '"region": "southcentralus", '
-            '"resource_group": "sc_res_group", '
-            '"storage_account": "scstorage1"}], '
-            '"provider_groups": ["test-azure-group"], '
-            '"requesting_user": "user1"}}'
+            JsonFormat.json_message({
+                "credentials_job_check": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "provider": "azure",
+                    "provider_accounts": [
+                        {
+                            "container_name": "sccontainer1",
+                            "name": "test-azure",
+                            "region": "southcentralus",
+                            "resource_group": "sc_res_group",
+                            "storage_account": "scstorage1"
+                        }
+                    ],
+                    "provider_groups": ["test-azure-group"],
+                    "requesting_user": "user1"
+                }
+            })
         )
 
     @patch('mash.services.jobcreator.service.validate')

--- a/test/unit/services/publisher/service_test.py
+++ b/test/unit/services/publisher/service_test.py
@@ -8,6 +8,7 @@ from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 from mash.services.base_service import BaseService
 from mash.services.publisher.service import PublisherService
 from mash.services.publisher.ec2_job import EC2PublisherJob
+from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
 
@@ -33,11 +34,19 @@ class TestPublisherService(object):
             method=self.method,
         )
 
-        self.error_message = '{"publisher_result": ' \
-            '{"id": "1", "status": "error"}}'
-        self.status_message = '{"publisher_result": ' \
-            '{"cloud_image_name": "image123", "id": "1", ' \
-            '"status": "success"}}'
+        self.error_message = JsonFormat.json_message({
+            "publisher_result": {
+                "id": "1",
+                "status": "error"
+            }
+        })
+        self.status_message = JsonFormat.json_message({
+            "publisher_result": {
+                "cloud_image_name": "image123",
+                "id": "1",
+                "status": "success"
+            }
+        })
 
         self.publisher = PublisherService()
         self.publisher.jobs = {}

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -9,6 +9,7 @@ from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 from mash.services.base_service import BaseService
 from mash.services.replication.service import ReplicationService
 from mash.services.replication.ec2_job import EC2ReplicationJob
+from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
 
@@ -34,11 +35,19 @@ class TestReplicationService(object):
             method=self.method,
         )
 
-        self.error_message = '{"replication_result": ' \
-            '{"id": "1", "status": "error"}}'
-        self.status_message = '{"replication_result": ' \
-            '{"cloud_image_name": "image123", "id": "1", ' \
-            '"status": "success"}}'
+        self.error_message = JsonFormat.json_message({
+            "replication_result": {
+                "id": "1",
+                "status": "error"
+            }
+        })
+        self.status_message = JsonFormat.json_message({
+            "replication_result": {
+                "cloud_image_name": "image123",
+                "id": "1",
+                "status": "success"
+            }
+        })
 
         self.replication = ReplicationService()
         self.replication.jobs = {}


### PR DESCRIPTION
- Ensure all json message strings have the same format.
- Make JsonFormat methods static as they make no use of the uninstantiated class.