### PR TITLE
Integrate Azure replication

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -5,6 +5,7 @@
 # $ pip install -U pip setuptools
 # $ pip install -r .virtualenv.requirements.txt
 
+adal
 apache-libcloud
 azure-mgmt-compute
 azure-mgmt-resource
@@ -26,3 +27,4 @@ ec2publishimg
 ec2uploadimg
 python3-ipa
 lxml
+requests

--- a/examples/messages/add_azure_account.json
+++ b/examples/messages/add_azure_account.json
@@ -1,6 +1,5 @@
 {
   "account_name": "test-azure",
-  "container_name": "container1",
   "credentials": {
     "clientId": "123456",
     "clientSecret": "654321",
@@ -11,6 +10,10 @@
   "provider": "azure",
   "region": "southcentralus",
   "requesting_user": "user1",
-  "resource_group": "rg_123",
-  "storage_account": "sa_1"
+  "source_resource_group": "rg-1",
+  "source_container": "container1",
+  "source_storage_account": "sa1",
+  "destination_resource_group": "rg-2",
+  "destination_container": "container2",
+  "destination_storage_account": "sa2"
 }

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -5,9 +5,12 @@
     {
       "name": "test-azure",
       "region": "southcentralus",
-      "resource_group": "sc_res_group",
-      "container_name": "sccontainer1",
-      "storage_account": "scstorage1"
+      "source_resource_group": "rg-1",
+      "source_container": "container1",
+      "source_storage_account": "sa1",
+      "destination_resource_group": "rg-2",
+      "destination_container": "container2",
+      "destination_storage_account": "sa2"
     }
   ],
   "provider_groups": ["test"],

--- a/mash/services/credentials/azure_account.py
+++ b/mash/services/credentials/azure_account.py
@@ -31,10 +31,15 @@ class AzureAccount(BaseAccount):
             message['provider'], message['requesting_user'],
             group_name=message.get('group')
         )
-        self.container_name = message['container_name']
         self.region = message['region']
-        self.resource_group = message['resource_group']
-        self.storage_account = message['storage_account']
+        self.source_container = message['source_container']
+        self.source_resource_group = message['source_resource_group']
+        self.source_storage_account = message['source_storage_account']
+        self.destination_container = message['destination_container']
+        self.destination_resource_group = \
+            message['destination_resource_group']
+        self.destination_storage_account = \
+            message['destination_storage_account']
 
     def add_account(self, accounts_file):
         """
@@ -43,10 +48,13 @@ class AzureAccount(BaseAccount):
         Update or add group if provided.
         """
         account_info = {
-            'container_name': self.container_name,
             'region': self.region,
-            'resource_group': self.resource_group,
-            'storage_account': self.storage_account
+            'source_container': self.source_container,
+            'source_resource_group': self.source_resource_group,
+            'source_storage_account': self.source_storage_account,
+            'destination_container': self.destination_container,
+            'destination_resource_group': self.destination_resource_group,
+            'destination_storage_account': self.destination_storage_account
         }
 
         accounts = accounts_file[self.provider]['accounts'].get(self.requesting_user)

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -47,9 +47,12 @@ class AzureJob(BaseJob):
         Example: {
             'southcentralus': {
                 'account': 'acnt1',
-                'resource_group': 'rg-1',
-                'container_name': 'container1,
-                'storage_account': 'sa1'
+                'source_resource_group': 'rg-1',
+                'source_container': 'container1',
+                'source_storage_account': 'sa1',
+                'destination_resource_group': 'rg-2',
+                'destination_container': 'container2',
+                'destination_storage_account': 'sa2'
             }
         }
         """
@@ -74,18 +77,36 @@ class AzureJob(BaseJob):
         for account, info in accounts.items():
             region = info.get('region') or \
                 self._get_account_value(account, 'region')
-            resource_group = info.get('resource_group') or \
-                self._get_account_value(account, 'resource_group')
-            container_name = info.get('container_name') or \
-                self._get_account_value(account, 'container_name')
-            storage_account = info.get('storage_account') or \
-                self._get_account_value(account, 'storage_account')
+            source_resource_group = info.get('source_resource_group') or \
+                self._get_account_value(account, 'source_resource_group')
+            source_container = info.get('source_container') or \
+                self._get_account_value(account, 'source_container')
+            source_storage_account = info.get('source_storage_account') or \
+                self._get_account_value(account, 'source_storage_account')
+            destination_resource_group = info.get(
+                'destination_resource_group'
+            ) or self._get_account_value(
+                account, 'destination_resource_group'
+            )
+            destination_container = info.get(
+                'destination_container'
+            ) or self._get_account_value(
+                account, 'destination_container'
+            )
+            destination_storage_account = info.get(
+                'destination_storage_account'
+            ) or self._get_account_value(
+                account, 'destination_storage_account'
+            )
 
             self.target_account_info[region] = {
                 'account': account,
-                'resource_group': resource_group,
-                'container_name': container_name,
-                'storage_account': storage_account
+                'source_resource_group': source_resource_group,
+                'source_container': source_container,
+                'source_storage_account': source_storage_account,
+                'destination_resource_group': destination_resource_group,
+                'destination_container': destination_container,
+                'destination_storage_account': destination_storage_account
             }
 
     def _get_account_value(self, account, key):
@@ -117,7 +138,7 @@ class AzureJob(BaseJob):
         """
         Return a dictionary of replication source regions.
         """
-        raise NotImplementedError('TODO')
+        return self.target_account_info
 
     def get_testing_regions(self):
         """
@@ -137,7 +158,14 @@ class AzureJob(BaseJob):
         target_regions = {}
 
         for source_region, value in self.target_account_info.items():
