### PR TITLE
Add IPA timeout option

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -65,6 +65,8 @@ provider:
       us-gov-west-1: ami-c2b5d7e1
       us-west-1: ami-d5ea86b5
       us-west-2: ami-f0091d9
+testing:
+  ipa_timeout: 600
 uploader:
   azure:
     max_chunk_byte_size: 4096

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -19,9 +19,6 @@
 import json
 import random
 
-from threading import Thread
-
-from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
@@ -52,23 +49,10 @@ class AzureTestingJob(TestingJob):
             instance_type=instance_type, ssh_user=ssh_user
         )
 
-    def _prepare_test_run(self, creds, region, results):
+    def _add_provider_creds(self, creds, ipa_kwargs):
         """
-        Create an IPA testing thread for the provided region.
+        Update IPA kwargs with Azure credentials.
         """
-        service_account_credentials = json.dumps(creds)
-        process = Thread(
-            name=region, target=ipa_test, args=(results,), kwargs={
-                'provider': self.provider,
-                'description': self.description,
-                'distro': self.distro,
-                'image_id': self.source_regions[region],
-                'instance_type': self.instance_type,
-                'region': region,
-                'service_account_credentials': service_account_credentials,
-                'ssh_private_key_file': self.ssh_private_key_file,
-                'ssh_user': self.ssh_user,
-                'tests': self.tests
-            }
-        )
-        return process
+        ipa_kwargs['service_account_credentials'] = json.dumps(creds)
+
+        return ipa_kwargs

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -38,7 +38,7 @@ class AzureTestingJob(TestingJob):
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ssh_user='azureuser'
+        instance_type=None, ipa_timeout=None, ssh_user='azureuser'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -46,7 +46,8 @@ class AzureTestingJob(TestingJob):
         super(AzureTestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ssh_user=ssh_user
+            instance_type=instance_type, ipa_timeout=ipa_timeout,
+            ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/config.py
+++ b/mash/services/testing/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -17,6 +17,7 @@
 #
 
 from mash.services.base_config import BaseConfig
+from mash.services.testing.defaults import Defaults
 
 
 class TestingConfig(BaseConfig):
@@ -28,7 +29,19 @@ class TestingConfig(BaseConfig):
     The mash configuration file is a yaml formatted file containing
     information to control the behavior of the mash services.
     """
-    __test__ = False
+    __test__ = False  # Used by pytest to ignore class in auto discovery
 
     def __init__(self, config_file=None):
         super(TestingConfig, self).__init__(config_file)
+
+    def get_ipa_timeout(self):
+        """
+        Return the IPA timeout value in seconds.
+
+        :rtype: int
+        """
+        ipa_timeout = self._get_attribute(
+            attribute='ipa_timeout',
+            element='testing'
+        )
+        return ipa_timeout or Defaults.get_ipa_timeout()

--- a/mash/services/testing/defaults.py
+++ b/mash/services/testing/defaults.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+
+class Defaults(object):
+    """
+    Default values
+    """
+
+    @staticmethod
+    def get_ipa_timeout():
+        return 600

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -18,9 +18,6 @@
 
 import random
 
-from threading import Thread
-
-from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
@@ -58,23 +55,11 @@ class EC2TestingJob(TestingJob):
             instance_type=instance_type, ssh_user=ssh_user
         )
 
-    def _prepare_test_run(self, creds, region, results):
+    def _add_provider_creds(self, creds, ipa_kwargs):
         """
-        Create an IPA testing thread for the provided region.
+        Update IPA kwargs with EC2 credentials.
         """
-        process = Thread(
-            name=region, target=ipa_test, args=(results,), kwargs={
-                'provider': self.provider,
-                'access_key_id': creds['access_key_id'],
-                'description': self.description,
-                'distro': self.distro,
-                'image_id': self.source_regions[region],
-                'instance_type': self.instance_type,
-                'region': region,
-                'secret_access_key': creds['secret_access_key'],
-                'ssh_private_key_file': self.ssh_private_key_file,
-                'ssh_user': self.ssh_user,
-                'tests': self.tests
-            }
-        )
-        return process
+        ipa_kwargs['access_key_id'] = creds['access_key_id']
+        ipa_kwargs['secret_access_key'] = creds['secret_access_key']
+
+        return ipa_kwargs

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -44,7 +44,7 @@ class EC2TestingJob(TestingJob):
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ssh_user='ec2-user'
+        instance_type=None, ipa_timeout=None, ssh_user='ec2-user'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -52,7 +52,8 @@ class EC2TestingJob(TestingJob):
         super(EC2TestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ssh_user=ssh_user
+            instance_type=instance_type, ipa_timeout=ipa_timeout,
+            ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -19,9 +19,6 @@
 import json
 import random
 
-from threading import Thread
-
-from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 instance_types = [
@@ -52,23 +49,10 @@ class GCETestingJob(TestingJob):
             instance_type=instance_type, ssh_user=ssh_user
         )
 
-    def _prepare_test_run(self, creds, region, results):
+    def _add_provider_creds(self, creds, ipa_kwargs):
         """
-        Create an IPA testing thread for the provided region.
+        Update IPA kwargs with GCE credentials.
         """
-        service_account_credentials = json.dumps(creds)
-        process = Thread(
-            name=region, target=ipa_test, args=(results,), kwargs={
-                'provider': self.provider,
-                'description': self.description,
-                'distro': self.distro,
-                'image_id': self.source_regions[region],
-                'instance_type': self.instance_type,
-                'region': region,
-                'service_account_credentials': service_account_credentials,
-                'ssh_private_key_file': self.ssh_private_key_file,
-                'ssh_user': self.ssh_user,
-                'tests': self.tests
-            }
-        )
-        return process
+        ipa_kwargs['service_account_credentials'] = json.dumps(creds)
+
+        return ipa_kwargs

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -38,7 +38,7 @@ class GCETestingJob(TestingJob):
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ssh_user='root'
+        instance_type=None, ipa_timeout=None, ssh_user='root'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -46,7 +46,8 @@ class GCETestingJob(TestingJob):
         super(GCETestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ssh_user=ssh_user
+            instance_type=instance_type, ipa_timeout=ipa_timeout,
+            ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -32,9 +32,9 @@ from mash.utils.mash_utils import generate_name, get_key_from_file
 
 def ipa_test(
     results, provider=None, access_key_id=None, description=None, distro=None,
-    image_id=None, instance_type=None, region=None, secret_access_key=None,
-    service_account_credentials=None, ssh_private_key_file=None, ssh_user=None,
-    tests=None
+    image_id=None, instance_type=None, ipa_timeout=None, region=None,
+    secret_access_key=None, service_account_credentials=None,
+    ssh_private_key_file=None, ssh_user=None, tests=None
 ):
     name = threading.current_thread().getName()
     service_account_file = None
@@ -71,7 +71,8 @@ def ipa_test(
             ssh_key_name=key_name,
             ssh_private_key_file=ssh_private_key_file,
             ssh_user=ssh_user,
-            tests=tests
+            tests=tests,
+            timeout=ipa_timeout
         )
     except Exception:
         results[name] = {

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -33,7 +33,7 @@ class TestingJob(object):
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, description=None, distro='sles', instance_type=None,
-        ssh_user=None
+        ipa_timeout=None, ssh_user=None
     ):
         self.cloud_image_name = None
         self.job_file = job_file
@@ -43,6 +43,7 @@ class TestingJob(object):
         self.instance_type = instance_type
         self.iteration_count = 0
         self.id = id
+        self.ipa_timeout = ipa_timeout
         self.log_callback = None
         self.provider = provider
         self.status = UNKOWN
@@ -73,6 +74,7 @@ class TestingJob(object):
                 'distro': self.distro,
                 'image_id': self.source_regions[region],
                 'instance_type': self.instance_type,
+                'ipa_timeout': self.ipa_timeout,
                 'region': region,
                 'ssh_private_key_file': self.ssh_private_key_file,
                 'ssh_user': self.ssh_user,

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -16,9 +16,12 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from threading import Thread
+
 from mash.mash_exceptions import MashTestingException
 from mash.services.status_levels import FAILED, SUCCESS, UNKOWN
 from mash.services.testing.constants import NOT_IMPLEMENTED
+from mash.services.testing.ipa_helper import ipa_test
 
 
 class TestingJob(object):
@@ -50,9 +53,9 @@ class TestingJob(object):
         self.tests = tests
         self.utctime = utctime
 
-    def _prepare_test_run(self, creds, region, results):
+    def _add_provider_creds(self, creds, ipa_kwargs):
         """
-        Create an IPA testing thread for the provided region.
+        Update IPA kwargs with provider credentials.
         """
         raise NotImplementedError(NOT_IMPLEMENTED)
 
@@ -64,7 +67,22 @@ class TestingJob(object):
         jobs = []
         for region, account in self.test_regions.items():
             creds = self.credentials[account]
-            process = self._prepare_test_run(creds, region, results)
+            ipa_kwargs = {
+                'provider': self.provider,
+                'description': self.description,
+                'distro': self.distro,
+                'image_id': self.source_regions[region],
+                'instance_type': self.instance_type,
+                'region': region,
+                'ssh_private_key_file': self.ssh_private_key_file,
+                'ssh_user': self.ssh_user,
+                'tests': self.tests
+            }
+            ipa_kwargs = self._add_provider_creds(creds, ipa_kwargs)
+            process = Thread(
+                name=region, target=ipa_test,
+                args=(results,), kwargs=ipa_kwargs
+            )
             process.start()
             jobs.append(process)
 

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -128,6 +128,7 @@ class TestingService(BaseService):
         4. Bind to job listener queue.
         """
         job_config['ssh_private_key_file'] = self.ssh_private_key_file
+        job_config['ipa_timeout'] = self.config.get_ipa_timeout()
         try:
             job = job_class(**job_config)
         except Exception as e:

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -29,6 +29,8 @@ provider:
       ap-northeast-2: ami-249b554a
       cn-north-1: ami-bcc45885
       us-gov-west-1: ami-c2b5d7e1
+testing:
+  ipa_timeout: 600
 uploader:
   azure:
     max_chunk_byte_size: 4096

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -62,7 +62,8 @@ class TestAzureTestingJob(object):
             ssh_key_name=None,
             ssh_private_key_file='private_ssh_key.file',
             ssh_user='azureuser',
-            tests=['test_stuff']
+            tests=['test_stuff'],
+            timeout=None
         )
         mock_send_log.reset_mock()
 

