### PR TITLE
Simplify listener messages.

### DIFF
--- a/mash/services/deprecation/service.py
+++ b/mash/services/deprecation/service.py
@@ -128,7 +128,6 @@ class DeprecationService(BaseService):
                 )
                 job.job_file = job_config['job_file']
 
-            self.bind_listener_queue(job.id)
             self.log.info(
                 'Job queued, awaiting publisher result.',
                 extra=job.get_metadata()
@@ -146,9 +145,6 @@ class DeprecationService(BaseService):
             )
 
             del self.jobs[job_id]
-            self.unbind_queue(
-                self.listener_queue, self.service_exchange, job_id
-            )
             self.remove_file(job.job_file)
         else:
             self.log.warning(
@@ -310,7 +306,7 @@ class DeprecationService(BaseService):
         """
         message = self._get_status_message(job)
         try:
-            self.publish_job_result('pint', job.id, message)
+            self.publish_job_result('pint', message)
         except AMQPError:
             self.log.warning(
                 'Message not received: {0}'.format(message),

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -59,7 +59,7 @@ class OBSImageBuildResultService(BaseService):
 
     def _send_job_result_for_uploader(self, job_id, trigger_info):
         self.publish_job_result(
-            'uploader', job_id, JsonFormat.json_message(trigger_info)
+            'uploader', JsonFormat.json_message(trigger_info)
         )
         if not self.jobs[job_id].job_nonstop:
             self._delete_job(job_id)
@@ -114,7 +114,7 @@ class OBSImageBuildResultService(BaseService):
                 }
             }
             self.publish_job_result(
-                'uploader', job_id, JsonFormat.json_message(message)
+                'uploader', JsonFormat.json_message(message)
             )
         else:
             result = {

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -121,7 +121,6 @@ class PublisherService(BaseService):
                 )
                 job.job_file = job_config['job_file']
 
-            self.bind_listener_queue(job.id)
             self.log.info(
                 'Job queued, awaiting replication result.',
                 extra=job.get_metadata()
@@ -139,9 +138,6 @@ class PublisherService(BaseService):
             )
 
             del self.jobs[job_id]
-            self.unbind_queue(
-                self.listener_queue, self.service_exchange, job_id
-            )
             self.remove_file(job.job_file)
         else:
             self.log.warning(
@@ -322,7 +318,7 @@ class PublisherService(BaseService):
         message = self._get_status_message(job)
 
         try:
-            self.publish_job_result('deprecation', job.id, message)
+            self.publish_job_result('deprecation', message)
         except AMQPError:
             self.log.warning(
                 'Message not received: {0}'.format(message),

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -126,7 +126,6 @@ class ReplicationService(BaseService):
                 )
                 job.job_file = job_config['job_file']
 
-            self.bind_listener_queue(job.id)
             self.log.info(
                 'Job queued, awaiting testing result.',
                 extra=job.get_metadata()
@@ -144,9 +143,6 @@ class ReplicationService(BaseService):
             )
 
             del self.jobs[job_id]
-            self.unbind_queue(
-                self.listener_queue, self.service_exchange, job_id
-            )
             self.remove_file(job.job_file)
         else:
             self.log.warning(
@@ -315,7 +311,7 @@ class ReplicationService(BaseService):
         message = self._get_status_message(job)
 
         try:
-            self.publish_job_result('publisher', job.id, message)
+            self.publish_job_result('publisher', message)
         except AMQPError:
             self.log.warning(
                 'Message not received: {0}'.format(message),

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -147,7 +147,6 @@ class TestingService(BaseService):
                 )
                 job.job_file = job_config['job_file']
 
-            self.bind_listener_queue(job.id)
             self.log.info(
                 'Job queued, awaiting uploader result.',
                 extra=job.get_metadata()
@@ -194,9 +193,6 @@ class TestingService(BaseService):
             )
 
             del self.jobs[job_id]
-            self.unbind_queue(
-                self.listener_queue, self.service_exchange, job_id
-            )
             self.remove_file(job.job_file)
         else:
             self.log.warning(
@@ -362,7 +358,7 @@ class TestingService(BaseService):
         """
         message = self._get_status_message(job)
         try:
-            self.publish_job_result('replication', job.id, message)
+            self.publish_job_result('replication', message)
         except AMQPError:
             self.log.warning(
                 'Message not received: {0}'.format(message),

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -86,7 +86,7 @@ class UploadImageService(BaseService):
                 or self.jobs[job_id]['last_service'] == self.service_exchange:
             return
         self.publish_job_result(
-            'testing', job_id, JsonFormat.json_message(
+            'testing', JsonFormat.json_message(
                 {'uploader_result': self.jobs[job_id]['uploader_result']}
             )
         )
@@ -204,7 +204,6 @@ class UploadImageService(BaseService):
                     'status': None
                 }
             }
-            self.bind_listener_queue(job_id)
             self._job_log(
                 job_id, 'Job queued, awaiting obs result'
             )
@@ -261,9 +260,6 @@ class UploadImageService(BaseService):
         if job_id not in self.jobs:
             self._job_log(job_id, 'Job does not exist')
         else:
-            self.unbind_queue(
-                self.listener_queue, self.service_exchange, job_id
-            )
             upload_image = self.jobs[job_id]['uploader'][0]
             # delete job file
             try:

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -77,7 +77,7 @@ class TestOBSImageBuildResultService(object):
         self.obs_result._send_job_result_for_uploader('815', {})
         mock_delete_job.assert_called_once_with('815')
         mock_publish_job_result.assert_called_once_with(
-            'uploader', '815', '{}'
+            'uploader', '{}'
         )
 
     def test_send_control_response_local(self):
@@ -138,7 +138,7 @@ class TestOBSImageBuildResultService(object):
         message.body = '{"job_delete": "4711"}'
         self.obs_result._process_message(message)
         mock_publish_job_result.assert_called_once_with(
-            'uploader', '4711',
+            'uploader',
             JsonFormat.json_message(
                 {'obs_result': {'id': '4711', 'status': 'delete'}}
             )

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -170,7 +170,7 @@ class TestUploadImageService(object):
             '123', publish_on_failed_job=True, status=FAILED
         )
         mock_publish_job_result.assert_called_once_with(
-            'testing', '123', JsonFormat.json_message(
+            'testing', JsonFormat.json_message(
                 {
                     'uploader_result':
                         self.uploader.jobs['123']['uploader_result']
@@ -344,9 +344,6 @@ class TestUploadImageService(object):
         self.uploader._delete_job('815')
         mock_job_log.assert_called_once_with(
             '815', 'Job Deleted'
-        )
-        mock_unbind_queue.assert_called_once_with(
-            'listener', 'uploader', '815'
         )
         mock_os_remove.assert_called_once_with('job_file')
         assert '815' not in self.uploader.jobs


### PR DESCRIPTION
No need to bind messages to job_id based routing key. The job_id is included in the message content. Instead bind to a generic key to prevent all the binding/unbinding which is error prone.