### PR TITLE
Drop uploader event loop

### DIFF
--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -1,12 +1,12 @@
 {
     "obs_job": {
         "id": "123",
-        "image": "SLES12-SP2-EC2-HVM-BYOS",
-        "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
+        "image": "openSUSE-Tumbleweed-JeOS",
+        "download_url": "http://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Tumbleweed/openSUSE_Tumbleweed",
         "utctime": "now",
         "conditions": [
             {"package": ["kernel-default", ">=4.4.1", ">=1.1"]},
-            {"image": "0.1.14"}
+            {"image": "15.1.0"}
         ]
     }
 }

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -1,12 +1,12 @@
 {
     "obs_job": {
         "id": "123",
-        "image": "test_image_oem",
+        "image": "SLES12-SP2-EC2-HVM-BYOS",
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "utctime": "now",
         "conditions": [
-            {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},
-            {"image": "1.42.1"}
+            {"package": ["kernel-default", ">=4.4.1", ">=1.1"]},
+            {"image": "0.1.14"}
         ]
     }
 }

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -17,7 +17,6 @@
 #
 import atexit
 import os
-import time
 from pytz import utc
 from apscheduler.schedulers.background import BackgroundScheduler
 
@@ -26,7 +25,10 @@ from mash.services.base_service import BaseService
 from mash.services.uploader.upload_image import UploadImage
 from mash.utils.json_format import JsonFormat
 from mash.csp import CSP
-from mash.services.status_levels import FAILED, SUCCESS
+from mash.services.status_levels import (
+    FAILED,
+    SUCCESS
+)
 
 
 class UploadImageService(BaseService):
@@ -50,15 +52,15 @@ class UploadImageService(BaseService):
 
         # Consume credentials response queue
         self.bind_credentials_queue()
-        self.consume_credentials_queue(self._process_message)
+        self.consume_credentials_queue(self._process_credentials)
 
         # read and launch open jobs
-        self.restart_jobs(self._schedule_job)
+        self.restart_jobs(self._init_job)
 
         # consume on service queue
         atexit.register(lambda: os._exit(0))
-        self.consume_queue(self._process_message, self.service_queue)
-        self.consume_queue(self._process_message, self.listener_queue)
+        self.consume_queue(self._process_job, self.service_queue)
+        self.consume_queue(self._process_obs_result, self.listener_queue)
 
         try:
             self.channel.start_consuming()
@@ -67,12 +69,30 @@ class UploadImageService(BaseService):
         finally:
             self.close_connection()
 
-    def _send_job_response(self, job_id, status_message):
-        self.log.info(status_message, extra={'job_id': job_id})
+    def _job_log(self, job_id, message):
+        self.log.info(message, extra={'job_id': job_id})
 
-    def _send_job_result(
-        self, job_id, last_upload_region, trigger_info
-    ):
+    def _publish_job_result(self, job_id, status=None):
+        """
+        Publish current uploader result to testing queue
+        """
+        if status:
+            self.jobs[job_id]['uploader_result']['status'] = status
+        self.publish_job_result(
+            'testing', job_id, JsonFormat.json_message(
+                {'uploader_result': self.jobs[job_id]['uploader_result']}
+            )
+        )
+
+    def _send_job_result(self, job_id, last_upload_region, trigger_info):
+        """
+        UploadImage result callback
+
+        Update the current uploader result with the information
+        from the UploadImage instance triggered by the callback
+        and publishes the overall result if the upload to the
+        last region has finished
+        """
         if self.jobs[job_id]['uploader_result']['status'] != 'failed':
             self.jobs[job_id]['uploader_result']['status'] = \
                 trigger_info['job_status']
@@ -80,119 +100,20 @@ class UploadImageService(BaseService):
         self.jobs[job_id]['uploader_result']['source_regions'][region] = \
             trigger_info['cloud_image_id']
         if last_upload_region:
-            self.publish_job_result(
-                'testing', job_id, JsonFormat.json_message(
-                    {'uploader_result': self.jobs[job_id]['uploader_result']}
-                )
-            )
-            if not self.jobs[job_id]['nonstop']:
+            self._publish_job_result(job_id)
+            if not self.jobs[job_id]['utctime'] == 'always':
                 self._delete_job(job_id)
 
-    def _send_control_response(self, result, job_id=None):
-        message = result['message']
-
-        job_metadata = {}
-        if job_id:
-            job_metadata['job_id'] = job_id
-
-        if result['ok']:
-            self.log.info(message, extra=job_metadata)
-        else:
-            self.log.error(message, extra=job_metadata)
-
-    def _process_message(self, message):
-        message.ack()
-        try:
-            job_data = JsonFormat.json_loads(format(message.body))
-        except Exception as e:
-            return self._send_control_response(
-                {
-                    'ok': False,
-                    'message': 'JSON:deserialize error: {0} : {1}'.format(
-                        message.body, e
-                    )
-                }
-            )
-        if 'uploader_job' in job_data:
-            self._handle_jobs(job_data)
-        elif 'jwt_token' in job_data:
-            self._handle_credentials(job_data)
-        elif 'obs_result' in job_data:
-            self._handle_obs_image(job_data)
-        else:
-            self._send_control_response(
-                {
-                    'ok': False,
-                    'message': 'No idea what to do with: {0}'.format(job_data)
-                }
-            )
-
-    def _handle_jobs(self, job_data):
+    def _process_job(self, message):
         """
-        handle uploader job document
-        """
-        job_id = job_data['uploader_job'].get('id', None)
-        result = self._add_job(job_data)
-        if result:
-            self._send_control_response(result, job_id)
-
-    def _handle_obs_image(self, job_data):
-        obs_result = job_data['obs_result']
-        if 'id' in obs_result:
-            job_id = obs_result['id']
-
-            if obs_result.get('status') == SUCCESS \
-                    and 'image_file' in obs_result:
-                self._set_job(job_id)
-                system_image_file = obs_result['image_file'][0]
-                self.jobs[job_id]['system_image_file'] = system_image_file
-                self._send_job_response(
-                    job_id, 'Got image file: {0}'.format(system_image_file)
-                )
-                self._check_ready(job_id)
-            else:
-                result = self._delete_job(job_id)
-                self._send_control_response(result, job_id)
-                self.publish_job_result(
-                    'testing', job_id, JsonFormat.json_message(
-                        {
-                            'uploader_result': {
-                                'id': job_id,
-                                'status': obs_result.get('status') or FAILED
-                            }
-                        }
-                    )
-                )
-
-    def _handle_credentials(self, job_data):
-        job_id, credentials = self.decode_credentials(job_data)
-        if job_id:
-            self._set_job(job_id)
-            self.jobs[job_id]['credentials'] = credentials
-            self._send_job_response(
-                job_id, 'Got credentials data'
-            )
-            self._check_ready(job_id)
-
-    def _set_job(self, job_id):
-        if job_id not in self.jobs:
-            self.jobs[job_id] = {}
-
-    def _check_ready(self, job_id):
-        if 'system_image_file' in self.jobs[job_id] and \
-           'credentials' in self.jobs[job_id]:
-            self.jobs[job_id]['ready'] = True
-
-    def _add_job(self, data):
-        """
-        Add a new job description file and start an image upload job
+        Add a new job description file and initialize new upload job
 
         job description example:
 
         {
           "uploader_job": {
             "id": "123",
-            "utctime": "now|always|timestring_utc_timezone",
+            "utctime": "now|always,
             "cloud_image_name": "name",
             "image_description": "description",
             "provider": "ec2",
@@ -205,19 +126,122 @@ class UploadImageService(BaseService):
           }
         }
         """
