### PR TITLE
Fixup systemd unit files for required services

### DIFF
--- a/config/mash_credentials.service
+++ b/config/mash_credentials.service
@@ -2,6 +2,7 @@
 Description=Mash Credentials service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-credentials-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_deprecation.service
+++ b/config/mash_deprecation.service
@@ -2,6 +2,7 @@
 Description=Mash Deprecation service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-deprecation-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_job_creator.service
+++ b/config/mash_job_creator.service
@@ -2,6 +2,7 @@
 Description=Mash Job Creator service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-job-creator-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_logger.service
+++ b/config/mash_logger.service
@@ -2,6 +2,7 @@
 Description=Mash Logger service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-logger-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_obs.service
+++ b/config/mash_obs.service
@@ -2,6 +2,7 @@
 Description=Mash OBS service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-obs-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_publisher.service
+++ b/config/mash_publisher.service
@@ -2,6 +2,7 @@
 Description=Mash Publisher service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-publisher-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_replication.service
+++ b/config/mash_replication.service
@@ -2,6 +2,7 @@
 Description=Mash replication service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-replication-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_testing.service
+++ b/config/mash_testing.service
@@ -2,6 +2,7 @@
 Description=Mash testing service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-testing-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mash_uploader.service
+++ b/config/mash_uploader.service
@@ -2,6 +2,7 @@
 Description=Mash Uploader service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
 
 [Service]
 User=mash
@@ -10,6 +11,7 @@ Type=simple
 ExecStart=/usr/bin/mash-uploader-service
 StandardOutput=journal
 Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The startup of the mash services requires the rabbitmq service
to be up and running. Thus it's not enough to run the service
startup after rabbitmq, it must be a required service such that
systemd waits for this service to be active before starting a
mash service. In addition the restart timeout for failed services
is too fast. systemd will stop restarting services if it happens
too fast, therefore a latch of 3sec before the next try is sufficient.
This issue can be seen if you run the mash server in the podman
container from Virtualization:Appliances:Images/mash-image-docker