### PR TITLE
Require date format in uploader cloud_image_name

### DIFF
--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -70,7 +70,8 @@ class MashCredentialsException(MashException):
 
 class MashConventionsException(MashException):
     """
-    Exception raised if no conventions handler for this cloud provider exists.
+    Exception raised if no conventions handler for this cloud provider exists
+    or the validation of the naming convention has failed for a reason
     """
 
 

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 from unittest.mock import Mock
 from unittest.mock import call
 from unittest.mock import patch
@@ -11,7 +13,8 @@ class TestUploadImage(object):
         self.custom_uploader_args = {'cloud-specific-param': 'foo'}
         self.upload_image = UploadImage(
             '123', 'job_file', False, 'ec2',
-            'token', 'cloud_image_name', 'cloud_image_description',
+            'token', 'cloud_image_name_at_{date}',
+            'cloud_image_description',
             last_upload_region=False,
             custom_uploader_args=self.custom_uploader_args
         )
@@ -23,12 +26,15 @@ class TestUploadImage(object):
     def test_upload(
         self, mock_result_callback, mock_log_callback, mock_Upload
     ):
+        today = datetime.date.today()
         uploader = Mock()
         uploader.upload.return_value = ('image_id', 'region')
         mock_Upload.return_value = uploader
         self.upload_image.upload()
         mock_Upload.assert_called_once_with(
-            'ec2', 'image_file', 'cloud_image_name', 'cloud_image_description',
+            'ec2', 'image_file',
+            'cloud_image_name_at_{0}'.format(today.strftime("%Y%m%d")),
+            'cloud_image_description',
             'token', {'cloud-specific-param': 'foo'}
         )
         uploader.upload.assert_called_once_with()
@@ -53,6 +59,28 @@ class TestUploadImage(object):
             ),
             call('error')
         ]
+
+    @patch('mash.services.uploader.upload_image.Upload')
+    @patch.object(UploadImage, '_log_callback')
+    @patch.object(UploadImage, '_result_callback')
+    def test_upload_cloud_image_name_convention_error(
+        self, mock_result_callback, mock_log_callback, mock_Upload
+    ):
+        self.upload_image.cloud_image_name = 'name_with_no_date_key'
+        self.upload_image.upload()
+        assert mock_log_callback.call_args_list[1] == call(
+            'No {date} key specified in cloud_image_name format: '
+            'name_with_no_date_key'
+        )
+
+        mock_log_callback.reset_mock()
+
+        self.upload_image.cloud_image_name = 'name_with_{invalid}_format'
+        self.upload_image.upload()
+        assert mock_log_callback.call_args_list[1] == call(
+            'Invalid cloud_image_name format to apply {date} in: '
+            'name_with_{invalid}_format'
+        )
 
     def test_set_log_handler(self):
         function = Mock()


### PR DESCRIPTION
The image uploaded to the cloud must contain the today date
information in its name at the time of the upload. Therefore
cloud_image_name supports the {date} format key which gets
replaced by the date when the upload is started.
This Fixes #278