### PR TITLE
Add GCE handling to replication and publisher

### DIFF
--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -17,6 +17,7 @@
 #
 
 from mash.services.jobcreator.base_job import BaseJob
+from mash.utils.json_format import JsonFormat
 
 
 class GCEJob(BaseJob):
@@ -97,19 +98,26 @@ class GCEJob(BaseJob):
         """
         Build publisher job message.
         """
-        raise NotImplementedError('TODO')
+        publisher_message = {
+            'publisher_job': {
+                'provider': self.provider
+            }
+        }
+        publisher_message['publisher_job'].update(self.base_message)
+
+        return JsonFormat.json_message(publisher_message)
 
     def get_publisher_regions(self):
         """
         Return a list of publisher region info.
         """
-        raise NotImplementedError('TODO')
+        return {}  # No publishing in GCE
 
     def get_replication_source_regions(self):
         """
         Return a dictionary of replication source regions.
         """
-        raise NotImplementedError('TODO')
+        return {}  # No replication in GCE
 
     def get_testing_regions(self):
         """

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -100,7 +100,8 @@ class GCEJob(BaseJob):
         """
         publisher_message = {
             'publisher_job': {
-                'provider': self.provider
+                'provider': self.provider,
+                'publish_regions': self.get_publisher_regions()
             }
         }
         publisher_message['publisher_job'].update(self.base_message)
@@ -111,7 +112,7 @@ class GCEJob(BaseJob):
         """
         Return a list of publisher region info.
         """
-        return {}  # No publishing in GCE
+        return []  # No publishing in GCE
 
     def get_replication_source_regions(self):
         """

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -30,11 +30,11 @@ class MashJob(object):
         self._cloud_image_name = None
         self._credentials = None
         self._log_callback = None
+        self._job_file = job_file
 
         self.iteration_count = 0
         self.status = UNKOWN
 
-        self.job_file = job_file
         self.id = id
         self.last_service = last_service
         self.provider = provider
@@ -81,6 +81,16 @@ class MashJob(object):
     def credentials(self, creds):
         """Setter for credentials."""
         self._credentials = creds
+
+    @property
+    def job_file(self):
+        """Job file property."""
+        return self._job_file
+
+    @job_file.setter
+    def job_file(self, file):
+        """Setter for job file."""
+        self._job_file = file
 
     @property
     def log_callback(self):

--- a/mash/services/publisher/gce_job.py
+++ b/mash/services/publisher/gce_job.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.publisher.job import PublisherJob
+from mash.services.status_levels import SUCCESS
+
+
+class GCEPublisherJob(PublisherJob):
+    """
+    Class for an GCE publishing job.
+    """
+
+    def __init__(
+        self, id, last_service, provider, publish_regions, utctime,
+        job_file=None
+    ):
+        super(GCEPublisherJob, self).__init__(
+            id, last_service, provider, publish_regions, utctime,
+            job_file=job_file
+        )
+
+    def _publish(self):
+        """
+        No publishing in GCE.
+        """
+        self.status = SUCCESS

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -20,6 +20,7 @@ from mash.csp import CSP
 from mash.services.pipeline_service import PipelineService
 from mash.services.status_levels import SUCCESS
 from mash.services.publisher.ec2_job import EC2PublisherJob
+from mash.services.publisher.gce_job import GCEPublisherJob
 from mash.utils.json_format import JsonFormat
 
 
@@ -43,6 +44,8 @@ class PublisherService(PipelineService):
             )
         elif provider == CSP.ec2:
             self._create_job(EC2PublisherJob, job_config)
+        elif provider == CSP.gce:
+            self._create_job(GCEPublisherJob, job_config)
         else:
             self.log.error(
                 'Provider {0} is not supported.'.format(provider)

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -37,12 +37,9 @@ class AzureReplicationJob(ReplicationJob):
         replication_source_regions, job_file=None
     ):
         super(AzureReplicationJob, self).__init__(
-            id, last_service, provider, utctime, job_file=job_file
+            id, image_description, last_service, provider, utctime,
+            replication_source_regions, job_file=job_file
         )
-        self.credentials = None
-        self.image_description = image_description
-        self.job_file = job_file
-        self.replication_source_regions = replication_source_regions
 
     def _replicate(self):
         """

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -36,13 +36,10 @@ class EC2ReplicationJob(ReplicationJob):
         replication_source_regions, job_file=None
     ):
         super(EC2ReplicationJob, self).__init__(
-            id, last_service, provider, utctime, job_file=job_file
+            id, image_description, last_service, provider, utctime,
+            replication_source_regions, job_file=job_file
         )
