### PR TITLE
Update max workers default.

### DIFF
--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -70,4 +70,4 @@ class Defaults(object):
 
     @staticmethod
     def get_azure_max_workers():
-        return 16
+        return 5

--- a/test/unit/services/base/defaults_test.py
+++ b/test/unit/services/base/defaults_test.py
@@ -18,4 +18,4 @@ def test_get_log_directory():
 
 def test_get_azure_max_workers():
     max_workers = Defaults.get_azure_max_workers()
-    assert max_workers == 16
+    assert max_workers == 5


### PR DESCRIPTION
Max connections defaults to 10 in pool so max workers at 16 causes continuous connection drops during upload.