### PR TITLE
Better error message for empty image_files.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -190,6 +190,14 @@ class OBSImageBuildResult(object):
             ['.xz', 'xz.sha256', '.tar.gz', '.tar.gz.sha256'],
             self.download_directory
         )
+
+        if not image_files:
+            raise MashImageDownloadException(
+                'No images found that match the image name {0}.'.format(
+                    self.image_name
+                )
+            )
+
         for image_file in image_files:
             if self._get_build_number(image_file) != build_number:
                 raise MashImageDownloadException(

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -159,6 +159,10 @@ class TestOBSImageBuildResult(object):
         with raises(MashImageDownloadException):
             self.obs_result.get_image()
 
+        self.obs_result.remote.fetch_files.return_value = []
+        with raises(MashImageDownloadException):
+            self.obs_result.get_image()
+
     def test_get_build_number(self):
         name = 'Azure-Factory.x86_64-1.0.5-Build42.42.packages'
         assert self.obs_result._get_build_number(name) == ['1.0.5', '42.42']


### PR DESCRIPTION
If image file name doesnt match the packages file there will be
an empty image list. Throw exception eagerly to provide useful
message.