### PR TITLE
Same defaults for ec2 options.

### DIFF
--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -32,8 +32,8 @@ class EC2Job(BaseJob):
         self, accounts_info, cloud_data, job_id, cloud,
         cloud_accounts, cloud_groups, requesting_user, last_service,
         utctime, image, cloud_image_name, image_description, distro,
-        download_url, tests, allow_copy=False, conditions=None,
-        instance_type=None, share_with='none', old_cloud_image_name=None,
+        download_url, tests, allow_copy=True, conditions=None,
+        instance_type=None, share_with='all', old_cloud_image_name=None,
         cleanup_images=True, cloud_architecture='x86_64'
     ):
         self.share_with = share_with

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -30,7 +30,7 @@ class EC2PublisherJob(PublisherJob):
 
     def __init__(
         self, id, last_service, cloud, publish_regions, utctime,
-        allow_copy=False, job_file=None, share_with='all'
+        allow_copy=True, job_file=None, share_with='all'
     ):
         super(EC2PublisherJob, self).__init__(
             id, last_service, cloud, utctime, job_file=job_file


### PR DESCRIPTION
Defaults for allow_copy and share_with match in job creator and publisher classes.

allow_copy default is True and share_with is all.

Resolves #397 