### PR TITLE
Add cleanup_images option.

### DIFF
--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -17,6 +17,7 @@
 #
 
 from mash.services.jobcreator.base_job import BaseJob
+from mash.utils.json_format import JsonFormat
 
 
 class AzureJob(BaseJob):
@@ -28,7 +29,7 @@ class AzureJob(BaseJob):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, image_description, distro,
         download_url, tests, conditions=None, instance_type=None,
-        old_cloud_image_name=None
+        old_cloud_image_name=None, cleanup_images=True
     ):
         self.target_account_info = {}
 
@@ -36,7 +37,7 @@ class AzureJob(BaseJob):
             accounts_info, provider_data, job_id, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name
+            conditions, instance_type, old_cloud_image_name, cleanup_images
         )
 
     def _get_account_info(self):
@@ -132,6 +133,23 @@ class AzureJob(BaseJob):
         Return a list of publisher region info.
         """
         raise NotImplementedError('TODO')
+
+    def get_replication_message(self):
+        """
+        Build replication job message and publish to replication exchange.
+        """
+        replication_message = {
+            'replication_job': {
+                'cleanup_images': self.cleanup_images,
+                'image_description': self.image_description,
+                'provider': self.provider,
+                'replication_source_regions':
+                    self.get_replication_source_regions()
+            }
+        }
+        replication_message['replication_job'].update(self.base_message)
+
+        return JsonFormat.json_message(replication_message)
 
     def get_replication_source_regions(self):
         """

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -30,7 +30,7 @@ class BaseJob(object):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, image_description, distro,
         download_url, tests, conditions=None, instance_type=None,
-        old_cloud_image_name=None
+        old_cloud_image_name=None, cleanup_images=True
     ):
         self.id = job_id
         self.accounts_info = accounts_info
@@ -46,6 +46,7 @@ class BaseJob(object):
         self.image_description = image_description
         self.distro = distro
         self.tests = tests
+        self.cleanup_images = cleanup_images
         self.conditions = conditions
         self.download_url = download_url
         self.instance_type = instance_type
@@ -165,17 +166,7 @@ class BaseJob(object):
         """
         Build replication job message and publish to replication exchange.
         """
-        replication_message = {
-            'replication_job': {
-                'image_description': self.image_description,
-                'provider': self.provider,
-                'replication_source_regions':
-                    self.get_replication_source_regions()
-            }
-        }
-        replication_message['replication_job'].update(self.base_message)
-
-        return JsonFormat.json_message(replication_message)
+        pass
 
     def get_replication_source_regions(self):
         """

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -33,7 +33,8 @@ class EC2Job(BaseJob):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, image_description, distro,
         download_url, tests, allow_copy=False, conditions=None,
-        instance_type=None, share_with='none', old_cloud_image_name=None
+        instance_type=None, share_with='none', old_cloud_image_name=None,
+        cleanup_images=True
     ):
         self.share_with = share_with
         self.allow_copy = allow_copy
@@ -43,7 +44,7 @@ class EC2Job(BaseJob):
             accounts_info, provider_data, job_id, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name
+            conditions, instance_type, old_cloud_image_name, cleanup_images
         )
 
     def _get_account_info(self):
@@ -156,6 +157,22 @@ class EC2Job(BaseJob):
         Return a list of publisher region info.
         """
         return self._get_target_regions_list()
