### PR TITLE
Catch generic exception in _update_image_status.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -37,8 +37,7 @@ from mash.services.obs.defaults import Defaults
 from mash.log.filter import SchedulerLoggingFilter
 from mash.mash_exceptions import (
     MashImageDownloadException,
-    MashVersionExpressionException,
-    MashException
+    MashVersionExpressionException
 )
 
 
@@ -335,7 +334,7 @@ class OBSImageBuildResult(object):
             else:
                 self._log_callback('Job done')
                 self._result_callback()
-        except MashException as issue:
+        except Exception as issue:
             self._log_error(
                 '{0}: {1}'.format(type(issue).__name__, issue)
             )


### PR DESCRIPTION
There may be non mash exceptions raised if the storage media is not accessible or if it doesn't exist.