### PR TITLE
Add base mash job class for shared methods.

### DIFF
--- a/mash/services/deprecation/job.py
+++ b/mash/services/deprecation/job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -16,25 +16,19 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from mash.services.status_levels import UNKOWN
+from mash.services.mash_job import MashJob
 from mash.services.deprecation.constants import NOT_IMPLEMENTED
 
 
-class DeprecationJob(object):
+class DeprecationJob(MashJob):
     """
     Class for an individual deprecation job.
     """
 
     def __init__(self, id, last_service, provider, utctime, job_file=None):
-        self.cloud_image_name = None
-        self.iteration_count = 0
-        self.id = id
-        self.job_file = job_file
-        self.last_service = last_service
-        self.log_callback = None
-        self.provider = provider
-        self.status = UNKOWN
-        self.utctime = utctime
+        super(DeprecationJob, self).__init__(
+            id, last_service, provider, utctime, job_file
+        )
 
     def _deprecate(self):
         """
@@ -42,38 +36,9 @@ class DeprecationJob(object):
         """
         raise NotImplementedError(NOT_IMPLEMENTED)
 
-    def get_metadata(self):
-        """
-        Return dictionary of metadata based on job.
-        """
-        return {'job_id': self.id}
-
     def deprecate_image(self):
         """
         Deprecate image.
         """
         self.iteration_count += 1
         self._deprecate()
-
-    def send_log(self, message, success=True):
-        if self.log_callback:
-            self.log_callback(
-                'Pass[{0}]: {1}'.format(
-                    self.iteration_count,
-                    message
-                ),
-                self.get_metadata(),
-                success
-            )
-
-    def set_cloud_image_name(self, cloud_image_name):
-        """
-        Setter for cloud image name.
-        """
-        self.cloud_image_name = cloud_image_name
-
-    def set_log_callback(self, callback):
-        """
-        Set log_callback function to callback.
-        """
-        self.log_callback = callback

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.status_levels import UNKOWN
+
+
+class MashJob(object):
+    """
+    Class for an individual mash job.
+    """
+    def __init__(
+        self, id, last_service, provider, utctime, job_file=None
+    ):
+        # Properties
+        self._cloud_image_name = None
+        self._credentials = None
+        self._log_callback = None
+
+        self.iteration_count = 0
+        self.status = UNKOWN
+
+        self.job_file = job_file
+        self.id = id
+        self.last_service = last_service
+        self.provider = provider
+        self.utctime = utctime
+
+    def get_metadata(self):
+        """
+        Return dictionary of metadata based on job.
+        """
+        return {'job_id': self.id}
+
+    def send_log(self, message, success=True):
+        """
+        Send a log message to the log callback function.
+        """
+        if self.log_callback:
+            self.log_callback(
+                'Pass[{0}]: {1}'.format(
+                    self.iteration_count,
+                    message
+                ),
+                self.get_metadata(),
+                success
+            )
+
+    @property
+    def cloud_image_name(self):
+        """Cloud image name property."""
+        return self._cloud_image_name
+
+    @cloud_image_name.setter
+    def cloud_image_name(self, name):
+        """
+        Setter for cloud image name.
+        """
+        self._cloud_image_name = name
+
+    @property
+    def credentials(self):
+        """Credentials property."""
+        return self._credentials
+
+    @credentials.setter
+    def credentials(self, creds):
+        """Setter for credentials."""
+        self._credentials = creds
+
+    @property
+    def log_callback(self):
+        """Log callback property."""
+        return self._log_callback
+
+    @log_callback.setter
+    def log_callback(self, callback):
+        """
+        Set log_callback function to callback.
+        """
+        self._log_callback = callback

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -96,7 +96,7 @@ class PipelineService(BaseService):
             )
         else:
             self.jobs[job.id] = job
