### PR TITLE
Update MASH requirements to use ec2imgutils

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -22,9 +22,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0,<3.0.0
 amqpstorm
-ec2deprecateimg
-ec2publishimg
-ec2uploadimg
+ec2imgutils
 python3-ipa
 lxml
 requests

--- a/mash/services/deprecation/ec2_job.py
+++ b/mash/services/deprecation/ec2_job.py
@@ -16,7 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from ec2utils.ec2deprecateimg import EC2DeprecateImg
+from ec2imgutils.ec2deprecateimg import EC2DeprecateImg
 
 from mash.mash_exceptions import MashDeprecationException
 from mash.services.deprecation.job import DeprecationJob

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -16,7 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from ec2utils.ec2publishimg import EC2PublishImage
+from ec2imgutils.ec2publishimg import EC2PublishImage
 
 from mash.mash_exceptions import MashPublisherException
 from mash.services.publisher.job import PublisherJob

--- a/mash/services/uploader/cloud/amazon.py
+++ b/mash/services/uploader/cloud/amazon.py
@@ -17,7 +17,7 @@
 #
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
-from ec2utils.ec2uploadimg import EC2ImageUploader
+from ec2imgutils.ec2uploadimg import EC2ImageUploader
 
 # project
 from mash.services.uploader.cloud.base import UploadBase

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -42,9 +42,7 @@ BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
 BuildRequires:  python3-python-dateutil < 3.0.0
-BuildRequires:  python3-ec2deprecateimg
-BuildRequires:  python3-ec2publishimg
-BuildRequires:  python3-ec2uploadimg
+BuildRequires:  python3-ec2imgutils
 BuildRequires:  python3-ipa
 BuildRequires:  python3-ipa-tests
 BuildRequires:  python3-lxml
@@ -66,9 +64,7 @@ Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 3.0.0
-Requires:       python3-ec2deprecateimg
-Requires:       python3-ec2publishimg
-Requires:       python3-ec2uploadimg
+Requires:       python3-ec2imgutils
 Requires:       python3-ipa
 Requires:       python3-ipa-tests
 Requires:       python3-lxml


### PR DESCRIPTION
ec2utils have moved to a combined package ec2imgutils.