### PR TITLE
Wait for obs conditions to be met.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -291,38 +291,48 @@ class OBSImageBuildResult(object):
     def _update_image_status(self):
         try:
             self.iteration_count += 1
+            conditions_fail_logged = False
             self._log_callback('Job running')
-            packages = self._lookup_image_packages_metadata()
-            for condition in self.image_status['conditions']:
-                if 'image' in condition:
-                    if self.image_status['version'] == condition['image']:
-                        condition['status'] = True
-                    else:
-                        condition['status'] = False
-                elif 'package' in condition:
-                    if self._lookup_package(packages, condition['package']):
-                        condition['status'] = True
-                    else:
-                        condition['status'] = False
 
-            if self._image_conditions_complied():
-                packages_digest = hashlib.md5()
-                packages_digest.update(format(packages).encode())
-                packages_checksum = packages_digest.hexdigest()
-                if packages_checksum != self.image_status['packages_checksum']:
-                    self._log_callback('Downloading image...')
-                    self.image_status['packages_checksum'] = 'unknown'
-                    self.image_status['image_source'] = self.get_image()
-                    self._log_callback(
-                        'Downloaded: {0}'.format(
-                            self.image_status['image_source']
+            while True:
+                packages = self._lookup_image_packages_metadata()
+                for condition in self.image_status['conditions']:
+                    if 'image' in condition:
+                        if self.image_status['version'] == condition['image']:
+                            condition['status'] = True
+                        else:
+                            condition['status'] = False
+                    elif 'package' in condition:
+                        if self._lookup_package(
+                            packages, condition['package']
+                        ):
+                            condition['status'] = True
+                        else:
+                            condition['status'] = False
+
+                if self._image_conditions_complied():
+                    packages_digest = hashlib.md5()
+                    packages_digest.update(format(packages).encode())
+                    packages_checksum = packages_digest.hexdigest()
+                    if packages_checksum != \
+                            self.image_status['packages_checksum']:
+                        self._log_callback('Downloading image...')
+                        self.image_status['packages_checksum'] = 'unknown'
+                        self.image_status['image_source'] = self.get_image()
+                        self._log_callback(
+                            'Downloaded: {0}'.format(
+                                self.image_status['image_source']
+                            )
                         )
-                    )
-                self.image_status['packages_checksum'] = packages_checksum
-                self.image_status['job_status'] = 'success'
-            else:
-                self._log_callback('Unaccomplished job download conditions')
-                self.image_status['job_status'] = 'failed'
+                    self.image_status['packages_checksum'] = packages_checksum
+                    self.image_status['job_status'] = 'success'
+                    break
+                else:
+                    if not conditions_fail_logged:
+                        self._log_callback('Waiting for conditions to be met.')
+                        conditions_fail_logged = True
+
+                    time.sleep(120)
 
             self._log_callback(
                 'Job status: {0}'.format(self.image_status['job_status'])

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -332,7 +332,7 @@ class OBSImageBuildResult(object):
                         self._log_callback('Waiting for conditions to be met.')
                         conditions_fail_logged = True
 
-                    time.sleep(120)
+                    time.sleep(300)
 
             self._log_callback(
                 'Job status: {0}'.format(self.image_status['job_status'])

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -229,6 +229,7 @@ class TestOBSImageBuildResult(object):
         self.obs_result.image_status['conditions'] = [{'status': False}]
         assert self.obs_result._image_conditions_complied() is False
 
+    @patch('mash.services.obs.build_result.time')
     @patch.object(OBSImageBuildResult, '_log_callback')
     @patch.object(OBSImageBuildResult, '_result_callback')
     @patch.object(OBSImageBuildResult, '_lookup_image_packages_metadata')
@@ -240,7 +241,7 @@ class TestOBSImageBuildResult(object):
         self, mock_get_image, mock_wait_for_new_image,
         mock_image_conditions_complied, mock_lookup_package,
         mock_lookup_image_packages_metadata,
-        mock_result_callback, mock_log_callback
+        mock_result_callback, mock_log_callback, mock_time
     ):
         self.obs_result.image_status['version'] = '1.2.3'
         self.obs_result.image_status['conditions'] = [
@@ -281,10 +282,9 @@ class TestOBSImageBuildResult(object):
         mock_wait_for_new_image.assert_called_once_with()
 
         self.obs_result.image_status['version'] = '7.7.7'
-        mock_lookup_package.return_value = False
-        mock_image_conditions_complied.return_value = False
+        mock_lookup_package.side_effect = [False, True]
+        mock_image_conditions_complied.side_effect = [False, True]
         self.obs_result._update_image_status()
-        assert self.obs_result.image_status['job_status'] == 'failed'
 
     @patch.object(OBSImageBuildResult, '_log_callback')
     @patch.object(OBSImageBuildResult, '_lookup_image_packages_metadata')


### PR DESCRIPTION
Rather than fail eagerly. Log only once that obs service is waiting on conditions for given job.

Fixes #378