-            job.set_log_callback(self.log_job_message)
+            job.log_callback = self.log_job_message
 
             if 'job_file' not in job_config:
                 job_config['job_file'] = self.persist_job_config(
@@ -354,7 +354,7 @@ class PipelineService(BaseService):
 
     def _process_msg_arg(self, listener_msg, arg, job):
         """Set the arg on the job using setter method."""
-        getattr(job, 'set_{0}'.format(arg))(listener_msg[arg])
+        setattr(job, arg, listener_msg[arg])
 
     def start(self):
         """

--- a/mash/services/publisher/job.py
+++ b/mash/services/publisher/job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -16,11 +16,11 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from mash.services.status_levels import UNKOWN
+from mash.services.mash_job import MashJob
 from mash.services.publisher.constants import NOT_IMPLEMENTED
 
 
-class PublisherJob(object):
+class PublisherJob(MashJob):
     """
     Class for an individual publisher job.
     """
@@ -29,23 +29,11 @@ class PublisherJob(object):
         self, id, last_service, provider, publish_regions, utctime,
         job_file=None
     ):
-        self.cloud_image_name = None
-        self.credentials = None
-        self.iteration_count = 0
-        self.id = id
-        self.job_file = job_file
-        self.last_service = last_service
-        self.log_callback = None
-        self.provider = provider
-        self.publish_regions = publish_regions
-        self.status = UNKOWN
-        self.utctime = utctime
+        super(PublisherJob, self).__init__(
+            id, last_service, provider, utctime, job_file
+        )
 
-    def get_metadata(self):
-        """
-        Return dictionary of metadata based on job.
-        """
-        return {'job_id': self.id}
+        self.publish_regions = publish_regions
 
     def _publish(self):
         """
@@ -59,29 +47,3 @@ class PublisherJob(object):
         """
         self.iteration_count += 1
         self._publish()
-
-    def send_log(self, message, success=True):
-        """
-        Send message to log callback method.
-        """
-        if self.log_callback:
-            self.log_callback(
-                'Pass[{0}]: {1}'.format(
-                    self.iteration_count,
-                    message
-                ),
-                self.get_metadata(),
-                success
-            )
-
-    def set_cloud_image_name(self, cloud_image_name):
-        """
-        Setter for cloud image name.
-        """
-        self.cloud_image_name = cloud_image_name
-
-    def set_log_callback(self, callback):
-        """
-        Set log_callback function to callback.
-        """
-        self.log_callback = callback

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -16,11 +16,11 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from mash.services.status_levels import UNKOWN
+from mash.services.mash_job import MashJob
 from mash.services.replication.constants import NOT_IMPLEMENTED
 
 
-class ReplicationJob(object):
+class ReplicationJob(MashJob):
     """
     Class for an individual replication job.
     """
@@ -28,28 +28,17 @@ class ReplicationJob(object):
     def __init__(
         self, id, last_service, provider, utctime, job_file=None
     ):
-        self.cloud_image_name = None
-        self.iteration_count = 0
-        self.id = id
-        self.job_file = job_file
-        self.last_service = last_service
-        self.log_callback = None
-        self.provider = provider
-        self.source_regions = None
-        self.status = UNKOWN
-        self.utctime = utctime
+        super(ReplicationJob, self).__init__(
+            id, last_service, provider, utctime, job_file
+        )
+
+        self._source_regions = None
 
     def _replicate(self):
         """
         Replicate image to all regions in each account.
         """
         raise NotImplementedError(NOT_IMPLEMENTED)
-
-    def get_metadata(self):
-        """
-        Return dictionary of metadata based on job.
-        """
-        return {'job_id': self.id}
 
     def replicate_image(self):
         """
@@ -58,31 +47,14 @@ class ReplicationJob(object):
         self.iteration_count += 1
         self._replicate()
 
-    def send_log(self, message, success=True):
-        if self.log_callback:
-            self.log_callback(
-                'Pass[{0}]: {1}'.format(
-                    self.iteration_count,
-                    message
-                ),
-                self.get_metadata(),
-                success
-            )
+    @property
+    def source_regions(self):
+        """Source regions property."""
+        return self._source_regions
 
-    def set_cloud_image_name(self, cloud_image_name):
-        """
-        Setter for cloud image name.
-        """
-        self.cloud_image_name = cloud_image_name
-
-    def set_log_callback(self, callback):
-        """
-        Set log_callback function to callback.
-        """
-        self.log_callback = callback
-
-    def set_source_regions(self, source_regions):
+    @source_regions.setter
+    def source_regions(self, regions):
         """
         Setter for source_regions dictionary.
         """
-        self.source_regions = source_regions
+        self._source_regions = regions

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+from mash.services.mash_job import MashJob
+
+
+class TestMashJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'last_service': 'testing',
+            'provider': 'ec2',
+            'utctime': 'now'
+        }
+
+    def test_valid_job(self):
+        job = MashJob(**self.job_config)
+
+        assert job.id == '1'
+        assert job.provider == 'ec2'
+        assert job.utctime == 'now'
+
+    def test_send_log(self):
+        callback = Mock()
+
+        job = MashJob(**self.job_config)
+        job.log_callback = callback
+        job.iteration_count = 0
+
+        job.send_log('Starting publish.')
+
+        callback.assert_called_once_with(
+            'Pass[0]: Starting publish.',
+            {'job_id': '1'},
+            True
+        )
+
+    def test_job_get_metadata(self):
+        job = MashJob(**self.job_config)
+        metadata = job.get_metadata()
+        assert metadata == {'job_id': '1'}
+
+    def test_set_cloud_image_name(self):
+        job = MashJob(**self.job_config)
+        job.cloud_image_name = 'name123'
+        assert job.cloud_image_name == 'name123'
+
+    def test_set_log_callback(self):
+        job = MashJob(**self.job_config)
+        callback = Mock()
+        job.log_callback = callback
+
+        assert job.log_callback == callback

