### PR TITLE
Make OBS package conditions expressive.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -21,7 +21,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -21,7 +21,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/examples/messages/obs_always_job.json
+++ b/examples/messages/obs_always_job.json
@@ -6,7 +6,12 @@
         "last_service": "testing",
         "utctime": "always",
         "conditions": [
-            {"package": ["kernel-default", ">=3.12.61", ">=52.136"]},
+            {
+                "name": "kernel-default",
+                "version": "3.12.61",
+                "build_id": "52.136",
+                "condition": ">="
+            },
             {"image": "0.2.4"}
         ]
     }

--- a/examples/messages/obs_always_job.json
+++ b/examples/messages/obs_always_job.json
@@ -7,7 +7,7 @@
         "utctime": "always",
         "conditions": [
             {
-                "name": "kernel-default",
+                "package_name": "kernel-default",
                 "version": "3.12.61",
                 "build_id": "52.136",
                 "condition": ">="

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -7,7 +7,7 @@
         "utctime": "now",
         "conditions": [
             {
-                "name": "kernel-default",
+                "package_name": "kernel-default",
                 "version": "4.4.1",
                 "build_id": "1.1",
                 "condition": ">="

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -6,7 +6,12 @@
         "last_service": "testing",
         "utctime": "now",
         "conditions": [
-            {"package": ["kernel-default", ">=4.4.1", ">=1.1"]},
+            {
+                "name": "kernel-default",
+                "version": "4.4.1",
+                "build_id": "1.1",
+                "condition": ">="
+            },
             {"image": "15.1.0"}
         ],
         "cloud_architecture": "x86_64"

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -269,7 +269,7 @@ base_job_message = {
         'non_empty_string': non_empty_string,
         'package_conditions': {
             'properties': {
-                'name': {'$ref': '#/definitions/non_empty_string'},
+                'package_name': {'$ref': '#/definitions/non_empty_string'},
                 'version': {'$ref': '#/definitions/non_empty_string'},
                 'build_id': {'$ref': '#/definitions/non_empty_string'},
                 'condition': {
@@ -277,7 +277,7 @@ base_job_message = {
                 }
             },
             'additionalProperties': False,
-            'required': ['name']
+            'required': ['package_name']
         }
     }
 }

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -269,14 +269,15 @@ base_job_message = {
         'non_empty_string': non_empty_string,
         'package_conditions': {
             'properties': {
-                'package': {
-                    'type': 'array',
-                    'items': {'$ref': '#/definitions/non_empty_string'},
-                    'minItems': 2
+                'name': {'$ref': '#/definitions/non_empty_string'},
+                'version': {'$ref': '#/definitions/non_empty_string'},
+                'build_id': {'$ref': '#/definitions/non_empty_string'},
+                'condition': {
+                    'enum': ['>=', '==', '<=', '>', '<']
                 }
             },
             'additionalProperties': False,
-            'required': ['package']
+            'required': ['name']
         }
     }
 }

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -67,7 +67,11 @@ class OBSImageBuildResult(object):
 
       conditions=[
           # a package condition with version and release spec
-          {'package': ['kernel-default', '4.13.1', '1.1']},
+          {
+           'package_name': 'kernel-default',
+           'version': '4.13.1',
+           'build_id': '1.1'
+          },
           # a image version condition
           {'image': '1.42.1'}
       ]
@@ -308,7 +312,7 @@ class OBSImageBuildResult(object):
                             condition['status'] = True
                         else:
                             condition['status'] = False
-                    elif 'name' in condition:
+                    elif 'package_name' in condition:
                         if self._lookup_package(
                             packages, condition
                         ):
@@ -417,7 +421,7 @@ class OBSImageBuildResult(object):
             )
 
     def _lookup_package(self, packages, condition):
-        package_name = condition['name']
+        package_name = condition['package_name']
 
         if package_name not in packages:
             return False

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -21,6 +21,7 @@ import logging
 import hashlib
 from distutils.dir_util import mkpath
 from datetime import datetime
+from pkg_resources import parse_version
 from pytz import utc
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
@@ -307,9 +308,9 @@ class OBSImageBuildResult(object):
                             condition['status'] = True
                         else:
                             condition['status'] = False
-                    elif 'package' in condition:
+                    elif 'name' in condition:
                         if self._lookup_package(
-                            packages, condition['package']
+                            packages, condition
                         ):
                             condition['status'] = True
                         else:
@@ -399,41 +400,51 @@ class OBSImageBuildResult(object):
                 result_packages[package_name] = package_result
         return result_packages
 
-    def _version_compare(self, expression):
-        expression = expression.replace('.', '')
-        if re.match(r'^\d+ (<|>|<=|>=|==)\d+$', expression):
-            return eval(expression)
+    def _version_compare(self, current, expected, condition):
+        if condition == '>=':
+            return parse_version(current) >= parse_version(expected)
+        elif condition == '<=':
+            return parse_version(current) <= parse_version(expected)
+        elif condition == '==':
+            return parse_version(current) == parse_version(expected)
+        elif condition == '>':
+            return parse_version(current) > parse_version(expected)
+        elif condition == '<':
+            return parse_version(current) < parse_version(expected)
         else:
             raise MashVersionExpressionException(
-                'Invalid version compare expression: "{0}"'.format(expression)
+                'Invalid version compare expression: "{0}"'.format(condition)
             )
 
-    def _lookup_package(self, packages, package_search_data):
-        package_name = package_search_data[0]
+    def _lookup_package(self, packages, condition):
+        package_name = condition['name']
+
         if package_name not in packages:
             return False
 
-        if len(package_search_data) > 1:
-            # we want to lookup a specific version, release of the package
-            package_data = packages[package_name]
+        condition_eval = condition.get('condition', '>=')
+        package_data = packages[package_name]
 
-            package_lookup_version = package_search_data[1]
-            package_lookup_release = None
-            if len(package_search_data) == 3:
-                package_lookup_release = package_search_data[2]
-
-            version_check = '{0} {1}'.format(
-                package_data.version, package_lookup_version
+        if 'version' in condition:
+            # we want to lookup a specific version
+            match = self._version_compare(
+                package_data.version,
+                condition['version'],
+                condition_eval
             )
-            if self._version_compare(version_check):
-                if not package_lookup_release:
-                    return True
-                release_check = '{0} {1}'.format(
-                    package_data.release, package_lookup_release
-                )
-                if self._version_compare(release_check):
-                    return True
-            return False
-        else:
-            # we want to lookup just the package name
-            return True
+
+            if not match:
+                return False
+
+        if 'build_id' in condition:
+            # we want to lookup a specific build number
+            match = self._version_compare(
+                package_data.release,
+                condition['build_id'],
+                condition_eval
+            )
+
+            if not match:
+                return False
+
+        return True

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -137,7 +137,12 @@ class OBSImageBuildResultService(MashService):
               "last_service": "uploader",
               "utctime": "now|always|timestring_utc_timezone",
               "conditions": [
-                  {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},
+                  {
+                    "name": "kernel-default",
+                    "version": "4.13.1",
+                    "build_id": "1.1",
+                    "condition": ">="
+                  },
                   {"image": "1.42.1"}
               ]
           }

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -138,7 +138,7 @@ class OBSImageBuildResultService(MashService):
               "utctime": "now|always|timestring_utc_timezone",
               "conditions": [
                   {
-                    "name": "kernel-default",
+                    "package_name": "kernel-default",
                     "version": "4.13.1",
                     "build_id": "1.1",
                     "condition": ">="

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -21,7 +21,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -21,7 +21,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -16,7 +16,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -16,7 +16,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"name": "name", "version": "and", "build_id": "constraints"},
+    {"package_name": "openssl", "version": "13.4.3", "build_id": "1.1"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -12,7 +12,7 @@
   "cloud_image_name": "new_image_123",
   "old_cloud_image_name": "old_new_image_123",
   "conditions": [
-    {"package": ["name", "and", "constraints"]},
+    {"name": "name", "version": "and", "build_id": "constraints"},
     {"image": "version"}
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -143,9 +143,9 @@ class TestJobCreatorService(object):
                     "cloud_architecture": "aarch64",
                     "conditions": [
                         {
-                            "build_id": "constraints",
-                            "name": "name",
-                            "version": "and"
+                            "build_id": "1.1",
+                            "package_name": "openssl",
+                            "version": "13.4.3"
                         },
                         {"image": "version"}
                     ],
@@ -348,9 +348,9 @@ class TestJobCreatorService(object):
                     "cloud_architecture": "x86_64",
                     "conditions": [
                         {
-                            "build_id": "constraints",
-                            "name": "name",
-                            "version": "and"
+                            "build_id": "1.1",
+                            "package_name": "openssl",
+                            "version": "13.4.3"
                         },
                         {"image": "version"}
                     ],
@@ -536,9 +536,9 @@ class TestJobCreatorService(object):
                     "cloud_architecture": "x86_64",
                     "conditions": [
                         {
-                            "build_id": "constraints",
-                            "name": "name",
-                            "version": "and"
+                            "build_id": "1.1",
+                            "package_name": "openssl",
+                            "version": "13.4.3"
                         },
                         {"image": "version"}
                     ],

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -142,7 +142,11 @@ class TestJobCreatorService(object):
                 "obs_job": {
                     "cloud_architecture": "aarch64",
                     "conditions": [
-                        {"package": ["name", "and", "constraints"]},
+                        {
+                            "build_id": "constraints",
+                            "name": "name",
+                            "version": "and"
+                        },
                         {"image": "version"}
                     ],
                     "download_url": "http://download.opensuse.org/"
@@ -343,7 +347,11 @@ class TestJobCreatorService(object):
                 "obs_job": {
                     "cloud_architecture": "x86_64",
                     "conditions": [
-                        {"package": ["name", "and", "constraints"]},
+                        {
+                            "build_id": "constraints",
+                            "name": "name",
+                            "version": "and"
+                        },
                         {"image": "version"}
                     ],
                     "download_url": "http://download.opensuse.org/"
@@ -527,7 +535,11 @@ class TestJobCreatorService(object):
                 "obs_job": {
                     "cloud_architecture": "x86_64",
                     "conditions": [
-                        {"package": ["name", "and", "constraints"]},
+                        {
+                            "build_id": "constraints",
+                            "name": "name",
+                            "version": "and"
+                        },
                         {"image": "version"}
                     ],
                     "download_url": "http://download.opensuse.org/"

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -246,7 +246,7 @@ class TestOBSImageBuildResult(object):
         self.obs_result.image_status['version'] = '1.2.3'
         self.obs_result.image_status['conditions'] = [
             {'image': '1.2.3'},
-            {'package': 'package'}
+            {'name': 'package'}
         ]
         package_type = namedtuple(
             'package_type', [
@@ -273,7 +273,7 @@ class TestOBSImageBuildResult(object):
             'version': '1.2.3',
             'conditions': [
                 {'status': True, 'image': '1.2.3'},
-                {'status': True, 'package': 'package'}
+                {'status': True, 'name': 'package'}
             ], 'image_source': []
         }
 
@@ -328,21 +328,61 @@ class TestOBSImageBuildResult(object):
         mock_NamedTemporaryFile.return_value = tempfile
         packages = self.obs_result._lookup_image_packages_metadata()
         assert self.obs_result._lookup_package(
-            packages, ['foo']
+            packages, {'name': 'foo'}
         ) is False
         assert self.obs_result._lookup_package(
-            packages, ['file-magic']
+            packages, {
+                'name': 'file-magic',
+                'version': '5.32'
+            }
         ) is True
         assert self.obs_result._lookup_package(
-            packages, ['file-magic', '>=5.32']
+            packages, {
+                'name': 'file-magic',
+                'version': '5.32',
+                'condition': '=='
+            }
         ) is True
         assert self.obs_result._lookup_package(
-            packages, ['file-magic', '>=5.32', '>=1.2']
+            packages,
+            {
+                'name': 'file-magic',
+                'version': '5.32',
+                'condition': '>'
+            }
+        ) is False
+        assert self.obs_result._lookup_package(
+            packages,
+            {
+                'name': 'file-magic',
+                'version': '5.32',
+                'condition': '<'
+            }
+        ) is False
+        assert self.obs_result._lookup_package(
+            packages,
+            {
+                'name': 'file-magic',
+                'version': '5.32',
+                'build_id': '1.2',
+                'condition': '<='
+            }
         ) is True
         assert self.obs_result._lookup_package(
-            packages, ['file-magic', '<5.32', '<1.2']
+            packages,
+            {
+                'name': 'file-magic',
+                'version': '5.32',
+                'build_id': '1.1',
+                'condition': '<='
+            }
         ) is False
         with raises(MashVersionExpressionException):
             self.obs_result._lookup_package(
-                packages, ['file-magic', '=5.32']
+                packages,
+                {
+                    'name': 'file-magic',
+                    'version': '5.32',
+                    'condition': '='
+                }
             )

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -246,7 +246,7 @@ class TestOBSImageBuildResult(object):
         self.obs_result.image_status['version'] = '1.2.3'
         self.obs_result.image_status['conditions'] = [
             {'image': '1.2.3'},
-            {'name': 'package'}
+            {'package_name': 'package'}
         ]
         package_type = namedtuple(
             'package_type', [
@@ -273,7 +273,7 @@ class TestOBSImageBuildResult(object):
             'version': '1.2.3',
             'conditions': [
                 {'status': True, 'image': '1.2.3'},
-                {'status': True, 'name': 'package'}
+                {'status': True, 'package_name': 'package'}
             ], 'image_source': []
         }
 
@@ -328,17 +328,17 @@ class TestOBSImageBuildResult(object):
         mock_NamedTemporaryFile.return_value = tempfile
         packages = self.obs_result._lookup_image_packages_metadata()
         assert self.obs_result._lookup_package(
-            packages, {'name': 'foo'}
+            packages, {'package_name': 'foo'}
         ) is False
         assert self.obs_result._lookup_package(
             packages, {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32'
             }
         ) is True
         assert self.obs_result._lookup_package(
             packages, {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32',
                 'condition': '=='
             }
@@ -346,7 +346,7 @@ class TestOBSImageBuildResult(object):
         assert self.obs_result._lookup_package(
             packages,
             {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32',
                 'condition': '>'
             }
@@ -354,7 +354,7 @@ class TestOBSImageBuildResult(object):
         assert self.obs_result._lookup_package(
             packages,
             {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32',
                 'condition': '<'
             }
@@ -362,7 +362,7 @@ class TestOBSImageBuildResult(object):
         assert self.obs_result._lookup_package(
             packages,
             {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32',
                 'build_id': '1.2',
                 'condition': '<='
@@ -371,7 +371,7 @@ class TestOBSImageBuildResult(object):
         assert self.obs_result._lookup_package(
             packages,
             {
-                'name': 'file-magic',
+                'package_name': 'file-magic',
                 'version': '5.32',
                 'build_id': '1.1',
                 'condition': '<='
@@ -381,7 +381,7 @@ class TestOBSImageBuildResult(object):
             self.obs_result._lookup_package(
                 packages,
                 {
-                    'name': 'file-magic',
+                    'package_name': 'file-magic',
                     'version': '5.32',
                     'condition': '='
                 }


### PR DESCRIPTION
Package conditions are now a dictionary with name, version, build_id and condition. Name is the only required option and condition defaults to >=.

Fixes #194 