+
+    def get_replication_message(self):
+        """
+        Build replication job message and publish to replication exchange.
+        """
+        replication_message = {
+            'replication_job': {
+                'image_description': self.image_description,
+                'provider': self.provider,
+                'replication_source_regions':
+                    self.get_replication_source_regions()
+            }
+        }
+        replication_message['replication_job'].update(self.base_message)
+
+        return JsonFormat.json_message(replication_message)
 
     def get_replication_source_regions(self):
         """

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -29,7 +29,7 @@ class GCEJob(BaseJob):
         provider_accounts, provider_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, image_description, distro,
         download_url, tests, conditions=None, instance_type=None, family=None,
-        old_cloud_image_name=None
+        old_cloud_image_name=None, cleanup_images=True
     ):
         self.family = family
         self.target_account_info = {}
@@ -38,7 +38,7 @@ class GCEJob(BaseJob):
             accounts_info, provider_data, job_id, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name
+            conditions, instance_type, old_cloud_image_name, cleanup_images
         )
 
     def _get_account_info(self):
@@ -112,6 +112,21 @@ class GCEJob(BaseJob):
         Return a list of publisher region info.
         """
         return []  # No publishing in GCE
+
+    def get_replication_message(self):
+        """
+        Build replication job message and publish to replication exchange.
+        """
+        replication_message = {
+            'replication_job': {
+                'provider': self.provider,
+                'replication_source_regions':
+                    self.get_replication_source_regions()
+            }
+        }
+        replication_message['replication_job'].update(self.base_message)
+
+        return JsonFormat.json_message(replication_message)
 
     def get_replication_source_regions(self):
         """

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -99,19 +99,12 @@ class GCEJob(BaseJob):
         """
         publisher_message = {
             'publisher_job': {
-                'provider': self.provider,
-                'publish_regions': self.get_publisher_regions()
+                'provider': self.provider
             }
         }
         publisher_message['publisher_job'].update(self.base_message)
 
         return JsonFormat.json_message(publisher_message)
-
-    def get_publisher_regions(self):
-        """
-        Return a list of publisher region info.
-        """
-        return []  # No publishing in GCE
 
     def get_replication_message(self):
         """
@@ -119,20 +112,12 @@ class GCEJob(BaseJob):
         """
         replication_message = {
             'replication_job': {
-                'provider': self.provider,
-                'replication_source_regions':
-                    self.get_replication_source_regions()
+                'provider': self.provider
             }
         }
         replication_message['replication_job'].update(self.base_message)
 
         return JsonFormat.json_message(replication_message)
