### PR TITLE
Log error and update failed status first.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -336,11 +336,12 @@ class OBSImageBuildResult(object):
                 self._log_callback('Job done')
                 self._result_callback()
         except MashException as issue:
-            if not self.job_nonstop:
-                self._result_callback()
             self._log_error(
                 '{0}: {1}'.format(type(issue).__name__, issue)
             )
+
+            if not self.job_nonstop:
+                self._result_callback()
 
     def _lookup_image_packages_metadata(self):
         packages_file = NamedTemporaryFile()


### PR DESCRIPTION
Before sending result to uploader.

Resolves #293 