### PR TITLE
If no instance type provided select random.

### DIFF
--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -26,8 +26,11 @@ from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
-    'Standard_DS1_v2', 'Standard_B1ms', 'Standard_F1s', 'Standard_H8m',
-    'Standard_A0', 'Standard_D1_v2', 'Standard_A2m_v2'
+    'Basic_A2',
+    'Standard_B1s',
+    'Standard_D2_v3',
+    'Standard_E2_v3',
+    'Standard_F2s_v2'
 ]
 
 

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -17,12 +17,18 @@
 #
 
 import json
+import random
 
 from threading import Thread
 
 from mash.services.status_levels import FAILED, SUCCESS
 from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
+
+instance_types = [
+    'Standard_DS1_v2', 'Standard_B1ms', 'Standard_F1s', 'Standard_H8m',
+    'Standard_A0', 'Standard_D1_v2', 'Standard_A2m_v2'
+]
 
 
 class AzureTestingJob(TestingJob):
@@ -36,6 +42,9 @@ class AzureTestingJob(TestingJob):
         job_file=None, credentials=None, description=None, distro='sles',
         instance_type=None, ssh_user='azureuser'
     ):
+        if not instance_type:
+            instance_type = random.choice(instance_types)
+
         super(AzureTestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -16,11 +16,18 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import random
+
 from threading import Thread
 
 from mash.services.status_levels import FAILED, SUCCESS
 from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
+
+instance_types = [
+    't2.micro', 'm5.large', 'c5d.large', 'x1e.xlarge',
+    'p3.2xlarge', 'h1.2xlarge', 'd2.xlarge'
+]
 
 
 class EC2TestingJob(TestingJob):
@@ -34,6 +41,9 @@ class EC2TestingJob(TestingJob):
         job_file=None, credentials=None, description=None, distro='sles',
         instance_type=None, ssh_user='ec2-user'
     ):
+        if not instance_type:
+            instance_type = random.choice(instance_types)
+
         super(EC2TestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -25,8 +25,18 @@ from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
-    't2.micro', 'm5.large', 'c5d.large', 'x1e.xlarge',
-    'p3.2xlarge', 'h1.2xlarge', 'd2.xlarge'
+    'c5d.large',
+    'd2.xlarge',
+    'h1.2xlarge',
+    'i3.8xlarge,'
+    'i3.metal',
+    'm5.large',
+    'm5d.large',
+    'p3.2xlarge',
+    'r5.24xlarge',
+    't2.micro',
+    't3.small',
+    'x1e.xlarge'
 ]
 
 

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -14,11 +14,12 @@ class TestAzureTestingJob(object):
             'utctime': 'now',
         }
 
+    @patch('mash.services.testing.azure_job.random')
     @patch('mash.services.testing.ipa_helper.NamedTemporaryFile')
     @patch('mash.services.testing.ipa_helper.test_image')
     @patch.object(AzureTestingJob, 'send_log')
     def test_testing_run_azure_test(
-        self, mock_send_log, mock_test_image, mock_temp_file
+        self, mock_send_log, mock_test_image, mock_temp_file, mock_random
     ):
         tmp_file = Mock()
         tmp_file.name = '/tmp/acnt.file'
@@ -34,6 +35,7 @@ class TestAzureTestingJob(object):
                 }
             }
         )
+        mock_random.choice.return_value = 'Standard_A0'
 
         job = AzureTestingJob(**self.job_config)
         job.credentials = {
@@ -52,7 +54,7 @@ class TestAzureTestingJob(object):
             description=job.description,
             distro='sles',
             image_id='ami-123',
-            instance_type=None,
+            instance_type='Standard_A0',
             log_level=30,
             region='East US',
             secret_access_key=None,

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -14,6 +14,7 @@ class TestEC2TestingJob(object):
             'utctime': 'now',
         }
 
+    @patch('mash.services.testing.ec2_job.random')
     @patch('mash.services.testing.ipa_helper.generate_name')
     @patch('mash.services.testing.ipa_helper.get_client')
     @patch('mash.services.testing.ipa_helper.get_key_from_file')
@@ -21,12 +22,13 @@ class TestEC2TestingJob(object):
     @patch.object(EC2TestingJob, 'send_log')
     def test_testing_run_test(
         self, mock_send_log, mock_test_image, mock_get_key_from_file,
-        mock_get_client, mock_generate_name
+        mock_get_client, mock_generate_name, mock_random
     ):
         client = Mock()
         mock_get_client.return_value = client
         mock_generate_name.return_value = 'random_name'
         mock_get_key_from_file.return_value = 'fakekey'
+        mock_random.choice.return_value = 't2.micro'
 
         mock_test_image.return_value = (
             0,
@@ -60,7 +62,7 @@ class TestEC2TestingJob(object):
             description=job.description,
             distro='sles',
             image_id='ami-123',
-            instance_type=None,
+            instance_type='t2.micro',
             log_level=30,
             region='us-east-1',
             secret_access_key='321',


### PR DESCRIPTION
Test against a random instance type if type is None.

@rjschwei  I think we should have a small subset of instance types per cloud. Are these lists okay? Any additions or deletions needed?

Also if we are testing against random regions then we need to sure that the instance types in list exist for all regions.

Also, when testing against very large instances in certain regions the provision and reboot time may be very slow. So we may need to override ipa timeout option with a very high value (default is 10 minutes per state change).