### PR TITLE
Print traceback in job log if exception.

### DIFF
--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -19,6 +19,7 @@
 import logging
 import os
 import threading
+import traceback
 
 from ipa.ipa_controller import test_image
 from tempfile import NamedTemporaryFile
@@ -72,8 +73,10 @@ def ipa_test(
             ssh_user=ssh_user,
             tests=tests
         )
-    except Exception as error:
-        results[name] = {'status': EXCEPTION, 'msg': str(error)}
+    except Exception:
+        results[name] = {
+            'status': EXCEPTION, 'msg': str(traceback.format_exc())
+        }
     else:
         status = SUCCESS if status == 0 else FAILED
         results[name] = {

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -62,11 +62,13 @@ class TestAzureTestingJob(object):
             ssh_user='azureuser',
             tests=['test_stuff']
         )
+        mock_send_log.reset_mock()
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
         job._run_tests()
-        mock_send_log.assert_has_calls(
-            [call('Image tests failed in region: East US.', success=False),
-             call('Tests broken!', success=False)]
+        assert mock_send_log.mock_calls[0] == call(
+            'Image tests failed in region: East US.', success=False
         )
+        assert 'Tests broken!' in mock_send_log.mock_calls[1][1][0]
+        assert mock_send_log.mock_calls[1][2] == {'success': False}


### PR DESCRIPTION
If there's an unknown exception when processing ipa tests print the entire traceback to assist in debugging.