### PR TITLE
Re-raise exceptions in event loop.

### DIFF
--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -63,9 +63,9 @@ class UploadImageService(BaseService):
         try:
             self.channel.start_consuming()
         except Exception:
-            if self.channel and self.channel.is_open:
-                self.channel.stop_consuming()
-                self.close_connection()
+            raise
+        finally:
+            self.close_connection()
 
     def _send_job_response(self, job_id, status_message):
         self.log.info(status_message, extra={'job_id': job_id})

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -1,3 +1,4 @@
+from pytest import raises
 from pytz import utc
 from unittest.mock import patch
 from unittest.mock import call
@@ -67,10 +68,11 @@ class TestUploadImageService(object):
             call(mock_process_message, 'listener')
         ])
         self.uploader.channel.start_consuming.assert_called_once_with()
+        self.uploader.close_connection.reset_mock()
 
         self.uploader.channel.start_consuming.side_effect = Exception
-        self.uploader.post_init()
-        self.uploader.channel.stop_consuming.assert_called_once_with()
+        with raises(Exception):
+            self.uploader.post_init()
         self.uploader.close_connection.assert_called_once_with()
 
     def test_send_job_response(self):


### PR DESCRIPTION
Always close connections when event loop exits.

Fixes #325 