### PR TITLE
Use temporary subnet and security group.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -23,6 +23,6 @@ APScheduler
 python-dateutil>=2.6.0,<3.0.0
 amqpstorm
 ec2imgutils
-python3-ipa
+python3-ipa>=2.5.0
 lxml
 requests

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -43,8 +43,8 @@ BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
 BuildRequires:  python3-python-dateutil < 3.0.0
 BuildRequires:  python3-ec2imgutils
-BuildRequires:  python3-ipa
-BuildRequires:  python3-ipa-tests
+BuildRequires:  python3-ipa>=2.5.0
+BuildRequires:  python3-ipa-tests>=2.5.0
 BuildRequires:  python3-lxml
 BuildRequires:  python3-Flask
 BuildRequires:  python3-requests
@@ -65,8 +65,8 @@ Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 3.0.0
 Requires:       python3-ec2imgutils
-Requires:       python3-ipa
-Requires:       python3-ipa-tests
+Requires:       python3-ipa>=2.5.0
+Requires:       python3-ipa-tests>=2.5.0
 Requires:       python3-lxml
 Requires:       python3-Flask
 Requires:       python3-requests

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -59,10 +59,12 @@ class TestAzureTestingJob(object):
             log_level=30,
             region='East US',
             secret_access_key=None,
+            security_group_id=None,
             service_account_file='/tmp/acnt.file',
             ssh_key_name=None,
             ssh_private_key_file='private_ssh_key.file',
             ssh_user='azureuser',
+            subnet_id=None,
             tests=['test_stuff'],
             timeout=None
         )

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -59,10 +59,12 @@ class TestGCETestingJob(object):
             log_level=30,
             region='us-west1',
             secret_access_key=None,
+            security_group_id=None,
             service_account_file='/tmp/acnt.file',
             ssh_key_name=None,
             ssh_private_key_file='private_ssh_key.file',
             ssh_user='root',
+            subnet_id=None,
             tests=['test_stuff'],
             timeout=None
         )


### PR DESCRIPTION
This guarantees the test instance is accessible on ssh port.