--- a/test/unit/services/deprecation/job_test.py
+++ b/test/unit/services/deprecation/job_test.py
@@ -20,43 +20,10 @@ class TestDeprecationJob(object):
         assert job.provider == 'ec2'
         assert job.utctime == 'now'
 
-    def test_job_get_metadata(self):
-        job = DeprecationJob(**self.job_config)
-        metadata = job.get_metadata()
-        assert metadata == {'job_id': '1'}
-
     def test_deprecate(self):
         job = DeprecationJob(**self.job_config)
         with raises(NotImplementedError):
             job._deprecate()
-
-    def test_send_log(self):
-        callback = Mock()
-
-        job = DeprecationJob(**self.job_config)
-        job.log_callback = callback
-        job.iteration_count = 0
-
-        job.send_log('Starting deprecation.')
-
-        callback.assert_called_once_with(
-            'Pass[0]: Starting deprecation.',
-            {'job_id': '1'},
-            True
-        )
-
-    def test_set_cloud_image_name(self):
-        job = DeprecationJob(**self.job_config)
-        job.set_cloud_image_name('name123')
-        assert job.cloud_image_name == 'name123'
-
-    def test_set_log_callback(self):
-        test = Mock()
-
-        job = DeprecationJob(**self.job_config)
-        job.set_log_callback(test.method)
-
-        assert job.log_callback == test.method
 
     @patch.object(DeprecationJob, '_deprecate')
     def test_deprecate_image(self, mock_deprecate):

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -129,9 +129,7 @@ class TestPipelineService(object):
         self.service._create_job(job_class, job_config)
 
         job_class.assert_called_once_with(id='1', provider='ec2')
