### PR TITLE
Remove utctime handling from Uploader service.

### DIFF
--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -253,7 +253,7 @@ class TestUploadImageService(object):
             'cloud_image_name': 'b',
             'image_description': 'a',
             'job_file': 'job_file',
-            'utctime': 'Wed Oct 11 17:50:26 UTC 2017',
+            'utctime': 'always',
             'provider': 'ec2',
             'target_regions': {
                 'us-east-1': {
@@ -264,14 +264,6 @@ class TestUploadImageService(object):
         }
         self.uploader.config = Mock()
         uploader_args = self.uploader._get_uploader_arguments_per_region(job)
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, 'date', args=[job, False, uploader_args[0], True],
-            run_date='2017-10-11T17:50:26+00:00',
-            timezone='utc'
-        )
-        self.uploader.scheduler.add_job.reset_mock()
-        job['utctime'] = 'always'
         self.uploader._schedule_job(job)
         self.uploader.scheduler.add_job.assert_called_once_with(
             mock_start_job, args=[job, True, uploader_args[0], True]
@@ -297,7 +289,7 @@ class TestUploadImageService(object):
             'cloud_image_name': 'b',
             'image_description': 'a',
             'job_file': 'job_file',
-            'utctime': 'Wed Oct 11 17:50:26 UTC 2017',
+            'utctime': 'always',
             'provider': 'azure',
             'target_regions': {
                 'westeurope': {
@@ -310,14 +302,6 @@ class TestUploadImageService(object):
         }
         self.uploader.config = Mock()
         uploader_args = self.uploader._get_uploader_arguments_per_region(job)
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, 'date', args=[job, False, uploader_args[0], True],
-            run_date='2017-10-11T17:50:26+00:00',
-            timezone='utc'
-        )
-        self.uploader.scheduler.add_job.reset_mock()
-        job['utctime'] = 'always'
         self.uploader._schedule_job(job)
         self.uploader.scheduler.add_job.assert_called_once_with(
             mock_start_job, args=[job, True, uploader_args[0], True]


### PR DESCRIPTION
Only OBS service should handle specific utctimes. All other services only distinguish between always and now/utctime jobs.

Fixes #297 