### PR TITLE
Cleanup GCE uploader integration

### DIFF
--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -296,6 +296,7 @@ gce_job_message['properties']['provider'] = {'enum': ['gce']}
 gce_job_message['properties']['family'] = {
     '$ref': '#/definitions/non_empty_string'
 }
+gce_job_message['required'].append('family')
 gce_job_message['definitions']['account'] = {
     'type': 'object',
     'properties': {

--- a/mash/services/uploader/cloud/__init__.py
+++ b/mash/services/uploader/cloud/__init__.py
@@ -18,6 +18,7 @@
 # project
 from mash.services.uploader.cloud.amazon import UploadAmazon
 from mash.services.uploader.cloud.azure import UploadAzure
+from mash.services.uploader.cloud.gce import UploadGCE
 from mash.services.uploader.conventions import Conventions
 from mash.csp import CSP
 
@@ -63,6 +64,11 @@ class Upload(object):
             )
         elif csp_name == CSP.azure:
             return UploadAzure(
+                credentials, system_image_file, cloud_image_name,
+                cloud_image_description, custom_uploader_args
+            )
+        elif csp_name == CSP.gce:
+            return UploadGCE(
                 credentials, system_image_file, cloud_image_name,
                 cloud_image_description, custom_uploader_args
             )

--- a/mash/services/uploader/conventions/__init__.py
+++ b/mash/services/uploader/conventions/__init__.py
@@ -18,6 +18,7 @@
 # project
 from mash.services.uploader.conventions.amazon import ConventionsAmazon
 from mash.services.uploader.conventions.azure import ConventionsAzure
+from mash.services.uploader.conventions.gce import ConventionsGCE
 from mash.csp import CSP
 
 from mash.mash_exceptions import MashConventionsException
@@ -37,6 +38,8 @@ class Conventions(object):
             return ConventionsAmazon()
         elif csp_name == CSP.azure:
             return ConventionsAzure()
+        elif csp_name == CSP.gce:
+            return ConventionsGCE()
         else:
             raise MashConventionsException(
                 'Support for {csp} Cloud Service not implemented'.format(

--- a/mash/services/uploader/conventions/gce.py
+++ b/mash/services/uploader/conventions/gce.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from mash.services.uploader.conventions.base import ConventionsBase
+
+
+class ConventionsGCE(ConventionsBase):
+    """
+    Implements Conventions class for GCE
+    """
+    def is_valid_name(self, name):
+        # TODO: needs definition by public cloud Team
+        return name

--- a/test/unit/services/uploader/cloud/main_test.py
+++ b/test/unit/services/uploader/cloud/main_test.py
@@ -38,3 +38,17 @@ class TestUpload(object):
         )
         with raises(MashUploadSetupException):
             Upload('foo', 'file', 'name', 'description', credentials)
+
+    @patch('mash.services.uploader.cloud.UploadGCE')
+    @patch('mash.services.uploader.cloud.Conventions')
+    def test_upload_gce(
+        self, mock_Conventions, mock_UploadGCE
+    ):
+        conventions = Mock()
+        credentials = {}
+        mock_Conventions.return_value = conventions
+        Upload('gce', 'file', 'name', 'description', credentials)
+        conventions.is_valid_name.assert_called_once_with('name')
+        mock_UploadGCE.assert_called_once_with(
+            credentials, 'file', 'name', 'description', None
+        )

--- a/test/unit/services/uploader/conventions/gce_test.py
+++ b/test/unit/services/uploader/conventions/gce_test.py
@@ -1,0 +1,9 @@
+from mash.services.uploader.conventions.gce import ConventionsGCE
+
+
+class TestConventionsGCE(object):
+    def setup(self):
+        self.conventions = ConventionsGCE()
+
+    def test_is_valid_name(self):
+        self.conventions.is_valid_name('name')

--- a/test/unit/services/uploader/conventions/main_test.py
+++ b/test/unit/services/uploader/conventions/main_test.py
@@ -19,3 +19,8 @@ class TestConventions(object):
         mock_ConventionsAzure.assert_called_once_with()
         with raises(MashConventionsException):
             Conventions('foo')
+
+    @patch('mash.services.uploader.conventions.ConventionsGCE')
+    def test_conventions_gce(self, mock_ConventionsGCE):
+        Conventions('gce')
+        mock_ConventionsGCE.assert_called_once_with()


### PR DESCRIPTION
- Require family arg in gce job schema.
- Add missing gce integrations to conventions and factory methods.