### PR TITLE
Fernet key rotation requires cryptography > 2.2.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -14,7 +14,7 @@ flask
 setuptools
 idna<2.7
 boto3
-cryptography
+cryptography>=2.2.0
 jsonschema
 PyYAML
 PyJWT

--- a/mash/services/credentials/key_rotate.py
+++ b/mash/services/credentials/key_rotate.py
@@ -59,10 +59,11 @@ def rotate_key(credentials_directory, keys_file, log_callback):
 
                 try:
                     credentials = fernet.rotate(credentials)
-                except Exception:
+                except Exception as error:
                     log_callback(
-                        'Failed key rotation on credential file {0}.'.format(
-                            path
+                        'Failed key rotation on credential file {0}:'
+                        ' {1}: {2}'.format(
+                            path, type(error).__name__, error
                         ),
                         success=False
                     )

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -33,7 +33,7 @@ BuildRequires:  python3-azure-mgmt-resource
 BuildRequires:  python3-azure-mgmt-storage
 BuildRequires:  python3-azure-storage
 BuildRequires:  python3-boto3
-BuildRequires:  python3-cryptography
+BuildRequires:  python3-cryptography >= 2.2.0
 BuildRequires:  python3-jsonschema
 BuildRequires:  python3-PyYAML
 BuildRequires:  python3-PyJWT
@@ -55,7 +55,7 @@ Requires:       python3-azure-mgmt-resource
 Requires:       python3-azure-mgmt-storage
 Requires:       python3-azure-storage
 Requires:       python3-boto3
-Requires:       python3-cryptography
+Requires:       python3-cryptography >= 2.2.0
 Requires:       python3-jsonschema
 Requires:       python3-PyYAML
 Requires:       python3-PyJWT

--- a/test/unit/services/credentials/key_rotate_test.py
+++ b/test/unit/services/credentials/key_rotate_test.py
@@ -63,7 +63,8 @@ def test_rotate_key():
                 )
             ),
             call(
-                'Failed key rotation on credential file {0}.'.format(
+                'Failed key rotation on credential file {0}:'
+                ' InvalidToken: '.format(
                     os.path.join(creds_dir, 'invalid.creds')
                 ),
                 success=False


### PR DESCRIPTION
Print exception info if credentials file fails to rotate.