### PR TITLE
Skip cred request in gce publish/replicate.

### DIFF
--- a/mash/services/publisher/gce_job.py
+++ b/mash/services/publisher/gce_job.py
@@ -32,6 +32,9 @@ class GCEPublisherJob(PublisherJob):
             id, last_service, provider, utctime, job_file=job_file
         )
 
+        # Skip credential request since there is no publishing in GCE
+        self.credentials = {'status': 'no publishing'}
+
     def _publish(self):
         """
         No publishing in GCE.

--- a/mash/services/replication/gce_job.py
+++ b/mash/services/replication/gce_job.py
@@ -32,6 +32,9 @@ class GCEReplicationJob(ReplicationJob):
             id, last_service, provider, utctime, job_file=job_file
         )
 
+        # Skip credential request since there is no replication in GCE
+        self.credentials = {'status': 'no replication'}
+
     def _replicate(self):
         """
         No replication in GCE.


### PR DESCRIPTION
There is no publish or replicate steps in GCE so set credentials to default value and skip the request/response.