### PR TITLE
Fetch image name should have period appended.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -345,7 +345,7 @@ class OBSImageBuildResult(object):
     def _lookup_image_packages_metadata(self):
         packages_file = NamedTemporaryFile()
         self.image_metadata_name = self.remote.fetch_file(
-            self.image_name, '.packages', packages_file.name
+            ''.join([self.image_name, '.']), '.packages', packages_file.name
         )
         try:
             # Extract image version information from .packages file name

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -311,7 +311,7 @@ class TestOBSImageBuildResult(object):
             'Azure-Factory.x86_64-1.0.5-Build5.28.packages'
         data = self.obs_result._lookup_image_packages_metadata()
         self.obs_result.remote.fetch_file.assert_called_once_with(
-            'obs_package', '.packages', '../data/image.packages'
+            'obs_package.', '.packages', '../data/image.packages'
         )
         assert data['file-magic'].checksum == '8e776ae58aac4e50edcf190e493e5c20'
         assert self.obs_result.image_status['version'] == '1.0.5'


### PR DESCRIPTION
Fix bug which causes build number mismatch if an image name matches multiple images in a project.