### PR TITLE
Cleanup cloud image name in replication jobs.

### DIFF
--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -34,14 +34,13 @@ class AzureReplicationJob(ReplicationJob):
 
     def __init__(
         self, id, image_description, last_service, provider, utctime,
-        replication_source_regions, cloud_image_name=None, job_file=None
+        replication_source_regions, job_file=None
     ):
         super(AzureReplicationJob, self).__init__(
             id, last_service, provider, utctime, job_file=job_file
         )
         self.credentials = None
         self.image_description = image_description
-        self.cloud_image_name = cloud_image_name
         self.job_file = job_file
         self.replication_source_regions = replication_source_regions
 

--- a/mash/services/replication/azure_utils.py
+++ b/mash/services/replication/azure_utils.py
@@ -38,7 +38,7 @@ from mash.utils.json_format import JsonFormat
 def copy_blob_to_classic_storage(
     auth_file, blob_name, source_container, source_resource_group,
     source_storage_account, destination_container, destination_resource_group,
-    destination_storage_account, timeout=600
+    destination_storage_account, timeout=1200
 ):
     """
     Copy a blob from ARM based storage account to a classic storage account.
@@ -69,6 +69,10 @@ def copy_blob_to_classic_storage(
     while time.time() < end:
         if copy.status == 'success':
             return
+        elif copy.status == 'failed':
+            raise MashReplicationException(
+                'Azure blob copy failed.'
+            )
         else:
             time.sleep(30)
 

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -33,11 +33,10 @@ class EC2ReplicationJob(ReplicationJob):
 
     def __init__(
         self, id, image_description, last_service, provider, utctime,
-        replication_source_regions, cloud_image_name=None, job_file=None
+        replication_source_regions, job_file=None
     ):
         super(EC2ReplicationJob, self).__init__(
-            id, last_service, provider, utctime, job_file=job_file,
-            cloud_image_name=cloud_image_name
+            id, last_service, provider, utctime, job_file=job_file
         )
         self.credentials = None
         self.image_description = image_description

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -26,10 +26,9 @@ class ReplicationJob(object):
     """
 
     def __init__(
-        self, id, last_service, provider, utctime, job_file=None,
-        cloud_image_name=None
+        self, id, last_service, provider, utctime, job_file=None
     ):
-        self.cloud_image_name = cloud_image_name
+        self.cloud_image_name = None
         self.iteration_count = 0
         self.id = id
         self.job_file = job_file


### PR DESCRIPTION
- Update timeout for blob copy.
- Raise exception if copy status is failed.