### PR TITLE
Ack job doc message only after the job is saved.

### DIFF
--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -77,7 +77,6 @@ class OBSImageBuildResultService(MashService):
             self.log.error(message, extra=job_metadata)
 
     def _process_message(self, message):
-        message.ack()
         try:
             job_data = JsonFormat.json_loads(format(message.body))
         except Exception as e:
@@ -91,6 +90,8 @@ class OBSImageBuildResultService(MashService):
             )
         if message.method['routing_key'] == 'job_document':
             self._handle_jobs(job_data)
+
+        message.ack()
 
     def _handle_jobs(self, job_data):
         """


### PR DESCRIPTION
Once the job is persisted to disk it's okay to remove the message from queue by responding with acknowledgement. This maintains fault tolerance if system goes down whilst processing the msg.