### PR TITLE
Set cloud image name in uploader service.

### DIFF
--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -15,11 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
-import datetime
 
 # project
 from mash.services.uploader.cloud import Upload
-from mash.mash_exceptions import MashConventionsException
 
 
 class UploadImage(object):
@@ -95,7 +93,6 @@ class UploadImage(object):
                 )
             )
             try:
-                self._set_upload_date()
                 self.uploader = Upload(
                     self.csp_name, self.system_image_file,
                     self.cloud_image_name, self.cloud_image_description,
@@ -120,25 +117,6 @@ class UploadImage(object):
 
     def call_result_handler(self):
         self._result_callback()
-
-    def _set_upload_date(self):
-        today = datetime.date.today().strftime("%Y%m%d")
-        try:
-            self.cloud_image_name = self.cloud_image_name.format(
-                date=today
-            )
-        except KeyError:
-            raise MashConventionsException(
-                'Invalid cloud_image_name format to apply {0} in: {1}'.format(
-                    '{date}', self.cloud_image_name
-                )
-            )
-        if today not in self.cloud_image_name:
-            raise MashConventionsException(
-                'No {0} key specified in cloud_image_name format: {1}'.format(
-                    '{date}', self.cloud_image_name
-                )
-            )
 
     def _result_callback(self):
         if self.result_callback:

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 from unittest.mock import Mock
 from unittest.mock import call
 from unittest.mock import patch
@@ -13,7 +11,7 @@ class TestUploadImage(object):
         self.custom_uploader_args = {'cloud-specific-param': 'foo'}
         self.upload_image = UploadImage(
             '123', 'job_file', 'ec2',
-            'token', 'cloud_image_name_at_{date}',
+            'token', 'cloud_image_name_at_080808',
             'cloud_image_description',
             last_upload_region=False,
             custom_uploader_args=self.custom_uploader_args
@@ -26,14 +24,13 @@ class TestUploadImage(object):
     def test_upload(
         self, mock_result_callback, mock_log_callback, mock_Upload
     ):
-        today = datetime.date.today()
         uploader = Mock()
         uploader.upload.return_value = ('image_id', 'region')
         mock_Upload.return_value = uploader
         self.upload_image.upload()
         mock_Upload.assert_called_once_with(
             'ec2', 'image_file',
-            'cloud_image_name_at_{0}'.format(today.strftime("%Y%m%d")),
+            'cloud_image_name_at_080808',
             'cloud_image_description',
             'token', {'cloud-specific-param': 'foo'}
         )
@@ -59,28 +56,6 @@ class TestUploadImage(object):
             ),
             call('error')
         ]
-
-    @patch('mash.services.uploader.upload_image.Upload')
-    @patch.object(UploadImage, '_log_callback')
-    @patch.object(UploadImage, '_result_callback')
-    def test_upload_cloud_image_name_convention_error(
-        self, mock_result_callback, mock_log_callback, mock_Upload
-    ):
-        self.upload_image.cloud_image_name = 'name_with_no_date_key'
-        self.upload_image.upload()
-        assert mock_log_callback.call_args_list[1] == call(
-            'No {date} key specified in cloud_image_name format: '
-            'name_with_no_date_key'
-        )
-
-        mock_log_callback.reset_mock()
-
-        self.upload_image.cloud_image_name = 'name_with_{invalid}_format'
-        self.upload_image.upload()
-        assert mock_log_callback.call_args_list[1] == call(
-            'Invalid cloud_image_name format to apply {date} in: '
-            'name_with_{invalid}_format'
-        )
 
     def test_set_log_handler(self):
         function = Mock()


### PR DESCRIPTION
The cloud image name is per job not per region. If {date} format is in string the current date string is used. Otherwise the name is left as is.

Valid image names:

image_{date} would become image_20121212
image_20181220 would be left as is
image_{fake} would be left as is (keyerror is ignored)

Fixes #355 
Resolves #356 