-
-    def get_replication_source_regions(self):
-        """
-        Return a dictionary of replication source regions.
-        """
-        return {}  # No replication in GCE
 
     def get_testing_regions(self):
         """

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -246,7 +246,8 @@ base_job_message = {
             'type': 'array',
             'items': {'$ref': '#/definitions/non_empty_string'},
             'minItems': 1
-        }
+        },
+        'cleanup_images': {'type': 'boolean'}
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -33,10 +33,11 @@ class EC2PublisherJob(PublisherJob):
         allow_copy=False, job_file=None, share_with='all'
     ):
         super(EC2PublisherJob, self).__init__(
-            id, last_service, provider, publish_regions, utctime,
-            job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
+
         self.allow_copy = allow_copy
+        self.publish_regions = publish_regions
         self.share_with = share_with
 
     def _publish(self):

--- a/mash/services/publisher/gce_job.py
+++ b/mash/services/publisher/gce_job.py
@@ -26,12 +26,10 @@ class GCEPublisherJob(PublisherJob):
     """
 
     def __init__(
-        self, id, last_service, provider, publish_regions, utctime,
-        job_file=None
+        self, id, last_service, provider, utctime, job_file=None
     ):
         super(GCEPublisherJob, self).__init__(
-            id, last_service, provider, publish_regions, utctime,
-            job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
 
     def _publish(self):

--- a/mash/services/publisher/job.py
+++ b/mash/services/publisher/job.py
@@ -26,14 +26,11 @@ class PublisherJob(MashJob):
     """
 
     def __init__(
-        self, id, last_service, provider, publish_regions, utctime,
-        job_file=None
+        self, id, last_service, provider, utctime, job_file=None
     ):
         super(PublisherJob, self).__init__(
             id, last_service, provider, utctime, job_file
         )
-
-        self.publish_regions = publish_regions
 
     def _publish(self):
         """

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -34,12 +34,14 @@ class AzureReplicationJob(ReplicationJob):
 
     def __init__(
         self, id, image_description, last_service, provider, utctime,
-        replication_source_regions, job_file=None
+        replication_source_regions, cleanup_images=True, job_file=None
     ):
         super(AzureReplicationJob, self).__init__(
             id, image_description, last_service, provider, utctime,
             replication_source_regions, job_file=job_file
         )
+
+        self.cleanup_images = cleanup_images
 
     def _replicate(self):
         """
@@ -78,18 +80,26 @@ class AzureReplicationJob(ReplicationJob):
                         reg_info['destination_resource_group'],
                         reg_info['destination_storage_account']
                     )
-                    delete_image(
-                        auth_file,
-                        reg_info['source_resource_group'],
-                        self.cloud_image_name
-                    )
-                    delete_page_blob(
-                        auth_file,
-                        blob_name,
-                        reg_info['source_container'],
-                        reg_info['source_resource_group'],
-                        reg_info['source_storage_account']
-                    )
+
+                    if self.cleanup_images:
+                        self.send_log(
+                            'Removing ARM image and page blob for account:'
+                            ' {}.'.format(
+                                reg_info['account']
+                            )
+                        )
+                        delete_image(
+                            auth_file,
+                            reg_info['source_resource_group'],
+                            self.cloud_image_name
+                        )
+                        delete_page_blob(
+                            auth_file,
+                            blob_name,
+                            reg_info['source_container'],
+                            reg_info['source_resource_group'],
+                            reg_info['source_storage_account']
+                        )
                 except Exception as error:
                     self.send_log(
                         'There was an error copying image blob in {0}:'

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -37,11 +37,12 @@ class AzureReplicationJob(ReplicationJob):
         replication_source_regions, cleanup_images=True, job_file=None
     ):
         super(AzureReplicationJob, self).__init__(
-            id, image_description, last_service, provider, utctime,
-            replication_source_regions, job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
 
         self.cleanup_images = cleanup_images
+        self.image_description = image_description
+        self.replication_source_regions = replication_source_regions
 
     def _replicate(self):
         """

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -36,9 +36,11 @@ class EC2ReplicationJob(ReplicationJob):
         replication_source_regions, job_file=None
     ):
         super(EC2ReplicationJob, self).__init__(
-            id, image_description, last_service, provider, utctime,
-            replication_source_regions, job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
+
+        self.image_description = image_description
+        self.replication_source_regions = replication_source_regions
         self.source_region_results = defaultdict(dict)
 
     def _replicate(self):

--- a/mash/services/replication/gce_job.py
+++ b/mash/services/replication/gce_job.py
@@ -26,12 +26,10 @@ class GCEReplicationJob(ReplicationJob):
     """
 
     def __init__(
-        self, id, image_description, last_service, provider, utctime,
-        replication_source_regions, job_file=None
+        self, id, last_service, provider, utctime, job_file=None
     ):
         super(GCEReplicationJob, self).__init__(
-            id, image_description, last_service, provider, utctime,
-            replication_source_regions, job_file=job_file
+            id, last_service, provider, utctime, job_file=job_file
         )
 
     def _replicate(self):

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -26,17 +26,13 @@ class ReplicationJob(MashJob):
     """
 
     def __init__(
-        self, id, image_description, last_service, provider, utctime,
-        replication_source_regions, job_file=None
+        self, id, last_service, provider, utctime, job_file=None
     ):
         super(ReplicationJob, self).__init__(
             id, last_service, provider, utctime, job_file
         )
 
         self._source_regions = None
-
-        self.image_description = image_description
-        self.replication_source_regions = replication_source_regions
 
     def _replicate(self):
         """

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -21,5 +21,6 @@
   "image_description": "New Image #123",
   "distro": "sles",
   "instance_type": "t2.micro",
-  "tests": ["test_stuff"]
+  "tests": ["test_stuff"],
+  "cleanup_images": true
 }

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -17,6 +17,7 @@ class TestJobCreatorBaseJob(object):
         self.job._get_account_info()
         self.job.get_deprecation_regions()
         self.job.get_publisher_message()
+        self.job.get_replication_message()
         self.job.get_replication_source_regions()
         self.job.get_testing_regions()
         self.job.get_uploader_regions()

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -401,6 +401,7 @@ class TestJobCreatorService(object):
             'replication', 'job_document',
             JsonFormat.json_message({
                 "replication_job": {
+                    "cleanup_images": True,
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "replication",
@@ -546,7 +547,6 @@ class TestJobCreatorService(object):
             JsonFormat.json_message({
                 "replication_job": {
                     "id": "12345678-1234-1234-1234-123456789012",
-                    "image_description": "New Image #123",
                     "last_service": "publisher",
                     "provider": "gce",
                     "replication_source_regions": {},

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -549,7 +549,6 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "last_service": "publisher",
                     "provider": "gce",
-                    "replication_source_regions": {},
                     "utctime": "now"
                 }
             })
@@ -561,7 +560,6 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "last_service": "publisher",
                     "provider": "gce",
-                    "publish_regions": [],
                     "utctime": "now"
                 }
             })

--- a/test/unit/services/publisher/gce_job_test.py
+++ b/test/unit/services/publisher/gce_job_test.py
@@ -7,7 +7,6 @@ class TestGCEPublisherJob(object):
             'id': '1',
             'last_service': 'publisher',
             'provider': 'ec2',
-            'publish_regions': [],
             'utctime': 'now'
         }
 

--- a/test/unit/services/publisher/job_test.py
+++ b/test/unit/services/publisher/job_test.py
@@ -10,12 +10,6 @@ class TestPublisherJob(object):
             'id': '1',
             'last_service': 'publisher',
             'provider': 'ec2',
-            'publish_regions': [
-                {
-                    'account': 'test-aws',
-                    'target_regions': ['us-east-2']
-                }
-            ],
             'utctime': 'now'
         }
 

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -22,7 +22,8 @@ class TestAzureReplicationJob(object):
                     'destination_container': 'container2',
                     'destination_storage_account': 'sa2'
                 }
-            }
+            },
+            "cleanup_images": True
         }
         self.job = AzureReplicationJob(**self.job_config)
 

--- a/test/unit/services/replication/gce_job_test.py
+++ b/test/unit/services/replication/gce_job_test.py
@@ -5,11 +5,9 @@ class TestGCEReplicationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
-            'image_description': 'test image',
             'last_service': 'replication',
             'provider': 'gce',
-            'utctime': 'now',
-            'replication_source_regions': {}
+            'utctime': 'now'
         }
         self.job = GCEReplicationJob(**self.job_config)
 

--- a/test/unit/services/replication/gce_job_test.py
+++ b/test/unit/services/replication/gce_job_test.py
@@ -9,7 +9,7 @@ class TestGCEReplicationJob(object):
             'last_service': 'replication',
             'provider': 'gce',
             'utctime': 'now',
-            "replication_source_regions": {}
+            'replication_source_regions': {}
         }
         self.job = GCEReplicationJob(**self.job_config)
 

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -8,16 +8,9 @@ class TestReplicationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
-            'image_description': 'test image',
             'last_service': 'replication',
             'provider': 'ec2',
-            'utctime': 'now',
-            'replication_source_regions': {
-                'us-east-1': {
-                    'account': 'test-aws',
-                    'target_regions': ['us-east-2']
-                }
-            }
+            'utctime': 'now'
         }
 
     def test_valid_job(self):


### PR DESCRIPTION
Pass option to replication jobs, Azure replication copies images from ARM to ASM and the ARM image artifacts are removed by default. They can be preserved by providing `cleanup_images==False`.

Resolves #376 