-        job.set_log_callback.assert_called_once_with(
-            self.service.log_job_message
-        )
+        assert job.log_callback == self.service.log_job_message
         assert job.job_file == 'temp-config.json'
         self.service.log.info.assert_called_once_with(
             'Job queued, awaiting listener message.',

--- a/test/unit/services/publisher/job_test.py
+++ b/test/unit/services/publisher/job_test.py
@@ -26,43 +26,10 @@ class TestPublisherJob(object):
         assert job.provider == 'ec2'
         assert job.utctime == 'now'
 
-    def test_job_get_metadata(self):
-        job = PublisherJob(**self.job_config)
-        metadata = job.get_metadata()
-        assert metadata == {'job_id': '1'}
-
     def test_publish(self):
         job = PublisherJob(**self.job_config)
         with raises(NotImplementedError):
             job._publish()
-
-    def test_send_log(self):
-        callback = Mock()
-
-        job = PublisherJob(**self.job_config)
-        job.log_callback = callback
-        job.iteration_count = 0
-
-        job.send_log('Starting publish.')
-
-        callback.assert_called_once_with(
-            'Pass[0]: Starting publish.',
-            {'job_id': '1'},
-            True
-        )
-
-    def test_set_cloud_image_name(self):
-        job = PublisherJob(**self.job_config)
-        job.set_cloud_image_name('name123')
-        assert job.cloud_image_name == 'name123'
-
-    def test_set_log_callback(self):
-        test = Mock()
-
-        job = PublisherJob(**self.job_config)
-        job.set_log_callback(test.method)
-
-        assert job.log_callback == test.method
 
     @patch.object(PublisherJob, '_publish')
     def test_publish_image(self, mock_publish):

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -20,47 +20,14 @@ class TestReplicationJob(object):
         assert job.provider == 'ec2'
         assert job.utctime == 'now'
 
-    def test_job_get_metadata(self):
-        job = ReplicationJob(**self.job_config)
-        metadata = job.get_metadata()
-        assert metadata == {'job_id': '1'}
-
     def test_replicate(self):
         job = ReplicationJob(**self.job_config)
         with raises(NotImplementedError):
             job._replicate()
 
-    def test_send_log(self):
-        callback = Mock()
-
-        job = ReplicationJob(**self.job_config)
-        job.log_callback = callback
-        job.iteration_count = 0
-
-        job.send_log('Starting replicate.')
-
-        callback.assert_called_once_with(
-            'Pass[0]: Starting replicate.',
-            {'job_id': '1'},
-            True
-        )
-
-    def test_set_cloud_image_name(self):
-        job = ReplicationJob(**self.job_config)
-        job.set_cloud_image_name('name123')
-        assert job.cloud_image_name == 'name123'
-
-    def test_set_log_callback(self):
-        test = Mock()
-
-        job = ReplicationJob(**self.job_config)
-        job.set_log_callback(test.method)
-
-        assert job.log_callback == test.method
-
     def test_source_regions(self):
         job = ReplicationJob(**self.job_config)
-        job.set_source_regions({'west': 'ami-123'})
+        job.source_regions = {'west': 'ami-123'}
         assert job.source_regions['west'] == 'ami-123'
 
     @patch.object(ReplicationJob, '_replicate')

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -25,11 +25,6 @@ class TestTestingJob(object):
         assert job.tests == ['test_stuff']
         assert job.utctime == 'now'
 
-    def test_job_get_metadata(self):
-        job = TestingJob(**self.job_config)
-        metadata = job.get_metadata()
-        assert metadata == {'job_id': '1'}
-
     def test_add_provider_creds(self):
         job = TestingJob(**self.job_config)
         with raises(NotImplementedError):
@@ -38,21 +33,9 @@ class TestTestingJob(object):
                 {}
             )
 
-    def test_set_cloud_image_name(self):
-        job = TestingJob(**self.job_config)
-        job.set_cloud_image_name('name123')
-        assert job.cloud_image_name == 'name123'
-
-    def test_set_log_callback(self):
-        job = TestingJob(**self.job_config)
-        callback = Mock()
-        job.set_log_callback(callback)
-
-        assert job.log_callback == callback
-
     def test_source_regions(self):
         job = TestingJob(**self.job_config)
-        job.set_source_regions({'west': 'ami-123'})
+        job.source_regions = {'west': 'ami-123'}
         assert job.source_regions['west'] == 'ami-123'
 
     @patch.object(TestingJob, '_run_tests')


### PR DESCRIPTION
Use python properties for values set in jobs after instantiation (cloud_image_name, log_callback, source_regions).

Fixes #110 