### PR TITLE
Refactor credentials deletion

### DIFF
--- a/examples/messages/credentials_job.json
+++ b/examples/messages/credentials_job.json
@@ -5,12 +5,6 @@
         "provider_accounts": ["test-aws", "test-aws-cn"],
         "requesting_user": "test-aws",
         "last_service": "pint",
-        "utctime": "now",
-        "test_credentials": {
-	        "access_key_id": "123456",
-	        "secret_access_key": "654321",
-	        "ssh_key_name": "my-key",
-	        "ssh_private_key": "my-key.pem"
-        }
+        "utctime": "now"
     }
 }

--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -21,7 +21,7 @@ import jwt
 import logging
 import os
 
-from amqpstorm import Connection
+from amqpstorm import AMQPError, Connection
 from cryptography.fernet import Fernet, MultiFernet
 from datetime import datetime, timedelta
 from jsonschema import FormatChecker, validate
@@ -396,6 +396,23 @@ class BaseService(object):
             config_file.write(JsonFormat.json_message(config))
 
         return config['job_file']
+
+    def publish_credentials_delete(self, job_id):
+        """
+        Publish delete message to credentials service.
+        """
+        delete_message = JsonFormat.json_message(
+            {"credentials_job_delete": job_id}
+        )
+
+        try:
+            self._publish(
+                'credentials', self.job_document_key, delete_message
+            )
+        except AMQPError:
+            self.log.warning(
+                'Message not received: {0}'.format(delete_message)
+            )
 
     def publish_credentials_request(self, job_id):
         """

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -448,10 +448,6 @@ class CredentialsService(BaseService):
             )
 
             self._publish_credentials_response(message, issuer)
-
-            if job['utctime'] != 'always' and \
-                    job['last_service'] == issuer:
-                self._delete_job(job_id)
         else:
             self._send_control_response(
                 'Credentials job {0} does not exist.'.format(job_id),

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -156,13 +156,6 @@ class JobCreatorService(BaseService):
             'obs', self.job_document_key, JsonFormat.json_message(delete_message)
         )
 
-        delete_message = {
-            "credentials_job_delete": job_id
-        }
-        self._publish(
-            'credentials', self.job_document_key, JsonFormat.json_message(delete_message)
-        )
-
     def publish_job_doc(self, service, job_doc):
         """
         Publish the job_doc message to the given service exchange.

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -120,6 +120,11 @@ class PipelineService(BaseService):
                 extra=job.get_metadata()
             )
 
+            if job.last_service == self.service_exchange:
+                # Send delete message to credentials
+                # if this is the last service.
+                self.publish_credentials_delete(job_id)
+
             del self.jobs[job_id]
             self.remove_file(job.job_file)
         else:

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -260,10 +260,14 @@ class UploadImageService(BaseService):
         if job_id not in self.jobs:
             self._job_log(job_id, 'Job does not exist')
         else:
-            upload_image = self.jobs[job_id]['uploader'][0]
+            if self.jobs[job_id]['last_service'] == self.service_exchange:
+                # Send delete message to credentials
+                # if this is the last service.
+                self.publish_credentials_delete(job_id)
+
             # delete job file
             try:
-                os.remove(upload_image.job_file)
+                os.remove(self.jobs[job_id]['job_file'])
             except Exception as issue:
                 self._job_log(
                     job_id, 'Job deletion failed: {0}'.format(issue)

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -495,12 +495,10 @@ class TestCredentialsService(object):
             'testing', 'response', 'response'
         )
 
-    @patch.object(CredentialsService, '_delete_job')
     @patch.object(CredentialsService, '_get_credentials_response')
     @patch.object(CredentialsService, '_publish_credentials_response')
     def test_send_credential_response(
-        self, mock_publish_credentials_response, mock_get_cred_response,
-        mock_delete_job
+        self, mock_publish_credentials_response, mock_get_cred_response
     ):
         job = {'id': '1', 'last_service': 'pint', 'utctime': 'now'}
         self.service.jobs = {'1': job}
@@ -515,7 +513,6 @@ class TestCredentialsService(object):
         mock_publish_credentials_response.assert_called_once_with(
             JsonFormat.json_message({"jwt_token": "response"}), 'pint'
         )
-        mock_delete_job.assert_called_once_with('1')
 
     @patch.object(CredentialsService, '_send_control_response')
     def test_send_credential_response_invalid(

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -670,10 +670,6 @@ class TestJobCreatorService(object):
             call(
                 'obs', 'job_document',
                 JsonFormat.json_message({"obs_job_delete": "1"})
-            ),
-            call(
-                'credentials', 'job_document',
-                JsonFormat.json_message({"credentials_job_delete": "1"})
             )
         ])
 

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -148,14 +148,16 @@ class TestPipelineService(object):
             'Invalid job configuration: Cannot create job.'
         )
 
+    @patch.object(PipelineService, 'publish_credentials_delete')
     @patch.object(PipelineService, 'remove_file')
     @patch.object(PipelineService, 'unbind_queue')
     def test_service_delete_job(
-        self, mock_unbind_queue, mock_remove_file
+        self, mock_unbind_queue, mock_remove_file, mock_publish_creds_delete
     ):
         job = Mock()
         job.id = '1'
         job.job_file = 'job-test.json'
+        job.last_service = 'replication'
         job.status = 'success'
         job.utctime = 'now'
         job.get_metadata.return_value = {'job_id': '1'}
@@ -163,6 +165,7 @@ class TestPipelineService(object):
         self.service.jobs['1'] = job
         self.service._delete_job('1')
 
+        mock_publish_creds_delete.assert_called_once_with('1')
         self.service.log.info.assert_called_once_with(
             'Deleting job.',
             extra={'job_id': '1'}


### PR DESCRIPTION
If a job is deleted in the pipeline and the current service is the last service for the given job a credentials delete message is sent to credentials service.

Fix bug in uploader where the job is not cleaned up if it fails in OBS.