### PR TITLE
Move create auth file method to mash utils.

### DIFF
--- a/mash/services/azure_utils.py
+++ b/mash/services/azure_utils.py
@@ -18,14 +18,11 @@
 
 import adal
 import json
-import os
 import re
 import requests
 import time
 
-from contextlib import contextmanager, suppress
 from datetime import date, datetime, timedelta
-from tempfile import NamedTemporaryFile
 
 from azure.common.client_factory import get_client_from_auth_file
 from azure.mgmt.compute import ComputeManagementClient
@@ -33,7 +30,6 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.storage.blob import ContainerPermissions, PageBlobService
 
 from mash.mash_exceptions import MashAzureUtilsException
-from mash.utils.json_format import JsonFormat
 
 
 def acquire_access_token(credentials, cloud_partner=False):
@@ -217,18 +213,6 @@ def get_classic_storage_account_keys(
     json_output = requests.post(endpoint, headers=headers).json()
 
     return json_output
-
-
-@contextmanager
-def create_auth_file(credentials):
-    try:
-        auth_file = NamedTemporaryFile(delete=False)
-        with open(auth_file.name, 'w') as azure_auth:
-            azure_auth.write(JsonFormat.json_message(credentials))
-        yield auth_file.name
-    finally:
-        with suppress(OSError):
-            os.remove(auth_file.name)
 
 
 def go_live_with_cloud_partner_offer(

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -17,7 +17,6 @@
 #
 
 from mash.services.azure_utils import (
-    create_auth_file,
     get_blob_url,
     get_classic_page_blob_service,
     publish_cloud_partner_offer,
@@ -29,6 +28,7 @@ from mash.services.azure_utils import (
 
 from mash.services.publisher.job import PublisherJob
 from mash.services.status_levels import FAILED, SUCCESS
+from mash.utils.mash_utils import create_json_file
 
 
 class AzurePublisherJob(PublisherJob):
@@ -64,7 +64,7 @@ class AzurePublisherJob(PublisherJob):
             credential = self.credentials[region_info['account']]
             blob_name = ''.join([self.cloud_image_name, '.vhd'])
 
-            with create_auth_file(credential) as auth_file:
+            with create_json_file(credential) as auth_file:
                 self.send_log(
                     'Publishing image for account: {},'
                     ' using cloud partner API.'.format(

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -18,13 +18,13 @@
 
 from mash.services.azure_utils import (
     copy_blob_to_classic_storage,
-    create_auth_file,
     delete_image,
     delete_page_blob
 )
 
 from mash.services.replication.job import ReplicationJob
 from mash.services.status_levels import FAILED, SUCCESS
+from mash.utils.mash_utils import create_json_file
 
 
 class AzureReplicationJob(ReplicationJob):
@@ -62,7 +62,7 @@ class AzureReplicationJob(ReplicationJob):
             credential = self.credentials[reg_info['account']]
             blob_name = ''.join([self.cloud_image_name, '.vhd'])
 
-            with create_auth_file(credential) as auth_file:
+            with create_json_file(credential) as auth_file:
                 self.send_log(
                     'Copying image for account: {},'
                     ' to classic storage container.'.format(

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -16,8 +16,26 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import os
 import random
+
+from contextlib import contextmanager, suppress
 from string import ascii_lowercase
+from tempfile import NamedTemporaryFile
+
+from mash.utils.json_format import JsonFormat
+
+
+@contextmanager
+def create_json_file(data):
+    try:
+        temp_file = NamedTemporaryFile(delete=False)
+        with open(temp_file.name, 'w') as json_file:
+            json_file.write(JsonFormat.json_message(data))
+        yield temp_file.name
+    finally:
+        with suppress(OSError):
+            os.remove(temp_file.name)
 
 
 def generate_name(length=8):

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -1,4 +1,3 @@
-import io
 import json
 
 from datetime import date
@@ -8,7 +7,6 @@ from unittest.mock import MagicMock, patch
 from mash.mash_exceptions import MashAzureUtilsException
 from mash.services.azure_utils import (
     acquire_access_token,
-    create_auth_file,
     delete_image,
     delete_page_blob,
     get_classic_storage_account_keys,
@@ -24,7 +22,6 @@ from mash.services.azure_utils import (
     update_cloud_partner_offer_doc,
     wait_on_cloud_partner_operation
 )
-from mash.utils.json_format import JsonFormat
 
 
 @patch('mash.services.azure_utils.adal')
@@ -73,25 +70,6 @@ def test_acquire_access_token_cloud_partner(mock_adal):
         '09876543-1234-1234-1234-123456789012',
         '09876543-1234-1234-1234-123456789012'
     )
-
-
-@patch('mash.services.azure_utils.os')
-@patch('mash.services.azure_utils.NamedTemporaryFile')
-def test_create_auth_file(mock_temp_file, mock_os):
-    auth_file = MagicMock()
-    auth_file.name = 'test.json'
-    mock_temp_file.return_value = auth_file
-
-    creds = {'tenantId': '123456', 'subscriptionId': '98765'}
-    with patch('builtins.open', create=True) as mock_open:
-        mock_open.return_value = MagicMock(spec=io.IOBase)
-        with create_auth_file(creds) as auth:
-            assert auth == 'test.json'
-
-        file_handle = mock_open.return_value.__enter__.return_value
-        file_handle.write.assert_called_with(JsonFormat.json_message(creds))
-
-    mock_os.remove.assert_called_once_with('test.json')
 
 
 @patch('mash.services.azure_utils.acquire_access_token')

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -56,17 +56,17 @@ class TestAzurePublisherJob(object):
     @patch(
         'mash.services.publisher.azure_job.request_cloud_partner_offer_doc'
     )
-    @patch('mash.services.publisher.azure_job.create_auth_file')
+    @patch('mash.services.publisher.azure_job.create_json_file')
     @patch.object(AzurePublisherJob, 'send_log')
     @patch.object(AzurePublisherJob, '_get_blob_url')
     def test_publish(
-        self, mock_get_blob_url, mock_send_log, mock_create_auth_file,
+        self, mock_get_blob_url, mock_send_log, mock_create_json_file,
         mock_request_doc, mock_put_doc, mock_publish_offer,
         mock_wait_on_operation
     ):
         self.job.version_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
         mock_get_blob_url.return_value = 'blob/url/.vhd'
-        mock_create_auth_file.return_value.__enter__.return_value = \
+        mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
 
         mock_request_doc.return_value = {
@@ -91,16 +91,16 @@ class TestAzurePublisherJob(object):
     @patch(
         'mash.services.publisher.azure_job.request_cloud_partner_offer_doc'
     )
-    @patch('mash.services.publisher.azure_job.create_auth_file')
+    @patch('mash.services.publisher.azure_job.create_json_file')
     @patch.object(AzurePublisherJob, 'send_log')
     @patch.object(AzurePublisherJob, '_get_blob_url')
     def test_publish_exception(
-        self, mock_get_blob_url, mock_send_log, mock_create_auth_file,
+        self, mock_get_blob_url, mock_send_log, mock_create_json_file,
         mock_request_doc, mock_put_doc
     ):
         self.job.version_key = None
         mock_get_blob_url.return_value = 'blob/url/.vhd'
-        mock_create_auth_file.return_value.__enter__.return_value = \
+        mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
 
         mock_request_doc.return_value = {

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -49,15 +49,15 @@ class TestAzureReplicationJob(object):
 
     @patch('mash.services.replication.azure_job.delete_page_blob')
     @patch('mash.services.replication.azure_job.delete_image')
-    @patch('mash.services.replication.azure_job.create_auth_file')
+    @patch('mash.services.replication.azure_job.create_json_file')
     @patch('mash.services.replication.azure_job.copy_blob_to_classic_storage')
     @patch.object(AzureReplicationJob, 'send_log')
     def test_replicate(
-        self, mock_send_log, mock_copy_blob, mock_create_auth_file,
+        self, mock_send_log, mock_copy_blob, mock_create_json_file,
         mock_delete_image, mock_delete_page_blob
     ):
         mock_delete_page_blob.side_effect = Exception('Cannot delete image.')
-        mock_create_auth_file.return_value.__enter__.return_value = \
+        mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
 
         self.job._replicate()

--- a/test/unit/utils/mash_utils_test.py
+++ b/test/unit/utils/mash_utils_test.py
@@ -19,7 +19,31 @@
 import io
 
 from unittest.mock import MagicMock, patch
-from mash.utils.mash_utils import generate_name, get_key_from_file
+from mash.utils.json_format import JsonFormat
+from mash.utils.mash_utils import (
+    create_json_file,
+    generate_name,
+    get_key_from_file
+)
+
+
+@patch('mash.utils.mash_utils.os')
+@patch('mash.utils.mash_utils.NamedTemporaryFile')
+def test_create_json_file(mock_temp_file, mock_os):
+    json_file = MagicMock()
+    json_file.name = 'test.json'
+    mock_temp_file.return_value = json_file
+
+    data = {'tenantId': '123456', 'subscriptionId': '98765'}
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        with create_json_file(data) as json_file:
+            assert json_file == 'test.json'
+
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(JsonFormat.json_message(data))
+
+    mock_os.remove.assert_called_once_with('test.json')
 
 
 def test_generate_name():


### PR DESCRIPTION
This is useful in other cases outside of Azure. Also make the method generic to creating a json file instead of just auth.