### PR TITLE
Add comment on pytest __test__ usage.

### DIFF
--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -25,7 +25,7 @@ class TestingJob(object):
     """
     Class for an individual testing job.
     """
-    __test__ = False
+    __test__ = False  # Used by pytest to ignore class in auto discovery
 
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,


### PR DESCRIPTION
To clarify why it's needed to prevent pytest from picking up the TestingJob class as a unittest and failing.