--- a/test/unit/services/testing/config_test.py
+++ b/test/unit/services/testing/config_test.py
@@ -9,3 +9,6 @@ class TestTestingConfig(object):
     def test_get_log_file(self):
         assert self.empty_config.get_log_file('testing') == \
             '/var/log/mash/testing_service.log'
+
+    def test_get_ipa_timeout(self):
+        assert self.empty_config.get_ipa_timeout() == 600

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -70,7 +70,8 @@ class TestEC2TestingJob(object):
             ssh_key_name='random_name',
             ssh_private_key_file='private_ssh_key.file',
             ssh_user='ec2-user',
-            tests=['test_stuff']
+            tests=['test_stuff'],
+            timeout=None
         )
         client.delete_key_pair.assert_called_once_with(KeyName='random_name')
         mock_send_log.reset_mock()

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -62,7 +62,8 @@ class TestGCETestingJob(object):
             ssh_key_name=None,
             ssh_private_key_file='private_ssh_key.file',
             ssh_user='root',
-            tests=['test_stuff']
+            tests=['test_stuff'],
+            timeout=None
         )
         mock_send_log.reset_mock()
 

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -29,14 +29,12 @@ class TestTestingJob(object):
         metadata = job.get_metadata()
         assert metadata == {'job_id': '1'}
 
