### PR TITLE
Send status message on obs job failure

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -348,6 +348,8 @@ class OBSImageBuildResult(object):
                 self._log_callback('Job done')
                 self._result_callback()
         except MashException as issue:
+            if not self.job_nonstop:
+                self._result_callback()
             self._log_error(
                 '{0}: {1}'.format(type(issue).__name__, issue)
             )

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -288,12 +288,15 @@ class TestOBSImageBuildResult(object):
 
     @patch.object(OBSImageBuildResult, '_log_callback')
     @patch.object(OBSImageBuildResult, '_lookup_image_packages_metadata')
+    @patch.object(OBSImageBuildResult, '_result_callback')
     def test_update_image_status_raises(
-        self, mock_lookup_image_packages_metadata, mock_log_callback
+        self, mock_result_callback, mock_lookup_image_packages_metadata,
+        mock_log_callback
     ):
         mock_lookup_image_packages_metadata.side_effect = \
             MashWebContentException('request error')
         self.obs_result._update_image_status()
+        mock_result_callback.assert_called_once_with()
         assert mock_log_callback.call_args_list == [
             call('Job running'),
             call('Error: MashWebContentException: request error')


### PR DESCRIPTION
For not nonstop jobs and in case of an error a status message
must be send to allow cleanup of the jobs in the service
queue referencing this job