-        data = data['uploader_job']
-        data['job_file'] = self.persist_job_config(data)
-        return self._schedule_job(data)
+        try:
+            job_data = JsonFormat.json_loads(format(message.body))
+            self._init_job(job_data)
+        except Exception as issue:
+            self.log.error(
+                'Error processing job: {0}: {1}'.format(message.body, issue)
+            )
+        message.ack()
+
+    def _process_obs_result(self, message):
+        """
+        Listen on obs service event
+        """
+        try:
+            job_data = JsonFormat.json_loads(format(message.body))
+            self._handle_obs_image(job_data)
+        except Exception as issue:
+            self.log.error(
+                'Invalid obs result: {0}: {1}'.format(message.body, issue)
+            )
+        message.ack()
+
+    def _process_credentials(self, message):
+        """
+        Listen on credentials service event
+        """
+        try:
+            job_data = JsonFormat.json_loads(format(message.body))
+            self._handle_credentials(job_data)
+        except Exception as issue:
+            self.log.error(
+                'Invalid credentials: {0}: {1}'.format(message.body, issue)
+            )
+        message.ack()
+
+    def _init_job(self, job_data):
+        """
+        Initialize new job
+
+        Bind listener queue to receive obs service result
+        """
+        if 'uploader_job' in job_data:
+            job_config = job_data['uploader_job']
+        else:
+            self._job_log(job_data['id'], 'Respawn preserved job')
+            job_config = job_data
+        job_id = job_config['id']
+        if job_id not in self.jobs:
+            self.jobs[job_id] = {
+                'job_config': job_config,
+                'utctime': job_config.get('utctime'),
+                'job_file': self.persist_job_config(job_config),
+                'credentials': None,
+                'system_image_file': None,
+                'uploader': [],
+                'uploader_result': {
+                    'id': job_id,
+                    'cloud_image_name': job_config['cloud_image_name'],
+                    'source_regions': {},
+                    'status': None
+                }
+            }
+            self.bind_listener_queue(job_id)
+            self._job_log(
+                job_id, 'Job queued, awaiting obs result'
+            )
+
+    def _handle_obs_image(self, job_data):
+        """
+        Read result from obs service
+
+        On success run uploader job if credentials are present,
+        if not request credentials
+
+        On failure delete job and publish uploader job result
+        for testing service to keep the service queue active
+        """
+        obs_result = job_data['obs_result']
+        job_id = obs_result.get('id')
+        obs_status = obs_result.get('status', FAILED)
+        if job_id and job_id in self.jobs:
+            if obs_status == SUCCESS and 'image_file' in obs_result:
+                system_image_file = obs_result['image_file'][0]
+                self.jobs[job_id]['system_image_file'] = system_image_file
+                self._job_log(
+                    job_id, 'Got image file: {0}'.format(system_image_file)
+                )
+                if self.jobs[job_id]['credentials']:
+                    self._schedule_job(job_id)
+                else:
+                    self.publish_credentials_request(job_id)
+            else:
+                self._delete_job(job_id)
+                self._publish_job_result(job_id, status=obs_status)
+                self._job_log(
+                    job_id, 'OBS service sent failed result, dequeue uploader'
+                )
+
+    def _handle_credentials(self, job_data):
+        """
+        Read and decode credentials
+
+        On success run uploader job if system image file is present
+        """
+        job_id, credentials = self.decode_credentials(job_data)
+        if job_id and job_id in self.jobs:
+            self.jobs[job_id]['credentials'] = credentials
+            if self.jobs[job_id]['system_image_file']:
+                self._schedule_job(job_id)
 
     def _delete_job(self, job_id):
         """
         Delete job description and stop image upload job
         """
         if job_id not in self.jobs:
