### PR TITLE
Improve web content fetch error messages

### DIFF
--- a/mash/utils/web_content.py
+++ b/mash/utils/web_content.py
@@ -51,11 +51,14 @@ class WebContent(object):
             return sorted(list(set(result)))
         except Exception as issue:
             raise MashWebContentException(
-                '{0}: {1}'.format(type(issue).__name__, issue)
+                'Fetching index list from {0} failed with {1}: {2}'.format(
+                    self.uri, type(issue).__name__, issue
+                )
             )
 
     def fetch_file(self, base_name, suffix, target_file):
         try:
+            name = base_name
             for name in self.fetch_index_list(base_name):
                 if name.startswith(base_name) and name.endswith(suffix):
                     urlretrieve(
@@ -65,12 +68,15 @@ class WebContent(object):
                     return name
         except Exception as issue:
             raise MashWebContentException(
-                '{0}: {1}'.format(type(issue).__name__, issue)
+                'Fetching file {0} failed with {1}: {2}'.format(
+                    os.sep.join([self.uri, name]), type(issue).__name__, issue
+                )
             )
 
     def fetch_files(self, base_name, suffix_list, target_dir):
         try:
             fetched = []
+            name = base_name
             for name in self.fetch_index_list(base_name):
                 if name.startswith(base_name):
                     for suffix in suffix_list:
@@ -84,5 +90,7 @@ class WebContent(object):
             return fetched
         except Exception as issue:
             raise MashWebContentException(
-                '{0}: {1}'.format(type(issue).__name__, issue)
+                'Fetching file {0} failed with {1}: {2}'.format(
+                    os.sep.join([self.uri, name]), type(issue).__name__, issue
+                )
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ formats=gztar
 
 [tool:pytest]
 norecursedirs = .git build .tox/ .tmp/
-addopts = --ignore=.tmp/ --ignore=.git/ --ignore=.tox/
+addopts = --ignore=.tmp/ --ignore=.git/ --ignore=.tox/ -p no:warnings
 testpaths = test/unit/
 
 [flake8]

--- a/test/unit/utils/web_content_test.py
+++ b/test/unit/utils/web_content_test.py
@@ -25,7 +25,7 @@ class TestWebContent(object):
         assert result[0] == \
             'SLES12-Azure-BYOS.x86_64-0.2.4-Build3.549-raw.tar.bz2'
         mock_Request.side_effect = Exception
-        with raises(MashWebContentException):
+        with raises(MashWebContentException, match='http://example.com'):
             self.web.fetch_index_list('SLES12-Azure-BYOS')
 
     @patch('mash.utils.web_content.Request')
@@ -45,7 +45,10 @@ class TestWebContent(object):
         assert result == \
             'SLES12-Azure-BYOS.x86_64-0.2.4-Build3.549-vmx.packages'
         mock_Request.side_effect = Exception
-        with raises(MashWebContentException):
+        with raises(
+            MashWebContentException,
+            match='http://example.com/SLES12-Azure-BYOS'
+        ):
             self.web.fetch_file('SLES12-Azure-BYOS', '.packages', 'target')
 
     @patch('mash.utils.web_content.Request')
@@ -80,7 +83,10 @@ class TestWebContent(object):
             'SLES12-Azure-BYOS.x86_64-0.2.4-Build3.549.vhdfixed.xz.sha256'
         ]
         mock_Request.side_effect = Exception
-        with raises(MashWebContentException):
+        with raises(
+            MashWebContentException,
+            match='http://example.com/SLES12-Azure-BYOS'
+        ):
             self.web.fetch_files(
                 'SLES12-Azure-BYOS', ['.packages', 'vhdfixed.xz.sha256'],
                 'target_dir'


### PR DESCRIPTION
In case the Request or urlretrieve, urlopen calls throws an
exception the exception type and message is part of the
resulting error message. However the information does not
include the request source URI which is is useful to know
This Fixes #271