-            target_regions[source_region] = value
+            target_regions[source_region] = {}
+            target_regions[source_region]['account'] = value['account']
+            target_regions[source_region]['container'] = \
+                value['source_container']
+            target_regions[source_region]['storage_account'] = \
+                value['source_storage_account']
+            target_regions[source_region]['resource_group'] = \
+                value['source_resource_group']
 
         return target_regions
 

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -29,7 +29,6 @@ add_account_azure = {
     'type': 'object',
     'properties': {
         'account_name': {'$ref': '#/definitions/non_empty_string'},
-        'container_name': {'$ref': '#/definitions/non_empty_string'},
         'credentials': {
             'type': 'object',
             'properties': {
@@ -47,13 +46,23 @@ add_account_azure = {
         'provider': {'enum': ['azure']},
         'region': {'$ref': '#/definitions/non_empty_string'},
         'requesting_user': {'$ref': '#/definitions/non_empty_string'},
-        'resource_group': {'$ref': '#/definitions/non_empty_string'},
-        'storage_account': {'$ref': '#/definitions/non_empty_string'}
+        'source_container': {'$ref': '#/definitions/non_empty_string'},
+        'source_resource_group': {'$ref': '#/definitions/non_empty_string'},
+        'source_storage_account': {'$ref': '#/definitions/non_empty_string'},
+        'destination_container': {'$ref': '#/definitions/non_empty_string'},
+        'destination_resource_group': {
+            '$ref': '#/definitions/non_empty_string'
+        },
+        'destination_storage_account': {
+            '$ref': '#/definitions/non_empty_string'
+        }
     },
     'additionalProperties': False,
     'required': [
-        'account_name', 'container_name', 'credentials', 'provider',
-        'requesting_user', 'resource_group', 'storage_account'
+        'account_name', 'credentials', 'provider', 'requesting_user',
+        'source_container', 'source_resource_group', 'source_storage_account',
+        'destination_container', 'destination_resource_group',
+        'destination_storage_account'
     ],
     'definitions': {
         'non_empty_string': non_empty_string
@@ -280,9 +289,16 @@ azure_job_message['definitions']['account'] = {
     'properties': {
         'name': {'$ref': '#/definitions/non_empty_string'},
         'region': {'$ref': '#/definitions/non_empty_string'},
-        'resource_group': {'$ref': '#/definitions/non_empty_string'},
-        'container_name': {'$ref': '#/definitions/non_empty_string'},
-        'storage_account': {'$ref': '#/definitions/non_empty_string'}
+        'source_container': {'$ref': '#/definitions/non_empty_string'},
+        'source_resource_group': {'$ref': '#/definitions/non_empty_string'},
+        'source_storage_account': {'$ref': '#/definitions/non_empty_string'},
+        'destination_container': {'$ref': '#/definitions/non_empty_string'},
+        'destination_resource_group': {
+            '$ref': '#/definitions/non_empty_string'
+        },
+        'destination_storage_account': {
+            '$ref': '#/definitions/non_empty_string'
+        }
     },
     'additionalProperties': False,
     'required': ['name']

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -35,11 +35,32 @@ add_account_azure = {
                 'clientId': {'$ref': '#/definitions/non_empty_string'},
                 'clientSecret': {'$ref': '#/definitions/non_empty_string'},
                 'subscriptionId': {'$ref': '#/definitions/non_empty_string'},
-                'tenantId': {'$ref': '#/definitions/non_empty_string'}
+                'tenantId': {'$ref': '#/definitions/non_empty_string'},
+                'activeDirectoryEndpointUrl': {
+                    '$ref': '#/definitions/non_empty_string'
+                },
+                'resourceManagerEndpointUrl': {
+                    '$ref': '#/definitions/non_empty_string'
+                },
+                'activeDirectoryGraphResourceId': {
+                    '$ref': '#/definitions/non_empty_string'
+                },
+                'sqlManagementEndpointUrl': {
+                    '$ref': '#/definitions/non_empty_string'
+                },
+                'galleryEndpointUrl': {
+                    '$ref': '#/definitions/non_empty_string'
+                },
+                'managementEndpointUrl': {
+                    '$ref': '#/definitions/non_empty_string'
+                }
             },
             'additionalProperties': True,
             'required': [
-                'clientId', 'clientSecret', 'subscriptionId', 'tenantId'
+                'clientId', 'clientSecret', 'subscriptionId', 'tenantId',
+                'activeDirectoryEndpointUrl', 'resourceManagerEndpointUrl',
+                'activeDirectoryGraphResourceId', 'sqlManagementEndpointUrl',
+                'galleryEndpointUrl', 'managementEndpointUrl'
             ],
         },
         'group': {'$ref': '#/definitions/non_empty_string'},

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -18,7 +18,8 @@
 
 from mash.services.replication.azure_utils import (
     copy_blob_to_classic_storage,
-    create_auth_file
+    create_auth_file,
+    delete_page_blob
 )
 
 from mash.services.replication.job import ReplicationJob
@@ -71,6 +72,13 @@ class AzureReplicationJob(ReplicationJob):
                         reg_info['destination_container'],
                         reg_info['destination_resource_group'],
                         reg_info['destination_storage_account']
+                    )
+                    delete_page_blob(
+                        auth_file,
+                        blob_name,
+                        reg_info['source_container'],
+                        reg_info['source_resource_group'],
+                        reg_info['source_storage_account']
                     )
                 except Exception as error:
                     self.send_log(

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.replication.azure_utils import (
+    copy_blob_to_classic_storage,
+    create_auth_file
+)
+
+from mash.services.replication.job import ReplicationJob
+from mash.services.status_levels import FAILED, SUCCESS
+
+
+class AzureReplicationJob(ReplicationJob):
+    """
+    Class for an Azure replication job.
+    """
+
+    def __init__(
+        self, id, image_description, provider, utctime,
+        replication_source_regions, cloud_image_name=None, job_file=None
+    ):
+        super(AzureReplicationJob, self).__init__(
+            id, provider, utctime, job_file=job_file
+        )
+        self.credentials = None
+        self.image_description = image_description
+        self.cloud_image_name = cloud_image_name
+        self.job_file = job_file
+        self.replication_source_regions = replication_source_regions
+
+    def _replicate(self):
+        """
+        Replicate image to all target regions in each source region.
+        """
+        self.status = SUCCESS
+
+        for source_region, reg_info in self.replication_source_regions.items():
+            credential = self.credentials[reg_info['account']]
+            blob_name = ''.join([self.cloud_image_name, '.vhd'])
+
+            with create_auth_file(credential) as auth_file:
+                self.send_log(
+                    'Copying image for account: {},'
+                    ' to classic storage container.'.format(
+                        reg_info['account']
+                    )
+                )
+
+                try:
+                    copy_blob_to_classic_storage(
+                        auth_file,
+                        blob_name,
+                        reg_info['source_container'],
+                        reg_info['source_resource_group'],
+                        reg_info['source_storage_account'],
+                        reg_info['destination_container'],
+                        reg_info['destination_resource_group'],
+                        reg_info['destination_storage_account']
+                    )
+                except Exception as error:
+                    self.send_log(
+                        'There was an error copying image blob in {0}:'
+                        ' {1}'.format(
+                            reg_info['account'], error
+                        ),
+                        False
+                    )
+                    self.status = FAILED

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -19,6 +19,7 @@
 from mash.services.replication.azure_utils import (
     copy_blob_to_classic_storage,
     create_auth_file,
+    delete_image,
     delete_page_blob
 )
 
@@ -72,6 +73,11 @@ class AzureReplicationJob(ReplicationJob):
                         reg_info['destination_container'],
                         reg_info['destination_resource_group'],
                         reg_info['destination_storage_account']
+                    )
+                    delete_image(
+                        auth_file,
+                        reg_info['source_resource_group'],
+                        self.cloud_image_name
                     )
                     delete_page_blob(
                         auth_file,

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -47,7 +47,15 @@ class AzureReplicationJob(ReplicationJob):
 
     def _replicate(self):
         """
-        Replicate image to all target regions in each source region.
+        Replicate image in each source region.
+
+        The azure replication process requires multiple steps:
+
+        - The image blob is copied from ARM storage to legacy ASM storage
+          + The azure publishing process requires an ASM based page blob
+
+        - Once the blob is copied to legacy storage the ARM based image
+          and blob are deleted
         """
         self.status = SUCCESS
 

--- a/mash/services/replication/azure_utils.py
+++ b/mash/services/replication/azure_utils.py
@@ -27,6 +27,7 @@ from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
 
 from azure.common.client_factory import get_client_from_auth_file
+from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.storage.blob import ContainerPermissions, PageBlobService
 
@@ -92,6 +93,19 @@ def delete_page_blob(
         auth_file, resource_group, storage_account
     )
     page_blob_service.delete_blob(container, blob)
+
+
+def delete_image(auth_file, resoure_group, image_name):
+    """
+    Delete the image from resource group.
+    """
+    compute_client = get_client_from_auth_file(
+        ComputeManagementClient, auth_path=auth_file
+    )
+    async_delete_image = compute_client.images.delete(
+        resoure_group, image_name
+    )
+    async_delete_image.wait()
 
 
 def get_blob_url(

--- a/mash/services/replication/azure_utils.py
+++ b/mash/services/replication/azure_utils.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import adal
+import json
+import requests
+import time
+
+from datetime import datetime, timedelta
+
+from azure.common.client_factory import get_client_from_auth_file
+from azure.mgmt.storage import StorageManagementClient
+from azure.storage.blob import ContainerPermissions, PageBlobService
+
+from mash.mash_exceptions import MashReplicationException
+
+
+def copy_blob_to_classic_storage(
+    auth_file, blob_name, source_container, source_resource_group,
+    source_storage_account, destination_container, destination_resource_group,
+    destination_storage_account, timeout=600
+):
+    """
+    Copy a blob from ARM based storage account to a classic storage account.
+    """
+    source_blob_url = get_blob_url(
+        auth_file, blob_name, source_container, source_resource_group,
+        source_storage_account
+    )
+
+    destination_keys = get_classic_storage_account_keys(
+        auth_file, destination_resource_group, destination_storage_account
+    )
+
+    page_blob_service = PageBlobService(
+        account_name=destination_storage_account,
+        account_key=destination_keys['primaryKey']
+    )
+
+    copy = page_blob_service.copy_blob(
+        destination_container,
+        blob_name,
+        source_blob_url
+    )
+
+    start = time.time()
+    end = start + timeout
+
+    while time.time() < end:
+        if copy.status == 'success':
+            return
+        else:
+            time.sleep(30)
+
+        copy = page_blob_service.get_blob_properties(
+            destination_container,
+            blob_name
+        ).properties.copy
+
+    raise MashReplicationException(
+        'Time out waiting for async copy to complete. Copy may not have'
+        ' completed successfully.'
+    )
+
+
+def get_blob_url(
+    auth_file, blob_name, container, resource_group, storage_account,
+    permissions=ContainerPermissions.READ, expire_hours=1
+):
+    """
+    Create a URL for the given blob with a shared access signature.
+
+    The storage account should be ARM based.
+
+    The signature will expire based on expire_hours.
+    """
+    storage_client = get_client_from_auth_file(
+        StorageManagementClient,
+        auth_path=auth_file
+    )
+    storage_key_list = storage_client.storage_accounts.list_keys(
+        resource_group, storage_account
+    )
+    page_blob_service = PageBlobService(
+        account_name=storage_account,
+        account_key=storage_key_list.keys[0].value
+    )
+
+    sas_token = page_blob_service.generate_container_shared_access_signature(
+        container,
+        permissions,
+        datetime.utcnow() + timedelta(hours=expire_hours)
+    )
+
+    source_blob_url = page_blob_service.make_blob_url(
+        container,
+        blob_name,
+        sas_token=sas_token,
+    )
+
+    return source_blob_url
+
+
+def get_classic_storage_account_keys(
+    auth_file, resource_group, storage_account, api_version='2016-11-01'
+):
+    """
+    Acquire classic storage account keys using service account credentials.
+    """
+    with open(auth_file) as sa_file:
+        credentials = json.load(sa_file)
+
+    # get an Azure access token using the adal library
+    context = adal.AuthenticationContext(
+        '/'.join([
+            credentials['activeDirectoryEndpointUrl'],
+            credentials['tenantId']
+        ])
+    )
+    access_token = context.acquire_token_with_client_credentials(
+        credentials['managementEndpointUrl'],
+        credentials['clientId'],
+        credentials['clientSecret']
+    ).get('accessToken')
+
+    url = '{resource_url}subscriptions/' \
+          '{subscription_id}/resourceGroups/{resource_group}/' \
+          'providers/Microsoft.ClassicStorage/storageAccounts/' \
+          '{storage_account}/listKeys?api-version={api_version}'
+    endpoint = url.format(
+        resource_url=credentials['resourceManagerEndpointUrl'],
+        subscription_id=credentials['subscriptionId'],
+        resource_group=resource_group,
+        storage_account=storage_account,
+        api_version=api_version
+    )
+
+    headers = {'Authorization': 'Bearer ' + access_token}
+    json_output = requests.post(endpoint, headers=headers).json()
+
+    return json_output

--- a/mash/services/replication/azure_utils.py
+++ b/mash/services/replication/azure_utils.py
@@ -82,6 +82,18 @@ def copy_blob_to_classic_storage(
     )
 
 
+def delete_page_blob(
+    auth_file, blob, container, resource_group, storage_account
+):
+    """
+    Delete page blob in container.
+    """
+    page_blob_service = get_page_blob_service(
+        auth_file, resource_group, storage_account
+    )
+    page_blob_service.delete_blob(container, blob)
+
+
 def get_blob_url(
     auth_file, blob_name, container, resource_group, storage_account,
     permissions=ContainerPermissions.READ, expire_hours=1
@@ -93,16 +105,8 @@ def get_blob_url(
 
     The signature will expire based on expire_hours.
     """
-    storage_client = get_client_from_auth_file(
-        StorageManagementClient,
-        auth_path=auth_file
-    )
-    storage_key_list = storage_client.storage_accounts.list_keys(
-        resource_group, storage_account
-    )
-    page_blob_service = PageBlobService(
-        account_name=storage_account,
-        account_key=storage_key_list.keys[0].value
+    page_blob_service = get_page_blob_service(
+        auth_file, resource_group, storage_account
     )
 
     sas_token = page_blob_service.generate_container_shared_access_signature(
@@ -118,6 +122,25 @@ def get_blob_url(
     )
 
     return source_blob_url
+
+
+def get_page_blob_service(auth_file, resource_group, storage_account):
+    """
+    Return authenticated page blob service instance for the storage account.
+    """
+    storage_client = get_client_from_auth_file(
+        StorageManagementClient,
+        auth_path=auth_file
+    )
+    storage_key_list = storage_client.storage_accounts.list_keys(
+        resource_group, storage_account
+    )
+    page_blob_service = PageBlobService(
+        account_name=storage_account,
+        account_key=storage_key_list.keys[0].value
+    )
+
+    return page_blob_service
 
 
 def get_classic_storage_account_keys(

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -24,8 +24,10 @@ from apscheduler import events
 from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from mash.csp import CSP
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
+from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
 from mash.utils.json_format import JsonFormat
 
@@ -68,8 +70,10 @@ class ReplicationService(BaseService):
                 'Job already queued.',
                 extra={'job_id': job_id}
             )
-        elif provider == 'ec2':
+        elif provider == CSP.ec2:
             self._create_job(EC2ReplicationJob, job_config)
+        elif provider == CSP.azure:
+            self._create_job(AzureReplicationJob, job_config)
         else:
             self.log.error(
                 'Provider {0} is not supported.'.format(provider)

--- a/mash/services/uploader/cloud/azure.py
+++ b/mash/services/uploader/cloud/azure.py
@@ -42,7 +42,7 @@ class UploadAzure(UploadBase):
 
         custom_args={
             'region': 'region_name',
-            'container_name': 'storage_container_name',
+            'container': 'storage_container_name',
             'storage_account': 'storage_account_name',
             'resource_group': 'optional_resource_group_name'
         }
@@ -57,8 +57,8 @@ class UploadAzure(UploadBase):
                 'required Azure region name for upload not specified'
             )
 
-        self.container_name = self.custom_args.get('container_name')
-        if not self.container_name:
+        self.container = self.custom_args.get('container')
+        if not self.container:
             raise MashUploadException(
                 'required Azure container name for upload not specified'
             )
@@ -92,7 +92,7 @@ class UploadAzure(UploadBase):
         blob_name = ''.join([self.cloud_image_name, '.vhd'])
         page_blob = PageBlob(
             page_blob_service, blob_name,
-            self.container_name, system_image_file_type.get_size()
+            self.container, system_image_file_type.get_size()
         )
         if system_image_file_type.is_xz():
             open_image = lzma.LZMAFile
@@ -123,7 +123,7 @@ class UploadAzure(UploadBase):
                         'caching': 'ReadWrite',
                         'blob_uri': 'https://{0}.{1}/{2}/{3}'.format(
                             self.storage_account, 'blob.core.windows.net',
-                            self.container_name, blob_name
+                            self.container, blob_name
                         )
                     }
                 }

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -261,8 +261,8 @@ class UploadImageService(BaseService):
                     {
                         'resource_group':
                             job_data['target_regions'][region]['resource_group'],
-                        'container_name':
-                            job_data['target_regions'][region]['container_name'],
+                        'container':
+                            job_data['target_regions'][region]['container'],
                         'storage_account':
                             job_data['target_regions'][region]['storage_account'],
                         'account':

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -27,6 +27,7 @@ Source:         mash-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+BuildRequires:  python3-adal
 BuildRequires:  python3-apache-libcloud
 BuildRequires:  python3-azure-mgmt-compute
 BuildRequires:  python3-azure-mgmt-resource
@@ -48,7 +49,9 @@ BuildRequires:  python3-ipa
 BuildRequires:  python3-ipa-tests
 BuildRequires:  python3-lxml
 BuildRequires:  python3-Flask
+BuildRequires:  python3-requests
 Requires:       rabbitmq-server
+Requires:       python3-adal
 Requires:       python3-apache-libcloud
 Requires:       python3-azure-mgmt-compute
 Requires:       python3-azure-mgmt-resource
@@ -70,6 +73,7 @@ Requires:       python3-ipa
 Requires:       python3-ipa-tests
 Requires:       python3-lxml
 Requires:       python3-Flask
+Requires:       python3-requests
 Requires:       apache2
 Requires:       apache2-mod_wsgi-python3
 Requires(pre):  pwdutils

--- a/test/data/azure_creds.json
+++ b/test/data/azure_creds.json
@@ -1,0 +1,12 @@
+{
+  "clientId": "09876543-1234-1234-1234-123456789012",
+  "clientSecret": "09876543-1234-1234-1234-123456789012",
+  "subscriptionId": "09876543-1234-1234-1234-123456789012",
+  "tenantId": "09876543-1234-1234-1234-123456789012",
+  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
+  "resourceManagerEndpointUrl": "https://management.azure.com/",
+  "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
+  "galleryEndpointUrl": "https://gallery.azure.com/",
+  "managementEndpointUrl": "https://management.core.windows.net/"
+}

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -5,14 +5,17 @@
     {
       "name": "test-azure",
       "region": "southcentralus",
-      "resource_group": "sc_res_group",
-      "container_name": "sccontainer1",
-      "storage_account": "scstorage1"
+      "source_resource_group": "rg-1",
+      "source_container": "container1",
+      "source_storage_account": "sa1",
+      "destination_resource_group": "rg-2",
+      "destination_container": "container2",
+      "destination_storage_account": "sa2"
     }
   ],
   "provider_groups": ["test-azure-group"],
   "requesting_user": "user1",
-  "last_service": "testing",
+  "last_service": "replication",
   "utctime": "now",
   "image": "test_image_oem",
   "cloud_image_name": "new_image_123",

--- a/test/unit/services/credentials/azure_account_test.py
+++ b/test/unit/services/credentials/azure_account_test.py
@@ -7,13 +7,16 @@ class TestAzureAccount(object):
     def setup(self):
         message = {
             'account_name': 'acnt123',
-            'container_name': 'container1',
             'group': 'group123',
             'provider': 'azure',
             'region': 'southcentralus',
             'requesting_user': 'user2',
-            'resource_group': 'rgroup1',
-            'storage_account': 'sa_12'
+            'source_resource_group': 'rg-1',
+            'source_container': 'container1',
+            'source_storage_account': 'sa1',
+            'destination_resource_group': 'rg-2',
+            'destination_container': 'container2',
+            'destination_storage_account': 'sa2'
         }
         self.azure_account = AzureAccount(message)
 
@@ -24,10 +27,13 @@ class TestAzureAccount(object):
         self.azure_account.add_account(accounts)
 
         account = accounts['azure']['accounts']['user2']['acnt123']
-        assert account['container_name'] == 'container1'
         assert account['region'] == 'southcentralus'
-        assert account['resource_group'] == 'rgroup1'
-        assert account['storage_account'] == 'sa_12'
+        assert account['source_container'] == 'container1'
+        assert account['source_resource_group'] == 'rg-1'
+        assert account['source_storage_account'] == 'sa1'
+        assert account['destination_container'] == 'container2'
+        assert account['destination_resource_group'] == 'rg-2'
+        assert account['destination_storage_account'] == 'sa2'
 
         group = accounts['azure']['groups']['user2']['group123']
         assert 'acnt123' in group

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -631,13 +631,16 @@ class TestCredentialsService(object):
     ):
         message = {
             "account_name": "test-azure",
-            "container_name": "container1",
             "credentials": {"encrypted": "creds"},
             "provider": "azure",
             "region": "southcentralus",
             "requesting_user": "user1",
-            "resource_group": "rg_123",
-            "storage_account": "sa_123"
+            "source_container": "container1",
+            "source_resource_group": "rg_1",
+            "source_storage_account": "sa_1",
+            "destination_container": "container2",
+            "destination_resource_group": "rg_2",
+            "destination_storage_account": "sa_2"
         }
 
         with open(self.service.accounts_file) as f:
@@ -653,10 +656,13 @@ class TestCredentialsService(object):
         )
 
         account = accounts['azure']['accounts']['user1']['test-azure']
-        assert account['container_name'] == 'container1'
         assert account['region'] == 'southcentralus'
-        assert account['resource_group'] == 'rg_123'
-        assert account['storage_account'] == 'sa_123'
+        assert account['source_container'] == 'container1'
+        assert account['source_resource_group'] == 'rg_1'
+        assert account['source_storage_account'] == 'sa_1'
+        assert account['destination_container'] == 'container2'
+        assert account['destination_resource_group'] == 'rg_2'
+        assert account['destination_storage_account'] == 'sa_2'
 
     @patch.object(CredentialsService, '_store_encrypted_credentials')
     @patch.object(CredentialsService, '_write_accounts_to_file')

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -21,8 +21,7 @@ class TestJobCreatorAzureJob(object):
         [
             'get_deprecation_regions',
             'get_publisher_message',
-            'get_publisher_regions',
-            'get_replication_source_regions'
+            'get_publisher_regions'
         ]
     )
     def test_not_implemented_methods(self, method):

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -285,15 +285,21 @@ class TestJobCreatorService(object):
                 "user1": {
                     "test-azure": {
                         "region": "southcentralus",
-                        "resource_group": "sc_res_group",
-                        "container_name": "sccontainer1",
-                        "storage_account": "scstorage1"
+                        "source_resource_group": "sc_res_group1",
+                        "source_container": "sccontainer1",
+                        "source_storage_account": "scstorage1",
+                        "destination_resource_group": "sc_res_group2",
+                        "destination_container": "sccontainer2",
+                        "destination_storage_account": "scstorage2"
                     },
                     "test-azure2": {
                         "region": "centralus",
-                        "resource_group": "c_res_group",
-                        "container_name": "ccontainer1",
-                        "storage_account": "cstorage1"
+                        "source_resource_group": "c_res_group1",
+                        "source_container": "ccontainer1",
+                        "source_storage_account": "cstorage1",
+                        "destination_resource_group": "c_res_group2",
+                        "destination_container": "ccontainer2",
+                        "destination_storage_account": "cstorage2"
                     }
                 }
             },
@@ -315,7 +321,7 @@ class TestJobCreatorService(object):
         msg = mock_publish.mock_calls[0][1][2]
         data = json.loads(msg)['credentials_job']
         assert data['id'] == '12345678-1234-1234-1234-123456789012'
-        assert data['last_service'] == 'testing'
+        assert data['last_service'] == 'replication'
         assert data['provider'] == 'azure'
         assert 'test-azure' in data['provider_accounts']
         assert 'test-azure2' in data['provider_accounts']
@@ -349,15 +355,15 @@ class TestJobCreatorService(object):
                     "target_regions": {
                         "centralus": {
                             "account": "test-azure2",
-                            "container_name": "ccontainer1",
-                            "resource_group": "c_res_group",
+                            "container": "ccontainer1",
+                            "resource_group": "c_res_group1",
                             "storage_account": "cstorage1"
                         },
                         "southcentralus": {
                             "account": "test-azure",
-                            "container_name": "sccontainer1",
-                            "resource_group": "sc_res_group",
-                            "storage_account": "scstorage1"
+                            "container": "container1",
+                            "resource_group": "rg-1",
+                            "storage_account": "sa1"
                         }
                     },
                     "utctime": "now"
@@ -377,6 +383,37 @@ class TestJobCreatorService(object):
                         "southcentralus": "test-azure"
                     },
                     "tests": ["test_stuff"],
+                    "utctime": "now"
+                }
+            })
+        )
+        assert mock_publish.mock_calls[4] == call(
+            'replication', 'job_document',
+            JsonFormat.json_message({
+                "replication_job": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image_description": "New Image #123",
+                    "provider": "azure",
+                    "replication_source_regions": {
+                        "centralus": {
+                            "account": "test-azure2",
+                            "source_container": "ccontainer1",
+                            "source_resource_group": "c_res_group1",
+                            "source_storage_account": "cstorage1",
+                            "destination_container": "ccontainer2",
+                            "destination_resource_group": "c_res_group2",
+                            "destination_storage_account": "cstorage2"
+                        },
+                        "southcentralus": {
+                            "account": "test-azure",
+                            "source_container": "container1",
+                            "source_resource_group": "rg-1",
+                            "source_storage_account": "sa1",
+                            "destination_container": "container2",
+                            "destination_resource_group": "rg-2",
+                            "destination_storage_account": "sa2"
+                        }
+                    },
                     "utctime": "now"
                 }
             })
@@ -680,11 +717,14 @@ class TestJobCreatorService(object):
                     "provider": "azure",
                     "provider_accounts": [
                         {
-                            "container_name": "sccontainer1",
                             "name": "test-azure",
                             "region": "southcentralus",
-                            "resource_group": "sc_res_group",
-                            "storage_account": "scstorage1"
+                            "source_resource_group": "rg-1",
+                            "source_storage_account": "sa1",
+                            "source_container": "container1",
+                            "destination_resource_group": "rg-2",
+                            "destination_storage_account": "sa2",
+                            "destination_container": "container2"
                         }
                     ],
                     "provider_groups": ["test-azure-group"],

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -46,12 +46,13 @@ class TestAzureReplicationJob(object):
         self.job.cloud_image_name = 'image123'
 
     @patch('mash.services.replication.azure_job.delete_page_blob')
+    @patch('mash.services.replication.azure_job.delete_image')
     @patch('mash.services.replication.azure_job.create_auth_file')
     @patch('mash.services.replication.azure_job.copy_blob_to_classic_storage')
     @patch.object(AzureReplicationJob, 'send_log')
     def test_replicate(
         self, mock_send_log, mock_copy_blob, mock_create_auth_file,
-        mock_delete_page_blob
+        mock_delete_image, mock_delete_page_blob
     ):
         mock_delete_page_blob.side_effect = Exception('Cannot delete image.')
         mock_create_auth_file.return_value.__enter__.return_value = \
@@ -66,6 +67,9 @@ class TestAzureReplicationJob(object):
         mock_copy_blob.assert_called_once_with(
             '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1',
             'container2', 'rg-2', 'sa2'
+        )
+        mock_delete_image.assert_called_once_with(
+            '/tmp/file.auth', 'rg-1', 'image123'
         )
         mock_delete_page_blob.assert_called_once_with(
             '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1'

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -1,0 +1,68 @@
+from unittest.mock import call, patch
+
+from mash.services.status_levels import FAILED
+from mash.services.replication.azure_job import AzureReplicationJob
+
+
+class TestAzureReplicationJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'image_description': 'My image',
+            'provider': 'azure',
+            'utctime': 'now',
+            "replication_source_regions": {
+                "westus": {
+                    'account': 'acnt1',
+                    'source_resource_group': 'rg-1',
+                    'source_container': 'container1',
+                    'source_storage_account': 'sa1',
+                    'destination_resource_group': 'rg-2',
+                    'destination_container': 'container2',
+                    'destination_storage_account': 'sa2'
+                }
+            }
+        }
+        self.job = AzureReplicationJob(**self.job_config)
+
+        self.job.credentials = {
+            "acnt1": {
+                "clientId": "09876543-1234-1234-1234-123456789012",
+                "clientSecret": "09876543-1234-1234-1234-123456789012",
+                "subscriptionId": "09876543-1234-1234-1234-123456789012",
+                "tenantId": "09876543-1234-1234-1234-123456789012",
+                "activeDirectoryEndpointUrl":
+                    "https://login.microsoftonline.com",
+                "resourceManagerEndpointUrl": "https://management.azure.com/",
+                "activeDirectoryGraphResourceId":
+                    "https://graph.windows.net/",
+                "sqlManagementEndpointUrl":
+                    "https://management.core.windows.net:8443/",
+                "galleryEndpointUrl": "https://gallery.azure.com/",
+                "managementEndpointUrl":
+                    "https://management.core.windows.net/"
+            }
+        }
+        self.job.cloud_image_name = 'image123'
+
+    @patch('mash.services.replication.azure_job.create_auth_file')
+    @patch('mash.services.replication.azure_job.copy_blob_to_classic_storage')
+    @patch.object(AzureReplicationJob, 'send_log')
+    def test_replicate(
+        self, mock_send_log, mock_copy_blob, mock_create_auth_file
+    ):
+        mock_copy_blob.side_effect = Exception('Cannot copy image.')
+        mock_create_auth_file.return_value.__enter__.return_value = \
+            '/tmp/file.auth'
+
+        self.job._replicate()
+
+        mock_send_log.has_calls([
+            call('Copying image for account: acnt1, to classic storage container.'),
+            call('There was an error copying image blob in acnt1.', False)
+        ])
+        mock_copy_blob.assert_called_once_with(
+            '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1',
+            'container2', 'rg-2', 'sa2'
+        )
+        assert self.job.status == FAILED

--- a/test/unit/services/replication/azure_utils_test.py
+++ b/test/unit/services/replication/azure_utils_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from mash.mash_exceptions import MashReplicationException
 from mash.services.replication.azure_utils import (
     create_auth_file,
+    delete_image,
     delete_page_blob,
     get_classic_storage_account_keys,
     get_blob_url,
@@ -193,3 +194,19 @@ def test_delete_page_blob(mock_get_page_blob_service):
         'container1',
         'blob1'
     )
+
+
+@patch('mash.services.replication.azure_utils.get_client_from_auth_file')
+def test_delete_image(mock_get_client):
+    compute_client = MagicMock()
+    async_wait = MagicMock()
+    compute_client.images.delete.return_value = async_wait
+    mock_get_client.return_value = compute_client
+
+    delete_image(
+        '../data/azure_creds.json', 'rg1', 'image123'
+    )
+    compute_client.images.delete.assert_called_once_with(
+        'rg1', 'image123'
+    )
+    async_wait.wait.assert_called_once_with()

--- a/test/unit/services/replication/azure_utils_test.py
+++ b/test/unit/services/replication/azure_utils_test.py
@@ -1,0 +1,165 @@
+import io
+
+from pytest import raises
+from unittest.mock import MagicMock, patch
+
+from mash.mash_exceptions import MashReplicationException
+from mash.services.replication.azure_utils import (
+    create_auth_file,
+    get_classic_storage_account_keys,
+    get_blob_url,
+    copy_blob_to_classic_storage
+)
+from mash.utils.json_format import JsonFormat
+
+
+@patch('mash.services.replication.azure_utils.os')
+@patch('mash.services.replication.azure_utils.NamedTemporaryFile')
+def test_create_auth_file(mock_temp_file, mock_os):
+    auth_file = MagicMock()
+    auth_file.name = 'test.json'
+    mock_temp_file.return_value = auth_file
+
+    creds = {'tenantId': '123456', 'subscriptionId': '98765'}
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        with create_auth_file(creds) as auth:
+            assert auth == 'test.json'
+
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(JsonFormat.json_message(creds))
+
+    mock_os.remove.assert_called_once_with('test.json')
+
+
+@patch('mash.services.replication.azure_utils.adal')
+@patch('mash.services.replication.azure_utils.requests')
+def test_get_classic_storage_account_keys(mock_requests, mock_adal):
+    context = MagicMock()
+    context.acquire_token_with_client_credentials.return_value = {
+        'accessToken': '1234567890'
+    }
+    mock_adal.AuthenticationContext.return_value = context
+    response = MagicMock()
+    response.json.return_value = {'primaryKey': '123', 'secondaryKey': '321'}
+    mock_requests.post.return_value = response
+
+    keys = get_classic_storage_account_keys(
+        '../data/azure_creds.json', 'rg1', 'sa1'
+    )
+
+    mock_adal.AuthenticationContext.assert_called_once_with(
+        'https://login.microsoftonline.com/'
+        '09876543-1234-1234-1234-123456789012'
+    )
+    context.acquire_token_with_client_credentials.assert_called_once_with(
+        'https://management.core.windows.net/',
+        '09876543-1234-1234-1234-123456789012',
+        '09876543-1234-1234-1234-123456789012'
+    )
+    assert keys['primaryKey'] == '123'
+    assert keys['secondaryKey'] == '321'
+
+
+@patch('mash.services.replication.azure_utils.get_client_from_auth_file')
+@patch('mash.services.replication.azure_utils.PageBlobService')
+def test_get_blob_url(mock_page_blob_service, mock_get_client_from_auth):
+    storage_client = MagicMock()
+    mock_get_client_from_auth.return_value = storage_client
+
+    key1 = MagicMock()
+    key1.value = '12345678'
+    key2 = MagicMock()
+    key2.value = '87654321'
+    key_list = MagicMock()
+    key_list.keys = [key1, key2]
+    storage_client.storage_accounts.list_keys.return_value = key_list
+
+    page_blob_service = MagicMock()
+    page_blob_service.generate_container_shared_access_signature \
+        .return_value = 'token123'
+    page_blob_service.make_blob_url.return_value = 'https://test/url/?token123'
+    mock_page_blob_service.return_value = page_blob_service
+
+    url = get_blob_url(
+        '../data/azure_creds.json', 'blob1', 'container1', 'rg1', 'sa1'
+    )
+
+    assert url == 'https://test/url/?token123'
+
+    storage_client.storage_accounts.list_keys.assert_called_once_with(
+        'rg1', 'sa1'
+    )
+    mock_page_blob_service.assert_called_once_with(
+        account_name='sa1', account_key='12345678'
+    )
+    page_blob_service.make_blob_url.assert_called_once_with(
+        'container1',
+        'blob1',
+        sas_token='token123'
+    )
+
+
+@patch('mash.services.replication.azure_utils.get_blob_url')
+@patch('mash.services.replication.azure_utils.get_classic_storage_account_keys')
+@patch('mash.services.replication.azure_utils.time.sleep')
+@patch('mash.services.replication.azure_utils.PageBlobService')
+def test_copy_blob_to_classic_storage(
+    mock_page_blob_service, mock_time, mock_get_keys, mock_get_blob_url
+):
+    mock_get_blob_url.return_value = 'https://test/url/?token123'
+    keys = {'primaryKey': '123456'}
+    mock_get_keys.return_value = keys
+
+    copy = MagicMock()
+    copy.status = 'pending'
+
+    props_copy = MagicMock()
+    props_copy.properties.copy.status = 'success'
+
+    page_blob_service = MagicMock()
+    page_blob_service.copy_blob.return_value = copy
+    page_blob_service.get_blob_properties.return_value = props_copy
+    mock_page_blob_service.return_value = page_blob_service
+
+    copy_blob_to_classic_storage(
+        '../data/azure_creds.json', 'blob1', 'sc1', 'srg1', 'ssa1',
+        'dc2', 'drg2', 'dsa2'
+    )
+
+    mock_get_blob_url.assert_called_once_with(
+        '../data/azure_creds.json', 'blob1', 'sc1', 'srg1', 'ssa1'
+    )
+
+    mock_get_keys.assert_called_once_with(
+        '../data/azure_creds.json', 'drg2', 'dsa2'
+    )
+
+
+@patch('mash.services.replication.azure_utils.get_blob_url')
+@patch('mash.services.replication.azure_utils.get_classic_storage_account_keys')
+@patch('mash.services.replication.azure_utils.time.sleep')
+@patch('mash.services.replication.azure_utils.PageBlobService')
+def test_copy_blob_to_classic_storage_timeout(
+    mock_page_blob_service, mock_time, mock_get_keys, mock_get_blob_url
+):
+    mock_get_blob_url.return_value = 'https://test/url/?token123'
+    keys = {'primaryKey': '123456'}
+    mock_get_keys.return_value = keys
+
+    copy = MagicMock()
+    copy.status = 'pending'
+
+    props_copy = MagicMock()
+    props_copy.properties.copy.status = 'success'
+
+    page_blob_service = MagicMock()
+    page_blob_service.copy_blob.return_value = copy
+    page_blob_service.get_blob_properties.return_value = props_copy
+    mock_page_blob_service.return_value = page_blob_service
+
+    with raises(MashReplicationException):
+        copy_blob_to_classic_storage(
+            '../data/azure_creds.json', 'blob1', 'sc1', 'srg1', 'ssa1',
+            'dc2', 'drg2', 'dsa2', timeout=0
+        )

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -8,6 +8,7 @@ from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 
 from mash.services.base_service import BaseService
 from mash.services.replication.service import ReplicationService
+from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
 from mash.utils.json_format import JsonFormat
 
@@ -95,6 +96,19 @@ class TestReplicationService(object):
 
         mock_create_job.assert_called_once_with(
             EC2ReplicationJob,
+            job_config
+        )
+
+    @patch.object(ReplicationService, '_create_job')
+    def test_replication_add_job_azure(self, mock_create_job):
+        job_config = {
+            'id': '1', 'provider': 'azure', 'utctime': 'now',
+        }
+
+        self.replication._add_job(job_config)
+
+        mock_create_job.assert_called_once_with(
+            AzureReplicationJob,
             job_config
         )
 

--- a/test/unit/services/uploader/cloud/azure_test.py
+++ b/test/unit/services/uploader/cloud/azure_test.py
@@ -43,7 +43,7 @@ class TestUploadAzure(object):
         }
         custom_args = {
             'resource_group': 'group_name',
-            'container_name': 'container',
+            'container': 'container',
             'storage_account': 'storage',
             'region': 'region'
         }
@@ -78,7 +78,7 @@ class TestUploadAzure(object):
     def test_init_incomplete_arguments(self, mock_NamedTemporaryFile):
         custom_args = {
             'resource_group': 'group_name',
-            'container_name': 'container',
+            'container': 'container',
             'storage_account': 'storage',
             'region': 'region'
         }
@@ -89,7 +89,7 @@ class TestUploadAzure(object):
                     self.credentials, 'file.vhdfixed.xz',
                     'name', 'description', custom_args
                 )
-            del custom_args['container_name']
+            del custom_args['container']
             with raises(MashUploadException):
                 UploadAzure(
                     self.credentials, 'file.vhdfixed.xz',

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -326,7 +326,7 @@ class TestUploadImageService(object):
             'target_regions': {
                 'westeurope': {
                     'resource_group': 'ms_group',
-                    'container_name': 'ms1container',
+                    'container': 'ms1container',
                     'storage_account': 'ms1storage',
                     'account': 'test-azure'
                 }


### PR DESCRIPTION
This is a bit to review but it's broken down into multiple commits.

- Add azure utils for handling the copy of arm blob to legacy storage.
- Update azure schema with source (arm) and destination (legacy) storage info.
- Integrate replication for azure.
- Add credentials endpoint urls to azure schema validation.
- Integrate page blob deletion.
- Integrate arm image deletion.

The last two would end up as part of the image cleanup service when it's integrated. That way they could be called if testing only. But I think it's good to have them here for now.

@bear454 If you want you can take a look at this as well. Is there anything missing?