-            return {
-                'ok': False,
-                'message': 'Job does not exist, can not delete it'
-            }
+            self._job_log(job_id, 'Job does not exist')
         else:
             self.unbind_queue(
                 self.listener_queue, self.service_exchange, job_id
@@ -226,155 +250,111 @@ class UploadImageService(BaseService):
             # delete job file
             try:
                 os.remove(upload_image.job_file)
-            except Exception as e:
-                return {
-                    'ok': False,
-                    'message': 'Job deletion failed: {0}'.format(e)
-                }
+            except Exception as issue:
+                self._job_log(
+                    job_id, 'Job deletion failed: {0}'.format(issue)
+                )
             else:
                 # delete upload image job instances
                 for upload_image in self.jobs[job_id]['uploader']:
                     del upload_image
                 del self.jobs[job_id]
-                return {
-                    'ok': True,
-                    'message': 'Job Deleted'
-                }
+                self._job_log(
+                    job_id, 'Job Deleted'
+                )
 
-    def _get_uploader_arguments_per_region(self, job_data):
+    def _get_uploader_arguments_ec2(self, job_config, region):
+        return {
+            'launch_ami':
+                job_config['target_regions'][region]['helper_image'],
+            'account':
+                job_config['target_regions'][region]['account'],
+            'region': region
+        }
+
+    def _get_uploader_arguments_azure(self, job_config, region):
+        return {
+            'resource_group':
+                job_config['target_regions'][region]['resource_group'],
+            'container':
+                job_config['target_regions'][region]['container'],
+            'storage_account':
+                job_config['target_regions'][region]['storage_account'],
+            'account':
+                job_config['target_regions'][region]['account'],
+            'region': region
+        }
+
+    def _get_uploader_arguments_gce(self, job_config, region):
+        return {
+            'account':
+                job_config['target_regions'][region]['account'],
+            'bucket':
+                job_config['target_regions'][region]['bucket'],
+            'family':
+                job_config['target_regions'][region]['family'],
+            'region':
+                region
+        }
+
+    def _get_uploader_arguments_per_region(self, job_config):
         uploader_args = []
-        for region in job_data['target_regions']:
-            if job_data['provider'] == CSP.ec2:
+        for region in job_config['target_regions']:
+            if job_config['provider'] == CSP.ec2:
                 # turn region metadata into EC2ImageUploader compatible format
                 uploader_args.append(
-                    {
-                        'launch_ami':
-                            job_data['target_regions'][region]['helper_image'],
-                        'account':
-                            job_data['target_regions'][region]['account'],
-                        'region': region
-                    }
+                    self._get_uploader_arguments_ec2(job_config, region)
                 )
-            elif job_data['provider'] == CSP.azure:
+            elif job_config['provider'] == CSP.azure:
                 # turn region metadata into AzureImageUploader compatible format
                 uploader_args.append(
-                    {
-                        'resource_group':
-                            job_data['target_regions'][region]['resource_group'],
-                        'container':
-                            job_data['target_regions'][region]['container'],
-                        'storage_account':
-                            job_data['target_regions'][region]['storage_account'],
-                        'account':
-                            job_data['target_regions'][region]['account'],
-                        'region': region
-                    }
+                    self._get_uploader_arguments_azure(job_config, region)
                 )
-            elif job_data['provider'] == CSP.gce:
+            elif job_config['provider'] == CSP.gce:
                 # turn region metadata into GCEImageUploader compatible format
                 uploader_args.append(
-                    {
-                        'account': job_data['target_regions'][region]['account'],
-                        'bucket': job_data['target_regions'][region]['bucket'],
-                        'family': job_data['target_regions'][region]['family'],
-                        'region': region
-                    }
+                    self._get_uploader_arguments_gce(job_config, region)
                 )
         return uploader_args
 
-    def _init_job(self, job_data):
-        # init empty job hash if not yet done
-        job_id = job_data['id']
-        if job_id not in self.jobs:
-            self.jobs[job_id] = {}
-        # get us the time when to start this job
-        time = job_data['utctime']
-
-        if time == 'always':
-            nonstop = True
-        else:
-            nonstop = False
-
-        # init the job result dictionary
-        self.jobs[job_id]['uploader_result'] = {
-            'id': job_id,
-            'cloud_image_name': job_data['cloud_image_name'],
-            'source_regions': {},
-            'status': None
-        }
-        self.jobs[job_id]['nonstop'] = nonstop
-        self.jobs[job_id]['uploader'] = []
-        # send request for credentials
-        self.publish_credentials_request(job_id)
-        return {'nonstop': nonstop}
-
-    def _schedule_job(self, job):
-        startup = self._init_job(job)
-        region_list = self._get_uploader_arguments_per_region(job)
+    def _schedule_job(self, job_id):
+        region_list = self._get_uploader_arguments_per_region(
+            self.jobs[job_id]['job_config']
+        )
         for index, uploader_args in enumerate(region_list):
             last_upload_region = False
             if index == len(region_list) - 1:
                 last_upload_region = True
             job_args = [
-                job, startup['nonstop'], uploader_args, last_upload_region
+                job_id, uploader_args, last_upload_region
             ]
             self.scheduler.add_job(
                 self._start_job, args=job_args
             )
 
-    def _wait_until_ready(self, job_id):
-        while True:
-            if job_id in self.jobs and 'ready' in self.jobs[job_id]:
-                break
-            time.sleep(1)
-
-    def _image_already_uploading(self, job_id, uploader):
-        if 'system_image_file' not in self.jobs[job_id]:
-            return False
-        system_image_file = self.jobs[job_id]['system_image_file']
-        if uploader.system_image_file != system_image_file:
-            return False
-        return True
-
-    def _start_job(self, job, nonstop, uploader_args, last_upload_region):
-        job_id = job['id']
-        delay_time_sec = 30
-        csp_name = job['provider']
-
-        self._send_job_response(
-            job_id, 'Region [{0}]: Waiting for image/credentials data'.format(
+    def _start_job(self, job_id, uploader_args, last_upload_region):
+        self._job_log(
+            job_id, 'Region [{0}]: Starting Upload'.format(
                 uploader_args['region']
             )
         )
-        self._wait_until_ready(job_id)
-
         upload_image = UploadImage(
-            job_id, job['job_file'], nonstop, csp_name,
+            job_id, self.jobs[job_id]['job_file'],
+            self.jobs[job_id]['job_config']['provider'],
             self.jobs[job_id]['credentials'][uploader_args['account']],
-            job['cloud_image_name'],
-            job['image_description'],
+            self.jobs[job_id]['job_config']['cloud_image_name'],
+            self.jobs[job_id]['job_config']['image_description'],
             last_upload_region,
             uploader_args
         )
         self.jobs[job_id]['uploader'].append(upload_image)
         upload_image.set_log_handler(
-            self._send_job_response
+            self._job_log
         )
         upload_image.set_result_handler(
             self._send_job_result
         )
-        while self.jobs[job_id]['ready']:
-            if not self._image_already_uploading(job_id, upload_image):
-                upload_image.set_image_file(
-                    self.jobs[job_id]['system_image_file']
-                )
-                upload_image.upload()
-            if nonstop:
-                self._send_job_response(
-                    job_id, 'Waiting {0}sec before next try...'.format(
-                        delay_time_sec
-                    )
-                )
-                time.sleep(delay_time_sec)
-            else:
-                break
+        upload_image.set_image_file(
+            self.jobs[job_id]['system_image_file']
+        )
+        upload_image.upload()

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -218,8 +218,8 @@ class UploadImageService(BaseService):
                 else:
                     self.publish_credentials_request(job_id)
             else:
-                self._delete_job(job_id)
                 self._publish_job_result(job_id, status=obs_status)
+                self._delete_job(job_id)
                 self._job_log(
                     job_id, 'OBS service sent failed result, dequeue uploader'
                 )

--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -32,9 +32,6 @@ class UploadImage(object):
     * :attr:`job_file`
         job file containing the job description
 
-    * :attr:`nonstop`
-        indicate one time stop or multiple uploads possible
-
     * :attr:`csp_name`
         cloud service provider name
 
@@ -53,14 +50,13 @@ class UploadImage(object):
         specific to the selected cloud and uploader class
     """
     def __init__(
-        self, job_id, job_file, nonstop, csp_name, credentials_token,
+        self, job_id, job_file, csp_name, credentials_token,
         cloud_image_name, cloud_image_description, last_upload_region,
         custom_uploader_args=None
     ):
         self.job_id = job_id
         self.job_file = job_file
         self.csp_name = csp_name
-        self.job_nonstop = nonstop
 
         self.cloud_image_name = cloud_image_name
         self.cloud_image_description = cloud_image_description

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -4,8 +4,9 @@ from unittest.mock import patch
 from unittest.mock import call
 from unittest.mock import Mock
 
-from test.unit.test_helper import (
-    patch_open
+from mash.services.status_levels import (
+    FAILED,
+    SUCCESS
 )
 
 from mash.services.uploader.service import UploadImageService
@@ -18,7 +19,9 @@ class TestUploadImageService(object):
     @patch.object(BaseService, 'consume_credentials_queue')
     @patch('mash.services.base_service.BaseService.set_logfile')
     @patch('mash.services.uploader.service.BackgroundScheduler')
-    @patch.object(UploadImageService, '_process_message')
+    @patch.object(UploadImageService, '_process_credentials')
+    @patch.object(UploadImageService, '_process_job')
+    @patch.object(UploadImageService, '_process_obs_result')
     @patch.object(UploadImageService, 'restart_jobs')
     @patch.object(BaseService, '__init__')
     @patch('os.listdir')
@@ -26,10 +29,72 @@ class TestUploadImageService(object):
     @patch('atexit.register')
     def setup(
         self, mock_register, mock_log, mock_listdir,
-        mock_BaseService, mock_restart_jobs, mock_process_message,
+        mock_BaseService, mock_restart_jobs, mock_process_obs_result,
+        mock_process_job, mock_process_credentials,
         mock_BackgroundScheduler, mock_set_logfile,
         mock_consume_creds_queue, mock_bind_creds_queue
     ):
+        self.job_data_from_preserved_ec2 = {
+            'id': '888',
+            'utctime': 'now',
+            'cloud_image_name': 'name',
+            'image_description': 'description',
+            'provider': 'ec2',
+            'target_regions': {
+                'eu-central-1': {
+                    'helper_image': 'ami-bc5b48d0',
+                    'account': 'test-aws'
+                }
+            }
+        }
+        self.job_data_ec2 = {
+            'uploader_job': {
+                'id': '123',
+                'utctime': 'now',
+                'cloud_image_name': 'name',
+                'image_description': 'description',
+                'provider': 'ec2',
+                'target_regions': {
+                    'eu-central-1': {
+                        'helper_image': 'ami-bc5b48d0',
+                        'account': 'test-aws'
+                    }
+                }
+            }
+        }
+        self.job_data_azure = {
+            'uploader_job': {
+                'id': '123',
+                'utctime': 'now',
+                'cloud_image_name': 'name',
+                'image_description': 'description',
+                'provider': 'azure',
+                'target_regions': {
+                    'westeurope': {
+                        'resource_group': 'ms_group',
+                        'container': 'ms1container',
+                        'storage_account': 'ms1storage',
+                        'account': 'test-azure'
+                    }
+                }
+            }
+        }
+        self.job_data_gce = {
+            'uploader_job': {
+                'id': '123',
+                'utctime': 'now',
+                'cloud_image_name': 'name',
+                'image_description': 'description',
+                'provider': 'gce',
+                'target_regions': {
+                    'us-east1': {
+                        'account': 'test-gce',
+                        'bucket': 'images',
+                        'family': 'sles-15'
+                    }
+                }
+            }
+        }
         scheduler = Mock()
         mock_BackgroundScheduler.return_value = scheduler
         config = Mock()
@@ -61,11 +126,11 @@ class TestUploadImageService(object):
 
         mock_BackgroundScheduler.assert_called_once_with(timezone=utc)
         scheduler.start.assert_called_once_with()
-        mock_restart_jobs.assert_called_once_with(self.uploader._schedule_job)
+        mock_restart_jobs.assert_called_once_with(self.uploader._init_job)
 
         self.uploader.consume_queue.assert_has_calls([
-            call(mock_process_message, 'service'),
-            call(mock_process_message, 'listener')
+            call(mock_process_job, 'service'),
+            call(mock_process_obs_result, 'listener')
         ])
         self.uploader.channel.start_consuming.assert_called_once_with()
         self.uploader.close_connection.reset_mock()
@@ -75,81 +140,55 @@ class TestUploadImageService(object):
             self.uploader.post_init()
         self.uploader.close_connection.assert_called_once_with()
 
-    def test_send_job_response(self):
-        self.uploader._send_job_response('815', {})
+    @patch.object(BaseService, 'persist_job_config')
+    def test_init_job(self, mock_persist_job_config):
+        self.uploader._init_job(self.job_data_from_preserved_ec2)
+        self.uploader._init_job(self.job_data_ec2)
+        assert self.uploader.jobs['123'].keys() == \
+            self.uploader.jobs['888'].keys()
+
+    def test_job_log(self):
+        self.uploader._job_log('815', 'message')
         self.uploader.log.info.assert_called_once_with(
-            {}, extra={'job_id': '815'}
+            'message', extra={'job_id': '815'}
         )
 
     @patch.object(BaseService, 'publish_job_result')
+    @patch.object(BaseService, 'persist_job_config')
+    def test_publish_job_result(
+        self, mock_persist_job_config, mock_publish_job_result
+    ):
+        self.uploader._init_job(self.job_data_ec2)
+        self.uploader._publish_job_result('123', status=FAILED)
+        mock_publish_job_result.assert_called_once_with(
+            'testing', '123', JsonFormat.json_message(
+                {
+                    'uploader_result':
+                        self.uploader.jobs['123']['uploader_result']
+                }
+            )
+        )
+        assert self.uploader.jobs['123']['uploader_result']['status'] == FAILED
+
+    @patch.object(BaseService, 'persist_job_config')
+    @patch.object(UploadImageService, '_publish_job_result')
     @patch.object(UploadImageService, '_delete_job')
     def test_send_job_result(
-        self, mock_delete_job, mock_publish_job_result
+        self, mock_delete_job, mock_publish_job_result, mock_persist_job_config
     ):
-        self.uploader.jobs['815'] = {
-            'nonstop': False,
-            'uploader_result': {
-                'status': None,
-                'source_regions': {}
-            }
-        }
+        self.uploader._init_job(self.job_data_ec2)
         trigger_info = {
             'job_status': 'success',
             'upload_region': 'region',
             'cloud_image_id': 'image_id'
         }
-        self.uploader._send_job_result('815', True, trigger_info)
-        mock_publish_job_result.assert_called_once_with(
-            'testing', '815', JsonFormat.json_message(
-                {'uploader_result':
-                 self.uploader.jobs['815']['uploader_result']}
-            )
-        )
-        mock_delete_job.assert_called_once_with('815')
+        self.uploader._send_job_result('123', True, trigger_info)
+        mock_publish_job_result.assert_called_once_with('123')
+        mock_delete_job.assert_called_once_with('123')
+        assert self.uploader.jobs['123']['uploader_result']['status'] == SUCCESS
 
-    def test_send_control_response_local(self):
-        result = {
-            'message': 'message',
-            'ok': False
-        }
-        self.uploader._send_control_response(result, '4711')
-        self.uploader.log.error.assert_called_once_with(
-            'message',
-            extra={'job_id': '4711'}
-        )
-
-    def test_send_control_response_public(self):
-        result = {
-            'message': 'message',
-            'ok': True
-        }
-        self.uploader._send_control_response(result)
-        self.uploader.log.info.assert_called_once_with(
-            'message',
-            extra={}
-        )
-
-    @patch.object(UploadImageService, '_send_control_response')
-    @patch.object(BaseService, 'decode_credentials')
-    def test_process_message_for_service_data(
-        self, mock_decode_credentials, mock_send_control_response
-    ):
-        message = Mock()
-        message.body = '{"obs_result": {"id": "123", ' + \
-            '"image_file": ["image", "sum"], "status": "success"}}'
-        self.uploader._process_message(message)
-        assert self.uploader.jobs['123']['system_image_file'] == 'image'
-        message.body = '{"jwt_token": {}}'
-        mock_decode_credentials.return_value = '123', {}
-        self.uploader._process_message(message)
-        assert self.uploader.jobs['123']['credentials'] == {}
-        assert self.uploader.jobs['123']['ready'] is True
-
-    @patch.object(UploadImageService, '_add_job')
-    @patch.object(UploadImageService, '_send_control_response')
-    def test_process_message_for_job_documents(
-        self, mock_send_control_response, mock_add_job
-    ):
+    @patch.object(UploadImageService, '_init_job')
+    def test_process_job(self, mock_init_job):
         message = Mock()
         message.body = '{"uploader_job": {"id": "123", ' + \
             '"utctime": "now", "cloud_image_name": "name", ' + \
@@ -157,336 +196,220 @@ class TestUploadImageService(object):
             '"provider": "ec2", ' +\
             '"target_regions": {"eu-central-1": { ' +\
             '"helper_image": "ami-bc5b48d0", "account": "test-aws"}}}}'
-        self.uploader._process_message(message)
+        self.uploader._process_job(message)
         message.ack.assert_called_once_with()
-        mock_add_job.assert_called_once_with(
-            {
-                'uploader_job': {
-                    'id': '123',
-                    'utctime': 'now',
-                    'cloud_image_name': 'name',
-                    'image_description': 'description',
-                    'provider': 'ec2',
-                    'target_regions': {
-                        'eu-central-1': {
-                            'helper_image': 'ami-bc5b48d0',
-                            'account': 'test-aws'
-                        }
-                    }
-                }
-            }
+        mock_init_job.assert_called_once_with(self.job_data_ec2)
+        message.body = '{"broken_command: "4711"}'
+        self.uploader._process_job(message)
+        self.uploader.log.error.assert_called_once_with(
+            'Error processing job: {"broken_command: "4711"}: '
+            'Expecting \':\' delimiter: line 1 column 20 (char 19)'
         )
-        mock_send_control_response.reset_mock()
-        message.body = '{"unknown_command": "4711"}'
-        self.uploader._process_message(message)
-        message.body = 'foo'
-        self.uploader._process_message(message)
-        assert mock_send_control_response.call_args_list == [
-            call(
-                {
-                    'message':
-                        "No idea what to do with: {'unknown_command': '4711'}",
-                    'ok': False
-                }
-            ),
-            call(
-                {
-                    'message':
-                        'JSON:deserialize error: foo : '
-                        'Expecting value: line 1 column 1 (char 0)',
-                    'ok': False
-                }
-            )
-        ]
 
-    @patch.object(UploadImageService, 'publish_job_result')
-    @patch.object(UploadImageService, '_delete_job')
-    @patch.object(UploadImageService, '_send_control_response')
-    def test_process_message_for_failed_job(
-        self, mock_send_control_response, mock_delete_job,
-        mock_publish_job_result
-    ):
-        mock_delete_job.return_value = {
-            'ok': True,
-            'message': 'Job Deleted'
-        }
+    @patch.object(UploadImageService, '_handle_obs_image')
+    def test_process_obs_result(self, mock_handle_obs_image):
         message = Mock()
-        message.body = '{"obs_result": {"id": "4711", "status": "failed"}}'
-        self.uploader._process_message(message)
-        mock_delete_job.assert_called_once_with('4711')
-        mock_send_control_response.assert_called_once_with(
-            {'ok': True, 'message': 'Job Deleted'},
-            '4711'
+        message.body = '{"obs_result": {"id": "123", ' + \
+            '"image_file": ["image", "sum"], "status": "success"}}'
+        self.uploader._process_obs_result(message)
+        message.ack.assert_called_once_with()
+        mock_handle_obs_image.assert_called_once_with(
+            {
+                'obs_result': {
+                    'id': '123',
+                    'image_file': ['image', 'sum'],
+                    'status': 'success'
+                }
+            }
         )
-        mock_publish_job_result.assert_called_once_with(
-            'testing', '4711',
-            JsonFormat.json_message(
-                {'uploader_result': {'id': '4711', 'status': 'failed'}}
-            )
+        message.body = '{"broken_command: "4711"}'
+        self.uploader._process_obs_result(message)
+        self.uploader.log.error.assert_called_once_with(
+            'Invalid obs result: {"broken_command: "4711"}: '
+            'Expecting \':\' delimiter: line 1 column 20 (char 19)'
         )
 
-    @patch.object(UploadImageService, 'persist_job_config')
+    @patch.object(UploadImageService, '_handle_credentials')
+    def test_process_credentials(self, mock_handle_credentials):
+        message = Mock()
+        message.body = '{"test-aws": {}}'
+        self.uploader._process_credentials(message)
+        message.ack.assert_called_once_with()
+        mock_handle_credentials.assert_called_once_with(
+            {'test-aws': {}}
+        )
+        message.body = '{"broken_command: "4711"}'
+        self.uploader._process_credentials(message)
+        self.uploader.log.error.assert_called_once_with(
+            'Invalid credentials: {"broken_command: "4711"}: '
+            'Expecting \':\' delimiter: line 1 column 20 (char 19)'
+        )
+
+    @patch.object(UploadImageService, '_job_log')
     @patch.object(UploadImageService, '_schedule_job')
-    @patch_open
-    def test_add_job(
-        self, mock_open, mock_schedule_job, mock_persist_job_config
+    @patch.object(UploadImageService, '_delete_job')
+    @patch.object(UploadImageService, '_publish_job_result')
+    @patch.object(UploadImageService, 'publish_credentials_request')
+    @patch.object(BaseService, 'persist_job_config')
+    def test_handle_obs_image(
+        self, mock_persist_job_config, mock_publish_credentials_request,
+        mock_publish_job_result, mock_delete_job, mock_schedule_job,
+        mock_job_log
     ):
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "name",
-                "image_description": "description",
-                "provider": "ec2",
-                "target_regions": {
-                    "eu-central-1": {
-                        "helper_image": "ami-bc5b48d0",
-                        "account": "test-aws"
-                    }
-                },
-                "utctime": "now"
+        self.uploader._init_job(self.job_data_ec2)
+        obs_result = {
+            'obs_result': {
+                'id': '123',
+                'image_file': ['image', 'sum'],
+                'status': 'success'
             }
         }
-        self.uploader._add_job(job_data)
-        mock_schedule_job.assert_called_once_with(job_data['uploader_job'])
-        mock_persist_job_config.assert_called_once_with(
-            job_data['uploader_job']
+        self.uploader._handle_obs_image(obs_result)
+        mock_publish_credentials_request.assert_called_once_with('123')
+
+        self.uploader.jobs['123']['credentials'] = {'test-aws': {}}
+        self.uploader._handle_obs_image(obs_result)
+        mock_schedule_job.assert_called_once_with('123')
+
+        obs_result['obs_result']['status'] = FAILED
+        self.uploader._handle_obs_image(obs_result)
+        mock_delete_job.assert_called_once_with('123')
+        mock_publish_job_result.assert_called_once_with(
+            '123', status='failed'
         )
+
+    @patch.object(UploadImageService, 'decode_credentials')
+    @patch.object(UploadImageService, '_schedule_job')
+    @patch.object(BaseService, 'persist_job_config')
+    def test_handle_credentials(
+        self, mock_persist_job_config, mock_schedule_job,
+        mock_decode_credentials
+    ):
+        mock_decode_credentials.return_value = '123', {}
+        self.uploader._init_job(self.job_data_ec2)
+        credentials_result = {'test-aws': {}}
+        self.uploader.jobs['123']['system_image_file'] = 'some image'
+        self.uploader._handle_credentials(credentials_result)
+        mock_schedule_job.assert_called_once_with('123')
 
     @patch.object(UploadImageService, 'unbind_queue')
+    @patch.object(UploadImageService, '_job_log')
     @patch('os.remove')
-    def test_delete_job(self, mock_os_remove, mock_unbind_queue):
-        assert self.uploader._delete_job('815') == {
-            'message': 'Job does not exist, can not delete it', 'ok': False
-        }
+    def test_delete_job(self, mock_os_remove, mock_job_log, mock_unbind_queue):
+        self.uploader._delete_job('815')
+        mock_job_log.assert_called_once_with(
+            '815', 'Job does not exist'
+        )
         upload_image = [Mock()]
         upload_image[0].job_file = 'job_file'
         self.uploader.jobs = {'815': {'uploader': upload_image}}
-        assert self.uploader._delete_job('815') == {
-            'message': 'Job Deleted', 'ok': True
-        }
+        mock_job_log.reset_mock()
+
+        self.uploader._delete_job('815')
+        mock_job_log.assert_called_once_with(
+            '815', 'Job Deleted'
+        )
         mock_unbind_queue.assert_called_once_with(
             'listener', 'uploader', '815'
         )
         mock_os_remove.assert_called_once_with('job_file')
         assert '815' not in self.uploader.jobs
+        mock_job_log.reset_mock()
+
         self.uploader.jobs = {'815': {'uploader': upload_image}}
         mock_os_remove.side_effect = Exception('remove_error')
-        assert self.uploader._delete_job('815') == {
-            'message': 'Job deletion failed: remove_error', 'ok': False
-        }
+        self.uploader._delete_job('815')
+        mock_job_log.assert_called_once_with(
+            '815', 'Job deletion failed: remove_error'
+        )
 
-    @patch.object(UploadImageService, 'publish_credentials_request')
+    @patch.object(BaseService, 'persist_job_config')
     @patch.object(UploadImageService, '_start_job')
-    def test_schedule_job_amazon(
-        self, mock_start_job, mock_publish_credentials_request
+    def test_schedule_job_ec2(
+        self, mock_start_job, mock_persist_job_config
     ):
-        job = {
-            'id': '123',
-            'cloud_image_name': 'b',
-            'image_description': 'a',
-            'job_file': 'job_file',
-            'utctime': 'always',
-            'provider': 'ec2',
-            'target_regions': {
-                'us-east-1': {
-                    'helper_image': 'ami-bc5b48d0',
-                    'account': 'test-aws'
-                }
-            }
-        }
-        self.uploader.config = Mock()
-        uploader_args = self.uploader._get_uploader_arguments_per_region(job)
-        self.uploader._schedule_job(job)
+        self.uploader._init_job(self.job_data_ec2)
+        self.uploader._schedule_job('123')
         self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, True, uploader_args[0], True]
-        )
-        self.uploader.scheduler.add_job.reset_mock()
-        mock_publish_credentials_request.reset_mock()
-        job['utctime'] = 'now'
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, False, uploader_args[0], True]
-        )
-        mock_publish_credentials_request.assert_called_once_with(
-            '123'
+            mock_start_job, args=[
+                '123', {
+                    'launch_ami': 'ami-bc5b48d0',
+                    'account': 'test-aws',
+                    'region': 'eu-central-1'
+                }, True
+            ]
         )
 
-    @patch.object(UploadImageService, 'publish_credentials_request')
+    @patch.object(BaseService, 'persist_job_config')
     @patch.object(UploadImageService, '_start_job')
     def test_schedule_job_azure(
-        self, mock_start_job, mock_publish_credentials_request
+        self, mock_start_job, mock_persist_job_config
     ):
-        job = {
-            'id': '123',
-            'cloud_image_name': 'b',
-            'image_description': 'a',
-            'job_file': 'job_file',
-            'utctime': 'always',
-            'provider': 'azure',
-            'target_regions': {
-                'westeurope': {
+        self.uploader._init_job(self.job_data_azure)
+        self.uploader._schedule_job('123')
+        self.uploader.scheduler.add_job.assert_called_once_with(
+            mock_start_job, args=[
+                '123', {
                     'resource_group': 'ms_group',
                     'container': 'ms1container',
                     'storage_account': 'ms1storage',
-                    'account': 'test-azure'
-                }
-            }
-        }
-        self.uploader.config = Mock()
-        uploader_args = self.uploader._get_uploader_arguments_per_region(job)
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, True, uploader_args[0], True]
-        )
-        self.uploader.scheduler.add_job.reset_mock()
-        mock_publish_credentials_request.reset_mock()
-        job['utctime'] = 'now'
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, False, uploader_args[0], True]
-        )
-        mock_publish_credentials_request.assert_called_once_with(
-            '123'
+                    'account': 'test-azure',
+                    'region': 'westeurope'
+                }, True
+            ]
         )
 
-    @patch.object(UploadImageService, 'publish_credentials_request')
+    @patch.object(BaseService, 'persist_job_config')
     @patch.object(UploadImageService, '_start_job')
-    def test_schedule_job_google(
-            self, mock_start_job, mock_publish_credentials_request
+    def test_schedule_job_gce(
+        self, mock_start_job, mock_persist_job_config
     ):
-        job = {
-            'id': '123',
-            'cloud_image_name': 'b',
-            'image_description': 'a {date}',
-            'job_file': 'job_file',
-            'utctime': 'always',
-            'provider': 'gce',
-            'target_regions': {
-                'us-east1': {
+        self.uploader._init_job(self.job_data_gce)
+        self.uploader._schedule_job('123')
+        self.uploader.scheduler.add_job.assert_called_once_with(
+            mock_start_job, args=[
+                '123', {
                     'account': 'test-gce',
                     'bucket': 'images',
-                    'family': 'sles-15'
-                }
-            }
-        }
-        self.uploader.config = Mock()
-        uploader_args = self.uploader._get_uploader_arguments_per_region(job)
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, True, uploader_args[0], True]
-        )
-        self.uploader.scheduler.add_job.reset_mock()
-        mock_publish_credentials_request.reset_mock()
-        job['utctime'] = 'now'
-        self.uploader._schedule_job(job)
-        self.uploader.scheduler.add_job.assert_called_once_with(
-            mock_start_job, args=[job, False, uploader_args[0], True]
-        )
-        mock_publish_credentials_request.assert_called_once_with(
-            '123'
+                    'family': 'sles-15',
+                    'region': 'us-east1'
+                }, True
+            ]
         )
 
     @patch('mash.services.uploader.service.UploadImage')
-    @patch.object(UploadImageService, '_send_job_response')
-    @patch.object(UploadImageService, '_image_already_uploading')
+    @patch.object(BaseService, 'persist_job_config')
+    @patch.object(UploadImageService, '_job_log')
     @patch.object(UploadImageService, '_send_job_result')
-    @patch.object(UploadImageService, '_wait_until_ready')
-    @patch('mash.services.uploader.service.time.sleep')
     def test_start_job(
-        self, mock_sleep, mock_wait_until_ready,
-        mock_send_job_result, mock_image_already_uploading,
-        mock_send_job_response, mock_UploadImage
+        self, mock_send_job_result, mock_job_log, mock_persist_job_config,
+        mock_UploadImage
     ):
+        mock_persist_job_config.return_value = 'job_file'
         upload_image = Mock()
-        uploader = self.uploader
-
-        def done_after_one_iteration(self):
-            uploader.jobs['123']['ready'] = False
-
-        mock_image_already_uploading.return_value = False
         mock_UploadImage.return_value = upload_image
-        job = {
-            'id': '123',
-            'cloud_image_name': 'b',
-            'image_description': 'a',
-            'job_file': 'job_file',
-            'utctime': 'now',
-            'provider': 'ec2',
-            'target_regions': {
-                'us-east-1': {
-                    'helper_image': 'ami-bc5b48d0',
-                    'account': 'test-aws'
-                }
-            }
-        }
-        uploader.jobs['123'] = {
-            'ready': True,
-            'uploader': [],
-            'credentials': {'test-aws': {}},
-            'system_image_file': 'image'
-        }
-        uploader_args = uploader._get_uploader_arguments_per_region(job)
-        uploader._start_job(job, False, uploader_args[0], False)
-
-        mock_wait_until_ready.assert_called_once_with('123')
-
+        self.uploader._init_job(self.job_data_ec2)
+        self.uploader.jobs['123']['credentials'] = {'test-aws': {}}
+        self.uploader.jobs['123']['system_image_file'] = 'image'
+        self.uploader._start_job(
+            '123', {
+                'launch_ami': 'ami-bc5b48d0',
+                'account': 'test-aws',
+                'region': 'eu-central-1'
+            }, True
+        )
         mock_UploadImage.assert_called_once_with(
-            '123', 'job_file', False, 'ec2', {}, 'b', 'a',
-            False, {
-                'launch_ami': 'ami-bc5b48d0', 'region': 'us-east-1',
+            '123', 'job_file', 'ec2', {}, 'name', 'description', True, {
+                'launch_ami': 'ami-bc5b48d0', 'region': 'eu-central-1',
                 'account': 'test-aws'
             }
         )
         upload_image.set_log_handler.assert_called_once_with(
-            mock_send_job_response
+            mock_job_log
         )
         upload_image.set_result_handler.assert_called_once_with(
             mock_send_job_result
         )
         upload_image.set_image_file.assert_called_once_with('image')
         upload_image.upload.assert_called_once_with()
-
-        mock_UploadImage.reset_mock()
-
-        mock_send_job_response.reset_mock()
-        mock_sleep.side_effect = done_after_one_iteration
-        uploader._start_job(job, True, uploader_args[0], False)
-        mock_UploadImage.assert_called_once_with(
-            '123', 'job_file', True, 'ec2', {}, 'b', 'a',
-            False, {
-                'launch_ami': 'ami-bc5b48d0', 'region': 'us-east-1',
-                'account': 'test-aws'
-            }
-        )
-        assert mock_send_job_response.call_args_list == [
-            call(
-                '123', 'Region [us-east-1]: Waiting for image/credentials data'
-            ),
-            call(
-                '123', 'Waiting 30sec before next try...'
-            )
-        ]
-        mock_sleep.assert_called_once_with(30)
-
-    @patch('mash.services.uploader.service.time.sleep')
-    def test_wait_until_ready(self, mock_sleep):
-        uploader = self.uploader
-        uploader.jobs = {'123': {}}
-
-        def done_after_one_iteration(self):
-            uploader.jobs['123']['ready'] = True
-
-        mock_sleep.side_effect = done_after_one_iteration
-        uploader._wait_until_ready('123')
-        mock_sleep.assert_called_once_with(1)
-
-    def test_image_already_uploading(self):
-        uploader = Mock()
-        self.uploader.jobs = {'123': {}}
-        assert self.uploader._image_already_uploading('123', uploader) is False
-        uploader.system_image_file = 'image_A'
-        self.uploader.jobs['123']['system_image_file'] = 'image_B'
-        assert self.uploader._image_already_uploading('123', uploader) is False
-        uploader.system_image_file = \
-            self.uploader.jobs['123']['system_image_file']
-        assert self.uploader._image_already_uploading('123', uploader) is True
+        assert self.uploader.jobs['123']['uploader'] == [upload_image]

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -12,7 +12,7 @@ class TestUploadImage(object):
     def setup(self, mock_mkpath):
         self.custom_uploader_args = {'cloud-specific-param': 'foo'}
         self.upload_image = UploadImage(
-            '123', 'job_file', False, 'ec2',
+            '123', 'job_file', 'ec2',
             'token', 'cloud_image_name_at_{date}',
             'cloud_image_description',
             last_upload_region=False,


### PR DESCRIPTION
Refactor uploader service to be event based
    
For historic reasons the uploader was based on one consumer
callback method because amqpstorm did not support having
multiple callbacks configured in the consumer. This lead
to an implementation with its own event loop and could be
simplified. In addition some artifacts from former design
aspects were still in the code and got removed by this
refactoring. Related to Issue #337