### PR TITLE
Remove job doc from log msg in credentials.

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -93,9 +93,7 @@ class CredentialsService(BaseService):
                 )
 
             self._send_control_response(
-                'Job queued, awaiting credentials requests: {0}'.format(
-                    JsonFormat.json_message(job_document)
-                ),
+                'Job queued, awaiting credentials requests.',
                 job_id=job_id
             )
 

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -87,9 +87,7 @@ class TestCredentialsService(object):
         mock_persist_job_config.assert_called_once_with(job_config)
 
         mock_send_control_response.assert_called_once_with(
-            'Job queued, awaiting credentials requests: {0}'.format(
-                JsonFormat.json_message(job_config)
-            ),
+            'Job queued, awaiting credentials requests.',
             job_id='1'
         )
 


### PR DESCRIPTION
Job doc is printed by the job creator service.