-        self.credentials = None
-        self.image_description = image_description
-        self.job_file = job_file
         self.source_region_results = defaultdict(dict)
-        self.replication_source_regions = replication_source_regions
 
     def _replicate(self):
         """

--- a/mash/services/replication/gce_job.py
+++ b/mash/services/replication/gce_job.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.replication.job import ReplicationJob
+from mash.services.status_levels import SUCCESS
+
+
+class GCEReplicationJob(ReplicationJob):
+    """
+    Class for an GCE replication job.
+    """
+
+    def __init__(
+        self, id, image_description, last_service, provider, utctime,
+        replication_source_regions, job_file=None
+    ):
+        super(GCEReplicationJob, self).__init__(
+            id, image_description, last_service, provider, utctime,
+            replication_source_regions, job_file=job_file
+        )
+
+    def _replicate(self):
+        """
+        No replication in GCE.
+        """
+        self.status = SUCCESS

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -26,13 +26,17 @@ class ReplicationJob(MashJob):
     """
 
     def __init__(
-        self, id, last_service, provider, utctime, job_file=None
+        self, id, image_description, last_service, provider, utctime,
+        replication_source_regions, job_file=None
     ):
         super(ReplicationJob, self).__init__(
             id, last_service, provider, utctime, job_file
         )
 
         self._source_regions = None
