### PR TITLE
Temporary type changes in EC2 job.

### DIFF
--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -24,18 +24,13 @@ from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
-    'c5d.large',
+    'c5.large',
     'd2.xlarge',
-    'h1.2xlarge',
-    'i3.8xlarge,'
-    'i3.metal',
+    'i3.8xlarge',
     'm5.large',
-    'm5d.large',
-    'p3.2xlarge',
-    'r5.24xlarge',
+    'r4.16xlarge',
     't2.micro',
-    't3.small',
-    'x1e.xlarge'
+    't2.small'
 ]
 
 


### PR DESCRIPTION
Libcloud is far behind on the EC2 types available. Thus the list must match what Libcloud has until a patch can be pushed through.