-    def test_prepare_test_run(self):
+    def test_add_provider_creds(self):
         job = TestingJob(**self.job_config)
-        results = Mock()
         with raises(NotImplementedError):
-            job._prepare_test_run(
+            job._add_provider_creds(
                 {'creds': 'dict'},
-                'us-west-1',
-                results
+                {}
             )
 
     def test_set_log_callback(self):

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -26,6 +26,8 @@ class TestIPATestingService(object):
 
         self.config = Mock()
         self.config.config_data = None
+        self.config.get_ipa_timeout.return_value = 600
+
         self.channel = Mock()
         self.channel.basic_ack.return_value = None
 
@@ -149,6 +151,7 @@ class TestIPATestingService(object):
         self, mock_persist_config, mock_bind_listener_queue
     ):
         mock_persist_config.return_value = 'temp-config.json'
+        self.testing.config = self.config
 
         job = Mock()
         job.id = '1'
@@ -160,7 +163,7 @@ class TestIPATestingService(object):
         self.testing._create_job(job_class, job_config)
 
         job_class.assert_called_once_with(
-            id=job.id, provider='ec2',
+            id=job.id, ipa_timeout=600, provider='ec2',
             ssh_private_key_file='private_ssh_key.file'
         )
         job.set_log_callback.assert_called_once_with(
@@ -176,6 +179,7 @@ class TestIPATestingService(object):
     def test_testing_create_job_exception(self):
         job_class = Mock()
         job_class.side_effect = Exception('Cannot create job.')
+        self.testing.config = self.config
         job_config = {'id': '1', 'provider': 'ec2'}
 
         self.testing._create_job(job_class, job_config)


### PR DESCRIPTION
- Move process creation all to base job. Append creds to dictionary in provider class before creating process.
- Add ipa_timeout option to MASH.