+
+        self.image_description = image_description
+        self.replication_source_regions = replication_source_regions
 
     def _replicate(self):
         """

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -21,6 +21,7 @@ from mash.services.pipeline_service import PipelineService
 from mash.services.status_levels import SUCCESS
 from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
+from mash.services.replication.gce_job import GCEReplicationJob
 from mash.utils.json_format import JsonFormat
 
 
@@ -46,6 +47,8 @@ class ReplicationService(PipelineService):
             self._create_job(EC2ReplicationJob, job_config)
         elif provider == CSP.azure:
             self._create_job(AzureReplicationJob, job_config)
+        elif provider == CSP.gce:
+            self._create_job(GCEReplicationJob, job_config)
         else:
             self.log.error(
                 'Provider {0} is not supported.'.format(provider)

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -10,7 +10,7 @@
   ],
   "provider_groups": ["test-gce-group"],
   "requesting_user": "user1",
-  "last_service": "testing",
+  "last_service": "publisher",
   "utctime": "now",
   "image": "test_image_oem",
   "cloud_image_name": "new_image_123",

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -39,6 +39,11 @@ class TestMashJob(object):
         metadata = job.get_job_id()
         assert metadata == {'job_id': '1'}
 
+    def test_job_file_property(self):
+        job = MashJob(**self.job_config)
+        job.job_file = 'test.file'
+        assert job.job_file == 'test.file'
+
     def test_set_cloud_image_name(self):
         job = MashJob(**self.job_config)
         job.cloud_image_name = 'name123'

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -28,6 +28,3 @@ class TestJobCreatorGCEJob(object):
             getattr(self.job, method)()
 
         assert 'TODO' == str(error.value)
-
-    def test_test_get_publisher_regions(self):
-        assert self.job.get_publisher_regions() == {}

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -19,10 +19,7 @@ class TestJobCreatorGCEJob(object):
     @pytest.mark.parametrize(
         'method',
         [
-            'get_deprecation_regions',
-            'get_publisher_message',
-            'get_publisher_regions',
-            'get_replication_source_regions'
+            'get_deprecation_regions'
         ]
     )
     def test_not_implemented_methods(self, method):
@@ -31,3 +28,6 @@ class TestJobCreatorGCEJob(object):
             getattr(self.job, method)()
 
         assert 'TODO' == str(error.value)
+
+    def test_test_get_publisher_regions(self):
+        assert self.job.get_publisher_regions() == {}

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -561,6 +561,7 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "last_service": "publisher",
                     "provider": "gce",
+                    "publish_regions": [],
                     "utctime": "now"
                 }
             })

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -474,7 +474,7 @@ class TestJobCreatorService(object):
         msg = mock_publish.mock_calls[0][1][2]
         data = json.loads(msg)['credentials_job']
         assert data['id'] == '12345678-1234-1234-1234-123456789012'
-        assert data['last_service'] == 'testing'
+        assert data['last_service'] == 'publisher'
         assert data['provider'] == 'gce'
         assert 'test-gce' in data['provider_accounts']
         assert 'test-gce2' in data['provider_accounts']
@@ -493,7 +493,7 @@ class TestJobCreatorService(object):
                                     "repositories/Cloud:Tools/images",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
-                    "last_service": "testing",
+                    "last_service": "publisher",
                     "utctime": "now"
                 }
             })
@@ -505,7 +505,7 @@ class TestJobCreatorService(object):
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
-                    "last_service": "testing",
+                    "last_service": "publisher",
                     "provider": "gce",
                     "target_regions": {
                         "us-west2": {
@@ -530,13 +530,37 @@ class TestJobCreatorService(object):
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
-                    "last_service": "testing",
+                    "last_service": "publisher",
                     "provider": "gce",
                     "test_regions": {
                         "us-west2": "test-gce2",
                         "us-west1": "test-gce"
                     },
                     "tests": ["test_stuff"],
+                    "utctime": "now"
+                }
+            })
+        )
+        assert mock_publish.mock_calls[4] == call(
+            'replication', 'job_document',
+            JsonFormat.json_message({
+                "replication_job": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "image_description": "New Image #123",
+                    "last_service": "publisher",
+                    "provider": "gce",
+                    "replication_source_regions": {},
+                    "utctime": "now"
+                }
+            })
+        )
+        assert mock_publish.mock_calls[5] == call(
+            'publisher', 'job_document',
+            JsonFormat.json_message({
+                "publisher_job": {
+                    "id": "12345678-1234-1234-1234-123456789012",
+                    "last_service": "publisher",
+                    "provider": "gce",
                     "utctime": "now"
                 }
             })

--- a/test/unit/services/publisher/gce_job_test.py
+++ b/test/unit/services/publisher/gce_job_test.py
@@ -1,0 +1,17 @@
+from mash.services.publisher.gce_job import GCEPublisherJob
+
+
+class TestGCEPublisherJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'last_service': 'publisher',
+            'provider': 'ec2',
+            'publish_regions': [],
+            'utctime': 'now'
+        }
+
+        self.job = GCEPublisherJob(**self.job_config)
+
+    def test_publish(self):
+        self.job._publish()

--- a/test/unit/services/publisher/service_test.py
+++ b/test/unit/services/publisher/service_test.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 from mash.services.mash_service import MashService
 from mash.services.publisher.service import PublisherService
 from mash.services.publisher.ec2_job import EC2PublisherJob
+from mash.services.publisher.gce_job import GCEPublisherJob
 from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
@@ -64,6 +65,19 @@ class TestPublisherService(object):
 
         mock_create_job.assert_called_once_with(
             EC2PublisherJob,
+            job_config
+        )
+
+    @patch.object(PublisherService, '_create_job')
+    def test_publisher_add_job_gce(self, mock_create_job):
+        job_config = {
+            'id': '1', 'provider': 'gce', 'utctime': 'now',
+        }
+
+        self.publisher._add_job(job_config)
+
+        mock_create_job.assert_called_once_with(
+            GCEPublisherJob,
             job_config
         )
 

--- a/test/unit/services/replication/gce_job_test.py
+++ b/test/unit/services/replication/gce_job_test.py
@@ -1,0 +1,17 @@
+from mash.services.replication.gce_job import GCEReplicationJob
+
+
+class TestGCEReplicationJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'image_description': 'test image',
+            'last_service': 'replication',
+            'provider': 'gce',
+            'utctime': 'now',
+            "replication_source_regions": {}
+        }
+        self.job = GCEReplicationJob(**self.job_config)
+
+    def test_replicate(self):
+        self.job._replicate()

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -8,9 +8,16 @@ class TestReplicationJob(object):
     def setup(self):
         self.job_config = {
             'id': '1',
+            'image_description': 'test image',
             'last_service': 'replication',
             'provider': 'ec2',
-            'utctime': 'now'
+            'utctime': 'now',
+            'replication_source_regions': {
+                'us-east-1': {
+                    'account': 'test-aws',
+                    'target_regions': ['us-east-2']
+                }
+            }
         }
 
     def test_valid_job(self):

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -4,6 +4,7 @@ from mash.services.mash_service import MashService
 from mash.services.replication.service import ReplicationService
 from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
+from mash.services.replication.gce_job import GCEReplicationJob
 from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
@@ -78,6 +79,19 @@ class TestReplicationService(object):
 
         mock_create_job.assert_called_once_with(
             AzureReplicationJob,
+            job_config
+        )
+
+    @patch.object(ReplicationService, '_create_job')
+    def test_replication_add_job_gce(self, mock_create_job):
+        job_config = {
+            'id': '1', 'provider': 'gce', 'utctime': 'now',
+        }
+
+        self.replication._add_job(job_config)
+
+        mock_create_job.assert_called_once_with(
+            GCEReplicationJob,
             job_config
         )
 


### PR DESCRIPTION
- Job is just passed through for GCE which has no replication or publishing.
- Cleanup options and args in replication job classes.