### PR TITLE
Pass job last_service to all services

### DIFF
--- a/examples/messages/deprecation_job.json
+++ b/examples/messages/deprecation_job.json
@@ -1,6 +1,7 @@
 {
     "deprecation_job": {
         "id": "123",
+        "last_service": "deprecation",
         "provider": "ec2",
         "utctime": "now",
         "old_cloud_image_name": "old_image_123",

--- a/examples/messages/obs_always_job.json
+++ b/examples/messages/obs_always_job.json
@@ -3,6 +3,7 @@
         "id": "5678",
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "image": "SLES12-Azure-BYOS",
+        "last_service": "obs",
         "utctime": "always",
         "conditions": [
             {"package": ["kernel-default", ">=3.12.61", ">=52.136"]},

--- a/examples/messages/obs_always_job.json
+++ b/examples/messages/obs_always_job.json
@@ -3,7 +3,7 @@
         "id": "5678",
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "image": "SLES12-Azure-BYOS",
-        "last_service": "obs",
+        "last_service": "testing",
         "utctime": "always",
         "conditions": [
             {"package": ["kernel-default", ">=3.12.61", ">=52.136"]},

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -3,7 +3,7 @@
         "id": "123",
         "image": "openSUSE-Tumbleweed-JeOS",
         "download_url": "http://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Tumbleweed/openSUSE_Tumbleweed",
-        "last_service": "obs",
+        "last_service": "testing",
         "utctime": "now",
         "conditions": [
             {"package": ["kernel-default", ">=4.4.1", ">=1.1"]},

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -3,6 +3,7 @@
         "id": "123",
         "image": "openSUSE-Tumbleweed-JeOS",
         "download_url": "http://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Tumbleweed/openSUSE_Tumbleweed",
+        "last_service": "obs",
         "utctime": "now",
         "conditions": [
             {"package": ["kernel-default", ">=4.4.1", ">=1.1"]},

--- a/examples/messages/obs_now_job.json
+++ b/examples/messages/obs_now_job.json
@@ -3,7 +3,7 @@
         "id": "0815",
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "image": "SLES12-Azure-BYOS",
-        "last_service": "obs",
+        "last_service": "testing",
         "utctime": "now"
     }
 }

--- a/examples/messages/obs_now_job.json
+++ b/examples/messages/obs_now_job.json
@@ -3,6 +3,7 @@
         "id": "0815",
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "image": "SLES12-Azure-BYOS",
+        "last_service": "obs",
         "utctime": "now"
     }
 }

--- a/examples/messages/pint_job.json
+++ b/examples/messages/pint_job.json
@@ -1,6 +1,7 @@
 {
     "pint_job": {
         "id": "123",
+        "last_service": "pint",
         "provider": "ec2",
         "utctime": "now",
         "cloud_image_name": "image_123",

--- a/examples/messages/publisher_job.json
+++ b/examples/messages/publisher_job.json
@@ -2,6 +2,7 @@
     "publisher_job": {
         "allow_copy": "",
         "id": "123",
+        "last_service": "publisher",
         "provider": "ec2",
         "share_with": "None",
         "utctime": "now",

--- a/examples/messages/replication_job.json
+++ b/examples/messages/replication_job.json
@@ -2,6 +2,7 @@
     "replication_job": {
         "id": "123",
         "image_description": "My Image",
+        "last_service": "replication",
         "provider": "ec2",
         "utctime": "now",
         "replication_source_regions": {

--- a/examples/messages/testing_job.json
+++ b/examples/messages/testing_job.json
@@ -3,6 +3,7 @@
         "id": "123",
         "distro": "sles",
         "instance_type": "t2.micro",
+        "last_service": "testing",
         "provider": "ec2",
         "tests": ["test_stuff"],
         "utctime": "now",

--- a/examples/messages/uploader_job.json
+++ b/examples/messages/uploader_job.json
@@ -3,6 +3,7 @@
         "id": "123",
         "cloud_image_name": "ms_image-{DS}-x86_64",
         "image_description": "ami-12345",
+        "last_service": "uploader",
         "utctime": "now",
         "provider": "ec2",
         "target_regions": {

--- a/mash/services/deprecation/ec2_job.py
+++ b/mash/services/deprecation/ec2_job.py
@@ -29,11 +29,11 @@ class EC2DeprecationJob(DeprecationJob):
     """
 
     def __init__(
-        self, id, provider, utctime, old_cloud_image_name,
+        self, id, last_service, provider, utctime, old_cloud_image_name,
         job_file=None, deprecation_regions=None
     ):
         super(EC2DeprecationJob, self).__init__(
-            id, provider, utctime, job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
         self.credentials = None
         self.old_cloud_image_name = old_cloud_image_name

--- a/mash/services/deprecation/job.py
+++ b/mash/services/deprecation/job.py
@@ -25,11 +25,12 @@ class DeprecationJob(object):
     Class for an individual deprecation job.
     """
 
-    def __init__(self, id, provider, utctime, job_file=None):
+    def __init__(self, id, last_service, provider, utctime, job_file=None):
         self.cloud_image_name = None
         self.iteration_count = 0
         self.id = id
         self.job_file = job_file
+        self.last_service = last_service
         self.log_callback = None
         self.provider = provider
         self.status = UNKOWN

--- a/mash/services/deprecation/service.py
+++ b/mash/services/deprecation/service.py
@@ -98,7 +98,9 @@ class DeprecationService(BaseService):
             pass
 
         self._delete_job(job.id)
-        self._publish_message(job)
+
+        if job.last_service != self.service_exchange:
+            self._publish_message(job)
 
     def _create_job(self, job_class, job_config):
         """
@@ -295,8 +297,10 @@ class DeprecationService(BaseService):
                 extra=metata
             )
 
-        # Don't send failure messages for always jobs.
-        if job.utctime != 'always' or job.status == SUCCESS:
+        # Don't send failure messages for always jobs and
+        # don't send message if last service.
+        if (job.utctime != 'always' or job.status == SUCCESS) \
+                and job.last_service != self.service_exchange:
             self._publish_message(job)
         job.listener_msg.ack()
 

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -51,7 +51,11 @@ class BaseJob(object):
         self.instance_type = instance_type
         self.utctime = utctime
 
-        self.base_message = {'id': self.id, 'utctime': self.utctime}
+        self.base_message = {
+            'id': self.id,
+            'utctime': self.utctime,
+            'last_service': self.last_service
+        }
 
         self.post_init()
 
@@ -80,7 +84,6 @@ class BaseJob(object):
         credentials_message = {
             'credentials_job': {
                 'provider': self.provider,
-                'last_service': self.last_service,
                 'provider_accounts': accounts,
                 'requesting_user': self.requesting_user
             }

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -134,6 +134,7 @@ class OBSImageBuildResultService(BaseService):
               "download_url": "http://download.suse.de/ibs/Devel:/PubCloud
               :/Stable:/Images12/images",
               "image": "SLES12-Azure-BYOS",
+              "last_service": "uploader",
               "utctime": "now|always|timestring_utc_timezone",
               "conditions": [
                   {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -29,11 +29,12 @@ class EC2PublisherJob(PublisherJob):
     """
 
     def __init__(
-        self, id, provider, publish_regions, utctime,
+        self, id, last_service, provider, publish_regions, utctime,
         allow_copy=False, job_file=None, share_with='all'
     ):
         super(EC2PublisherJob, self).__init__(
-            id, provider, publish_regions, utctime, job_file=job_file
+            id, last_service, provider, publish_regions, utctime,
+            job_file=job_file
         )
         self.allow_copy = allow_copy
         self.share_with = share_with

--- a/mash/services/publisher/job.py
+++ b/mash/services/publisher/job.py
@@ -25,12 +25,16 @@ class PublisherJob(object):
     Class for an individual publisher job.
     """
 
-    def __init__(self, id, provider, publish_regions, utctime, job_file=None):
+    def __init__(
+        self, id, last_service, provider, publish_regions, utctime,
+        job_file=None
+    ):
         self.cloud_image_name = None
         self.credentials = None
         self.iteration_count = 0
         self.id = id
         self.job_file = job_file
+        self.last_service = last_service
         self.log_callback = None
         self.provider = provider
         self.publish_regions = publish_regions

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -91,7 +91,9 @@ class PublisherService(BaseService):
             pass
 
         self._delete_job(job.id)
-        self._publish_message(job)
+
+        if job.last_service != self.service_exchange:
+            self._publish_message(job)
 
     def _create_job(self, job_class, job_config):
         """
@@ -299,7 +301,10 @@ class PublisherService(BaseService):
                 extra=metata
             )
 
-        if job.utctime != 'always' or job.status == SUCCESS:
+        # Don't send failure messages for always jobs and
+        # don't send message if last service.
+        if (job.utctime != 'always' or job.status == SUCCESS) \
+                and job.last_service != self.service_exchange:
             self._publish_message(job)
         job.listener_msg.ack()
 

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -33,11 +33,11 @@ class AzureReplicationJob(ReplicationJob):
     """
 
     def __init__(
-        self, id, image_description, provider, utctime,
+        self, id, image_description, last_service, provider, utctime,
         replication_source_regions, cloud_image_name=None, job_file=None
     ):
         super(AzureReplicationJob, self).__init__(
-            id, provider, utctime, job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
         self.credentials = None
         self.image_description = image_description

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -32,11 +32,11 @@ class EC2ReplicationJob(ReplicationJob):
     """
 
     def __init__(
-        self, id, image_description, provider, utctime,
+        self, id, image_description, last_service, provider, utctime,
         replication_source_regions, cloud_image_name=None, job_file=None
     ):
         super(EC2ReplicationJob, self).__init__(
-            id, provider, utctime, job_file=job_file,
+            id, last_service, provider, utctime, job_file=job_file,
             cloud_image_name=cloud_image_name
         )
         self.credentials = None

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -26,12 +26,14 @@ class ReplicationJob(object):
     """
 
     def __init__(
-        self, id, provider, utctime, job_file=None, cloud_image_name=None
+        self, id, last_service, provider, utctime, job_file=None,
+        cloud_image_name=None
     ):
         self.cloud_image_name = cloud_image_name
         self.iteration_count = 0
         self.id = id
         self.job_file = job_file
+        self.last_service = last_service
         self.log_callback = None
         self.provider = provider
         self.status = UNKOWN

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -96,7 +96,9 @@ class ReplicationService(BaseService):
             pass
 
         self._delete_job(job.id)
-        self._publish_message(job)
+
+        if job.last_service != self.service_exchange:
+            self._publish_message(job)
 
     def _create_job(self, job_class, job_config):
         """
@@ -292,7 +294,10 @@ class ReplicationService(BaseService):
                 extra=metata
             )
 
-        if job.utctime != 'always' or job.status == SUCCESS:
+        # Don't send failure messages for always jobs and
+        # don't send message if last service.
+        if (job.utctime != 'always' or job.status == SUCCESS) \
+                and job.last_service != self.service_exchange:
             self._publish_message(job)
         job.listener_msg.ack()
 

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -36,18 +36,19 @@ class AzureTestingJob(TestingJob):
     """
 
     def __init__(
-        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ipa_timeout=None, ssh_user='azureuser'
+        self, id, last_service, provider, ssh_private_key_file, test_regions,
+        tests, utctime, job_file=None, credentials=None, description=None,
+        distro='sles', instance_type=None, ipa_timeout=None,
+        ssh_user='azureuser'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
 
         super(AzureTestingJob, self).__init__(
-            id, provider, ssh_private_key_file, test_regions, tests, utctime,
-            job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ipa_timeout=ipa_timeout,
-            ssh_user=ssh_user
+            id, last_service, provider, ssh_private_key_file, test_regions,
+            tests, utctime, job_file=job_file, description=description,
+            distro=distro, instance_type=instance_type,
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -42,18 +42,19 @@ class EC2TestingJob(TestingJob):
     """
 
     def __init__(
-        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ipa_timeout=None, ssh_user='ec2-user'
+        self, id, last_service, provider, ssh_private_key_file, test_regions,
+        tests, utctime, job_file=None, credentials=None, description=None,
+        distro='sles', instance_type=None, ipa_timeout=None,
+        ssh_user='ec2-user'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
 
         super(EC2TestingJob, self).__init__(
-            id, provider, ssh_private_key_file, test_regions, tests, utctime,
-            job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ipa_timeout=ipa_timeout,
-            ssh_user=ssh_user
+            id, last_service, provider, ssh_private_key_file, test_regions,
+            tests, utctime, job_file=job_file, description=description,
+            distro=distro, instance_type=instance_type,
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -36,18 +36,18 @@ class GCETestingJob(TestingJob):
     """
 
     def __init__(
-        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ipa_timeout=None, ssh_user='root'
+        self, id, last_service, provider, ssh_private_key_file, test_regions,
+        tests, utctime, job_file=None, credentials=None, description=None,
+        distro='sles', instance_type=None, ipa_timeout=None, ssh_user='root'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
 
         super(GCETestingJob, self).__init__(
-            id, provider, ssh_private_key_file, test_regions, tests, utctime,
-            job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type, ipa_timeout=ipa_timeout,
-            ssh_user=ssh_user
+            id, last_service, provider, ssh_private_key_file, test_regions,
+            tests, utctime, job_file=job_file, description=description,
+            distro=distro, instance_type=instance_type,
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user
         )
 
     def _add_provider_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -31,9 +31,9 @@ class TestingJob(object):
     __test__ = False  # Used by pytest to ignore class in auto discovery
 
     def __init__(
-        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, description=None, distro='sles', instance_type=None,
-        ipa_timeout=None, ssh_user=None
+        self, id, last_service, provider, ssh_private_key_file, test_regions,
+        tests, utctime, job_file=None, description=None, distro='sles',
+        instance_type=None, ipa_timeout=None, ssh_user=None
     ):
         self.cloud_image_name = None
         self.job_file = job_file
@@ -44,6 +44,7 @@ class TestingJob(object):
         self.iteration_count = 0
         self.id = id
         self.ipa_timeout = ipa_timeout
+        self.last_service = last_service
         self.log_callback = None
         self.provider = provider
         self.status = UNKOWN

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -115,7 +115,9 @@ class TestingService(BaseService):
             pass
 
         self._delete_job(job.id)
-        self._publish_message(job)
+
+        if job.last_service != self.service_exchange:
+            self._publish_message(job)
 
     def _create_job(self, job_class, job_config):
         """
@@ -260,6 +262,7 @@ class TestingService(BaseService):
         {
             "testing_job": {
                 "id": "123",
+                "last_service": "testing",
                 "provider": "ec2",
                 "tests": "test_stuff",
                 "utctime": "now",
@@ -346,8 +349,10 @@ class TestingService(BaseService):
                 extra=metata
             )
 
-        # Don't send failure messages for always jobs.
-        if job.utctime != 'always' or job.status == SUCCESS:
+        # Don't send failure messages for always jobs and
+        # don't send message if last service.
+        if (job.utctime != 'always' or job.status == SUCCESS) \
+                and job.last_service != self.service_exchange:
             self._publish_message(job)
         job.listener_msg.ack()
 

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -81,7 +81,8 @@ class UploadImageService(BaseService):
         if status:
             self.jobs[job_id]['uploader_result']['status'] = status
         job_status = self.jobs[job_id]['uploader_result']['status']
-        if job_status == FAILED and publish_on_failed_job is False:
+        if (job_status == FAILED and publish_on_failed_job is False) \
+                or self.jobs[job_id]['last_service'] == self.service_exchange:
             return
         self.publish_job_result(
             'testing', job_id, JsonFormat.json_message(
@@ -183,6 +184,7 @@ class UploadImageService(BaseService):
         if job_id not in self.jobs:
             self.jobs[job_id] = {
                 'job_config': job_config,
+                'last_service': job_config.get('last_service'),
                 'utctime': job_config.get('utctime'),
                 'job_file': self.persist_job_config(job_config),
                 'credentials': None,

--- a/test/unit/services/deprecation/ec2_job_test.py
+++ b/test/unit/services/deprecation/ec2_job_test.py
@@ -10,6 +10,7 @@ class TestEC2DeprecationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'deprecation',
             'provider': 'ec2',
             'old_cloud_image_name': 'old_image_123',
             'deprecation_regions': [

--- a/test/unit/services/deprecation/job_test.py
+++ b/test/unit/services/deprecation/job_test.py
@@ -8,6 +8,7 @@ class TestDeprecationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'deprecation',
             'provider': 'ec2',
             'utctime': 'now'
         }

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -148,6 +148,7 @@ class TestJobCreatorService(object):
                                     "repositories/Cloud:Tools/images",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
+                    "last_service": "pint",
                     "utctime": "now"
                 }
             })
@@ -160,6 +161,7 @@ class TestJobCreatorService(object):
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
+                    "last_service": "pint",
                     "provider": "ec2",
                     "target_regions": {
                         "ap-northeast-1": {
@@ -182,6 +184,7 @@ class TestJobCreatorService(object):
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
+                    "last_service": "pint",
                     "provider": "ec2",
                     "test_regions": {
                         "ap-northeast-1": "test-aws",
@@ -198,6 +201,7 @@ class TestJobCreatorService(object):
                 "replication_job": {
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
+                    "last_service": "pint",
                     "provider": "ec2",
                     "replication_source_regions": {
                         "ap-northeast-1": {
@@ -224,6 +228,7 @@ class TestJobCreatorService(object):
         assert data['provider'] == 'ec2'
         assert data['share_with'] == 'all'
         assert data['utctime'] == 'now'
+        assert data['last_service'] == 'pint'
 
         for region in data['publish_regions']:
             if region['account'] == 'test-aws-gov':
@@ -242,6 +247,7 @@ class TestJobCreatorService(object):
         assert data['old_cloud_image_name'] == 'old_new_image_123'
         assert data['provider'] == 'ec2'
         assert data['utctime'] == 'now'
+        assert data['last_service'] == 'pint'
 
         for region in data['deprecation_regions']:
             if region['account'] == 'test-aws-gov':
@@ -260,6 +266,7 @@ class TestJobCreatorService(object):
                 "pint_job": {
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
+                    "last_service": "pint",
                     "old_cloud_image_name": "old_new_image_123",
                     "provider": "ec2",
                     "utctime": "now"
@@ -340,6 +347,7 @@ class TestJobCreatorService(object):
                                     "repositories/Cloud:Tools/images",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
+                    "last_service": "replication",
                     "utctime": "now"
                 }
             })
@@ -351,6 +359,7 @@ class TestJobCreatorService(object):
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
+                    "last_service": "replication",
                     "provider": "azure",
                     "target_regions": {
                         "centralus": {
@@ -377,6 +386,7 @@ class TestJobCreatorService(object):
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
+                    "last_service": "replication",
                     "provider": "azure",
                     "test_regions": {
                         "centralus": "test-azure2",
@@ -393,6 +403,7 @@ class TestJobCreatorService(object):
                 "replication_job": {
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
+                    "last_service": "replication",
                     "provider": "azure",
                     "replication_source_regions": {
                         "centralus": {
@@ -482,6 +493,7 @@ class TestJobCreatorService(object):
                                     "repositories/Cloud:Tools/images",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
+                    "last_service": "testing",
                     "utctime": "now"
                 }
             })
@@ -493,6 +505,7 @@ class TestJobCreatorService(object):
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
+                    "last_service": "testing",
                     "provider": "gce",
                     "target_regions": {
                         "us-west2": {
@@ -517,6 +530,7 @@ class TestJobCreatorService(object):
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
+                    "last_service": "testing",
                     "provider": "gce",
                     "test_regions": {
                         "us-west2": "test-gce2",

--- a/test/unit/services/publisher/ec2_job_test.py
+++ b/test/unit/services/publisher/ec2_job_test.py
@@ -11,6 +11,7 @@ class TestEC2PublisherJob(object):
         self.job_config = {
             'allow_copy': False,
             'id': '1',
+            'last_service': 'publisher',
             'provider': 'ec2',
             'publish_regions': [
                 {

--- a/test/unit/services/publisher/job_test.py
+++ b/test/unit/services/publisher/job_test.py
@@ -8,6 +8,7 @@ class TestPublisherJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'publisher',
             'provider': 'ec2',
             'publish_regions': [
                 {

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -9,6 +9,7 @@ class TestAzureReplicationJob(object):
         self.job_config = {
             'id': '1',
             'image_description': 'My image',
+            'last_service': 'replication',
             'provider': 'azure',
             'utctime': 'now',
             "replication_source_regions": {

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -12,6 +12,7 @@ class TestEC2ReplicationJob(object):
         self.job_config = {
             'id': '1',
             'image_description': 'My image',
+            'last_service': 'replication',
             'provider': 'ec2',
             'utctime': 'now',
             "replication_source_regions": {

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -8,6 +8,7 @@ class TestReplicationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'replication',
             'provider': 'ec2',
             'utctime': 'now'
         }

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -7,6 +7,7 @@ class TestAzureTestingJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'testing',
             'provider': 'azure',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'East US': 'test-azure'},

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -7,6 +7,7 @@ class TestEC2TestingJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'testing',
             'provider': 'ec2',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -7,6 +7,7 @@ class TestGCETestingJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'testing',
             'provider': 'gce',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-west1': 'test-gce'},

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -9,6 +9,7 @@ class TestTestingJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'last_service': 'testing',
             'provider': 'ec2',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -36,6 +36,7 @@ class TestUploadImageService(object):
     ):
         self.job_data_from_preserved_ec2 = {
             'id': '888',
+            'last_service': 'uploader',
             'utctime': 'now',
             'cloud_image_name': 'name',
             'image_description': 'description',
@@ -50,6 +51,7 @@ class TestUploadImageService(object):
         self.job_data_ec2 = {
             'uploader_job': {
                 'id': '123',
+                'last_service': 'testing',
                 'utctime': 'now',
                 'cloud_image_name': 'name',
                 'image_description': 'description',
@@ -65,6 +67,7 @@ class TestUploadImageService(object):
         self.job_data_azure = {
             'uploader_job': {
                 'id': '123',
+                'last_service': 'uploader',
                 'utctime': 'now',
                 'cloud_image_name': 'name',
                 'image_description': 'description',
@@ -82,6 +85,7 @@ class TestUploadImageService(object):
         self.job_data_gce = {
             'uploader_job': {
                 'id': '123',
+                'last_service': 'uploader',
                 'utctime': 'now',
                 'cloud_image_name': 'name',
                 'image_description': 'description',
@@ -208,6 +212,7 @@ class TestUploadImageService(object):
     def test_process_job(self, mock_init_job):
         message = Mock()
         message.body = '{"uploader_job": {"id": "123", ' + \
+            '"last_service": "testing", ' + \
             '"utctime": "now", "cloud_image_name": "name", ' + \
             '"image_description": "description", ' + \
             '"provider": "ec2", ' +\


### PR DESCRIPTION
This is required to prevent extra noise when a job has finished. If the job's last service is the current service don't publish a message downstream.

last_service is also needed to fix 341 .

Resolves #346 