### PR TITLE
Cleanup start/stop service methods.

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -26,6 +26,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from contextlib import suppress
 from cryptography.fernet import Fernet
 from datetime import datetime, timedelta
+from pytz import utc
 
 # project
 from mash.csp import CSP
@@ -66,7 +67,7 @@ class CredentialsService(MashService):
         )
         self._bind_credential_request_keys()
 
-        self.scheduler = BackgroundScheduler()
+        self.scheduler = BackgroundScheduler(timezone=utc)
         self.scheduler.add_listener(
             self._handle_key_rotation_result,
             events.EVENT_JOB_EXECUTED | events.EVENT_JOB_ERROR
@@ -615,14 +616,5 @@ class CredentialsService(MashService):
         except Exception:
             raise
         finally:
-            self.stop()
-
-    def stop(self):
-        """
-        Stop credentials service.
-
-        Stop consuming queues and close pika connections.
-        """
-        self.scheduler.shutdown()
-        self.channel.stop_consuming()
-        self.close_connection()
+            self.scheduler.shutdown()
+            self.close_connection()

--- a/mash/services/logger/service.py
+++ b/mash/services/logger/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -79,6 +79,7 @@ class LoggerService(MashService):
         Start logger service.
         """
         self.consume_queue(self._process_log, 'logging')
+
         try:
             self.channel.start_consuming()
         except KeyboardInterrupt:
@@ -86,11 +87,4 @@ class LoggerService(MashService):
         except Exception:
             raise
         finally:
-            self.stop()
-
-    def stop(self):
-        """
-        Stop logger service.
-        """
-        self.channel.stop_consuming()
-        self.close_connection()
+            self.close_connection()

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -46,13 +46,15 @@ class OBSImageBuildResultService(MashService):
         # consume on service queue
         atexit.register(lambda: os._exit(0))
         self.consume_queue(self._process_message)
+
         try:
             self.channel.start_consuming()
-        except Exception as issue:
-            if self.channel and self.channel.is_open:
-                self.channel.stop_consuming()
-                self.close_connection()
-            raise(issue)
+        except KeyboardInterrupt:
+            pass
+        except Exception:
+            raise
+        finally:
+            self.close_connection()
 
     def _send_job_response(self, job_id, status_message):
         self.log.info(status_message, extra={'job_id': job_id})

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -65,9 +65,12 @@ class UploadImageService(MashService):
 
         try:
             self.channel.start_consuming()
+        except KeyboardInterrupt:
+            pass
         except Exception:
             raise
         finally:
+            self.scheduler.shutdown()
             self.close_connection()
 
     def _job_log(self, job_id, message):

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -59,8 +59,10 @@ class TestOBSImageBuildResultService(object):
         self.obs_result.channel.start_consuming.side_effect = Exception
         with raises(Exception):
             self.obs_result.post_init()
-            self.obs_result.channel.stop_consuming.assert_called_once_with()
             self.obs_result.close_connection.assert_called_once_with()
+
+        self.obs_result.channel.start_consuming.side_effect = KeyboardInterrupt()
+        self.obs_result.post_init()
 
     def test_send_job_response(self):
         self.obs_result._send_job_response('815', {})

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -148,6 +148,9 @@ class TestUploadImageService(object):
             self.uploader.post_init()
         self.uploader.close_connection.assert_called_once_with()
 
+        self.uploader.channel.start_consuming.side_effect = KeyboardInterrupt()
+        self.uploader.post_init()
+
     @patch.object(MashService, 'persist_job_config')
     def test_init_job(self, mock_persist_job_config):
         self.uploader._init_job(self.job_data_from_preserved_ec2)


### PR DESCRIPTION
- Start all schedulers with utc timezone.
- Remove stop methods and move close_connection call to finally.
- Make event loop similar for all services.