### PR TITLE
Delete job doc logging from obs and uploader

### DIFF
--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -99,10 +99,6 @@ class OBSImageBuildResultService(BaseService):
         job_id = None
         if 'obs_job' in job_data:
             job_id = job_data['obs_job'].get('id', None)
-            self.log.info(
-                JsonFormat.json_message(job_data),
-                extra={'job_id': job_id}
-            )
             result = self._add_job(job_data)
         elif 'obs_job_delete' in job_data and job_data['obs_job_delete']:
             job_id = job_data['obs_job_delete']

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -132,10 +132,6 @@ class UploadImageService(BaseService):
         handle uploader job document
         """
         job_id = job_data['uploader_job'].get('id', None)
-        self.log.info(
-            JsonFormat.json_message(job_data),
-            extra={'job_id': job_id}
-        )
         result = self._add_job(job_data)
         if result:
             self._send_control_response(result, job_id)


### PR DESCRIPTION
The complete job documents are logged by the job creator
service. Thus there is no need for other services to log
their individual parts of it. This Fixes #276