### PR TITLE
Remove timeout from Azure copy blob function.

### DIFF
--- a/mash/services/replication/azure_utils.py
+++ b/mash/services/replication/azure_utils.py
@@ -38,7 +38,7 @@ from mash.utils.json_format import JsonFormat
 def copy_blob_to_classic_storage(
     auth_file, blob_name, source_container, source_resource_group,
     source_storage_account, destination_container, destination_resource_group,
-    destination_storage_account, timeout=1200
+    destination_storage_account
 ):
     """
     Copy a blob from ARM based storage account to a classic storage account.
@@ -63,10 +63,7 @@ def copy_blob_to_classic_storage(
         source_blob_url
     )
 
-    start = time.time()
-    end = start + timeout
-
-    while time.time() < end:
+    while True:
         if copy.status == 'success':
             return
         elif copy.status == 'failed':
@@ -74,17 +71,11 @@ def copy_blob_to_classic_storage(
                 'Azure blob copy failed.'
             )
         else:
-            time.sleep(30)
-
-        copy = page_blob_service.get_blob_properties(
-            destination_container,
-            blob_name
-        ).properties.copy
-
-    raise MashReplicationException(
-        'Time out waiting for async copy to complete. Copy may not have'
-        ' completed successfully.'
-    )
+            time.sleep(60)
+            copy = page_blob_service.get_blob_properties(
+                destination_container,
+                blob_name
+            ).properties.copy
 
 
 def delete_page_blob(

--- a/test/unit/services/replication/azure_utils_test.py
+++ b/test/unit/services/replication/azure_utils_test.py
@@ -178,35 +178,6 @@ def test_copy_blob_to_classic_storage_failed(
     assert str(error.value) == 'Azure blob copy failed.'
 
 
-@patch('mash.services.replication.azure_utils.get_blob_url')
-@patch('mash.services.replication.azure_utils.get_classic_storage_account_keys')
-@patch('mash.services.replication.azure_utils.time.sleep')
-@patch('mash.services.replication.azure_utils.PageBlobService')
-def test_copy_blob_to_classic_storage_timeout(
-    mock_page_blob_service, mock_time, mock_get_keys, mock_get_blob_url
-):
-    mock_get_blob_url.return_value = 'https://test/url/?token123'
-    keys = {'primaryKey': '123456'}
-    mock_get_keys.return_value = keys
-
-    copy = MagicMock()
-    copy.status = 'pending'
-
-    props_copy = MagicMock()
-    props_copy.properties.copy.status = 'success'
-
-    page_blob_service = MagicMock()
-    page_blob_service.copy_blob.return_value = copy
-    page_blob_service.get_blob_properties.return_value = props_copy
-    mock_page_blob_service.return_value = page_blob_service
-
-    with raises(MashReplicationException):
-        copy_blob_to_classic_storage(
-            '../data/azure_creds.json', 'blob1', 'sc1', 'srg1', 'ssa1',
-            'dc2', 'drg2', 'dsa2', timeout=0
-        )
-
-
 @patch('mash.services.replication.azure_utils.get_page_blob_service')
 def test_delete_page_blob(mock_get_page_blob_service):
     page_blob_service = MagicMock()


### PR DESCRIPTION
The copy process is inconsistent and if it fails there is an exception raised.