### PR TITLE
Remove random region handling for ec2 jobs.

### DIFF
--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -119,11 +119,14 @@ add_account_ec2 = {
         },
         'group': {'$ref': '#/definitions/non_empty_string'},
         'partition': {'$ref': '#/definitions/non_empty_string'},
+        'region': {'$ref': '#/definitions/non_empty_string'},
         'cloud': {'enum': ['ec2']},
         'requesting_user': {'$ref': '#/definitions/non_empty_string'},
     },
     'additionalProperties': False,
-    'required': ['account_name', 'credentials', 'cloud', 'requesting_user'],
+    'required': [
+        'account_name', 'credentials', 'cloud', 'requesting_user', 'region'
+    ],
     'definitions': {
         'non_empty_string': non_empty_string
     }
@@ -304,12 +307,7 @@ ec2_job_message['definitions']['account'] = {
     'type': 'object',
     'properties': {
         'name': {'$ref': '#/definitions/non_empty_string'},
-        'target_regions': {
-            'type': 'array',
-            'items': {'$ref': '#/definitions/non_empty_string'},
-            'uniqueItems': True,
-            'minItems': 1
-        }
+        'region': {'$ref': '#/definitions/non_empty_string'}
     },
     'additionalProperties': False,
     'required': ['name']

--- a/mash/services/credentials/ec2_account.py
+++ b/mash/services/credentials/ec2_account.py
@@ -32,6 +32,7 @@ class EC2Account(BaseAccount):
             group_name=message.get('group')
         )
         self.additional_regions = message.get('additional_regions')
+        self.region = message.get('region')
         self.partition = message['partition']
 
     def add_account(self, accounts_file):
@@ -42,7 +43,8 @@ class EC2Account(BaseAccount):
         """
         account_info = {
             'additional_regions': self.additional_regions,
-            'partition': self.partition
+            'partition': self.partition,
+            'region': self.region
         }
 
         accounts = accounts_file[self.cloud]['accounts'].get(self.requesting_user)

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -2,7 +2,7 @@
   "job_id": "12345678-1234-1234-1234-123456789012",
   "cloud": "ec2",
   "cloud_accounts": [
-    {"name": "test-aws-gov", "target_regions": ["us-gov-west-1"]}
+    {"name": "test-aws-gov"}
   ],
   "cloud_groups": ["test"],
   "requesting_user": "user1",

--- a/test/unit/services/api/api_test.py
+++ b/test/unit/services/api/api_test.py
@@ -40,6 +40,7 @@ def test_api_add_account(mock_connection, mock_config, test_client):
         'group': 'group1',
         'partition': 'aws',
         'cloud': 'ec2',
+        'region': 'us-east-1',
         'requesting_user': 'user1'
     }, sort_keys=True)
     response = test_client.post(

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -599,6 +599,7 @@ class TestCredentialsService(object):
             'partition': 'aws',
             'cloud': 'ec2',
             'requesting_user': 'user1',
+            'region': 'us-east-1',
             'group': 'group123'
         }
 
@@ -614,8 +615,11 @@ class TestCredentialsService(object):
             'acnt123', 'encryptedcreds', 'ec2', 'user1'
         )
 
-        assert accounts['ec2']['accounts']['user1']['acnt123'] == \
-            {'additional_regions': None, 'partition': 'aws'}
+        assert accounts['ec2']['accounts']['user1']['acnt123'] == {
+            'additional_regions': None,
+            'partition': 'aws',
+            'region': 'us-east-1'
+        }
         assert accounts['ec2']['groups']['user1']['group123'] == ['acnt123']
 
     @patch.object(CredentialsService, '_store_encrypted_credentials')

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -64,10 +64,9 @@ class TestJobCreatorService(object):
         ])
         mock_start.assert_called_once_with()
 
-    @patch('mash.services.jobcreator.ec2_job.random')
     @patch.object(JobCreatorService, '_publish')
     def test_jobcreator_handle_service_message(
-            self, mock_publish, mock_random
+            self, mock_publish
     ):
         self.jobcreator.jobs = {}
         self.jobcreator.cloud_data = {
@@ -87,8 +86,6 @@ class TestJobCreatorService(object):
         }
         message = MagicMock()
 
-        mock_random.randint.return_value = 0
-
         with open('../data/job.json', 'r') as job_doc:
             job = json.load(job_doc)
 
@@ -103,7 +100,8 @@ class TestJobCreatorService(object):
             "accounts": {
                 "user1": {
                     "test-aws-gov": {
-                        "partition": "aws-us-gov"
+                        "partition": "aws-us-gov",
+                        "region": "us-gov-west-1"
                     },
                     "test-aws": {
                         "additional_regions": [
@@ -112,7 +110,8 @@ class TestJobCreatorService(object):
                                 "helper_image": "ami-82444aff"
                             }
                         ],
-                        "partition": "aws"
+                        "partition": "aws",
+                        "region": "ap-northeast-1"
                     }
                 }
             }
@@ -779,8 +778,7 @@ class TestJobCreatorService(object):
                     "cloud": "ec2",
                     "cloud_accounts": [
                         {
-                            "name": "test-aws-gov",
-                            "target_regions": ["us-gov-west-1"]
+                            "name": "test-aws-gov"
                         }
                     ],
                     "cloud_groups": ["test"],


### PR DESCRIPTION
Instead a single target region is used similar to azure and gce.
This region is used for upload and testing and will be replicated
from.