### PR TITLE
Add email notifications

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -6,6 +6,9 @@ ssh_private_key_file: /var/lib/mash/ssh_key
 amqp_host: localhost
 amqp_user: guest
 amqp_pass: guest
+smtp_host: localhost
+smtp_port: 25
+smtp_ssl: False
 services:
   - obs
   - uploader

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -9,6 +9,7 @@ amqp_pass: guest
 smtp_host: localhost
 smtp_port: 25
 smtp_ssl: False
+smtp_user: test@fake.com
 services:
   - obs
   - uploader

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -34,5 +34,6 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "version_key": "key123"
+  "version_key": "key123",
+  "notification_email": "test@fake.com"
 }

--- a/examples/messages/credentials_job.json
+++ b/examples/messages/credentials_job.json
@@ -5,6 +5,8 @@
         "cloud_accounts": ["test-aws", "test-aws-cn"],
         "requesting_user": "test-aws",
         "last_service": "pint",
-        "utctime": "now"
+        "utctime": "now",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/deprecation_job.json
+++ b/examples/messages/deprecation_job.json
@@ -14,6 +14,8 @@
               "account": "test-aws-cn",
               "target_regions": ["cn-north-1", "cn-northwest-1"]
             }
-        ]
+        ],
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -20,5 +20,6 @@
   "distro": "sles",
   "instance_type": "t2.micro",
   "family": "sles-15",
-  "tests": ["test_stuff"]
+  "tests": ["test_stuff"],
+  "notification_email": "test@fake.com"
 }

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -21,5 +21,6 @@
   "image_description": "New Image #123",
   "distro": "sles",
   "instance_type": "t2.micro",
-  "tests": ["test_stuff"]
+  "tests": ["test_stuff"],
+  "notification_email": "test@fake.com"
 }

--- a/examples/messages/obs_always_job.json
+++ b/examples/messages/obs_always_job.json
@@ -13,6 +13,8 @@
                 "condition": ">="
             },
             {"image": "0.2.4"}
-        ]
+        ],
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -14,6 +14,8 @@
             },
             {"image": "15.1.0"}
         ],
-        "cloud_architecture": "x86_64"
+        "cloud_architecture": "x86_64",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/obs_now_job.json
+++ b/examples/messages/obs_now_job.json
@@ -4,6 +4,8 @@
         "download_url": "http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/Images12/images",
         "image": "SLES12-Azure-BYOS",
         "last_service": "testing",
-        "utctime": "now"
+        "utctime": "now",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/pint_job.json
+++ b/examples/messages/pint_job.json
@@ -5,6 +5,8 @@
         "cloud": "ec2",
         "utctime": "now",
         "cloud_image_name": "image_123",
-        "old_cloud_image_name": "old_image_123"
+        "old_cloud_image_name": "old_image_123",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/publisher_job.json
+++ b/examples/messages/publisher_job.json
@@ -17,6 +17,8 @@
                 "account": "test-aws-cn",
                 "target_regions": ["cn-north-1", "cn-northwest-1"]
             }
-        ]
+        ],
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/replication_job.json
+++ b/examples/messages/replication_job.json
@@ -14,6 +14,8 @@
                  "account": "test-aws-cn",
                  "target_regions": ["cn-northwest-1"]
             }
-        }
+        },
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/testing_job.json
+++ b/examples/messages/testing_job.json
@@ -10,6 +10,8 @@
         "test_regions": {
             "us-east-1": "test-aws",
             "cn-north-1": "test-aws-cn"
-        }
+        },
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/examples/messages/uploader_job.json
+++ b/examples/messages/uploader_job.json
@@ -15,6 +15,8 @@
                 "helper_image": "ami-bc5b4853",
                 "account": "test-aws-cn"
             }
-        }
+        },
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -255,6 +255,14 @@ base_job_message = {
         'cleanup_images': {'type': 'boolean'},
         'cloud_architecture': {
             'enum': ['x86_64', 'aarch64']
+        },
+        'notification_email': {
+            '$ref': '#/definitions/non_empty_string',
+            'format': 'regex',
+            'pattern': r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
+        },
+        'notification_type': {
+            'enum': ['periodic', 'single']
         }
     },
     'additionalProperties': False,

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -233,6 +233,11 @@ class BaseConfig(object):
             attribute='smtp_user'
         )
 
+        if not smtp_user:
+            raise MashConfigException(
+                'smtp_user is required in MASH configuration file.'
+            )
+
         return smtp_user
 
     def get_smtp_pass(self):

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -251,3 +251,15 @@ class BaseConfig(object):
         )
 
         return smtp_pass
+
+    def get_notification_subject(self):
+        """
+        Return the email notification_subject.
+
+        :rtype: string
+        """
+        notification_subject = self._get_attribute(
+            attribute='notification_subject'
+        )
+
+        return notification_subject or Defaults.get_notification_subject()

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -186,3 +186,63 @@ class BaseConfig(object):
         )
 
         return amqp_pass or Defaults.get_amqp_pass()
+
+    def get_smtp_host(self):
+        """
+        Return the smtp hostname.
+
+        :rtype: string
+        """
+        smtp_host = self._get_attribute(
+            attribute='smtp_host'
+        )
+
+        return smtp_host or Defaults.get_smtp_host()
+
+    def get_smtp_port(self):
+        """
+        Return the smtp port.
+
+        :rtype: string
+        """
+        smtp_port = self._get_attribute(
+            attribute='smtp_port'
+        )
+
+        return smtp_port or Defaults.get_smtp_port()
+
+    def get_smtp_ssl(self):
+        """
+        Return the smtp ssl boolean.
+
+        :rtype: string
+        """
+        smtp_ssl = self._get_attribute(
+            attribute='smtp_ssl'
+        )
+
+        return smtp_ssl or Defaults.get_smtp_ssl()
+
+    def get_smtp_user(self):
+        """
+        Return the smtp username.
+
+        :rtype: string
+        """
+        smtp_user = self._get_attribute(
+            attribute='smtp_user'
+        )
+
+        return smtp_user
+
+    def get_smtp_pass(self):
+        """
+        Return the smtp password.
+
+        :rtype: string
+        """
+        smtp_pass = self._get_attribute(
+            attribute='smtp_pass'
+        )
+
+        return smtp_pass

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -83,3 +83,7 @@ class Defaults(object):
     @staticmethod
     def get_smtp_ssl():
         return False
+
+    @staticmethod
+    def get_notification_subject():
+        return '[MASH] Job Status Update'

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -71,3 +71,15 @@ class Defaults(object):
     @staticmethod
     def get_azure_max_workers():
         return 5
+
+    @staticmethod
+    def get_smtp_host():
+        return 'localhost'
+
+    @staticmethod
+    def get_smtp_port():
+        return 25
+
+    @staticmethod
+    def get_smtp_ssl():
+        return False

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -164,7 +164,10 @@ class CredentialsService(MashService):
                 'Invalid job: {0}.'.format(error), success=False,
                 job_id=job_id
             )
-            job_response = {'invalid_job': job_id}
+            job_response = {
+                'invalid_job': job_id,
+                'error_msg': str(error)
+            }
             self._publish(
                 'jobcreator', self.job_document_key,
                 JsonFormat.json_message(job_response)

--- a/mash/services/deprecation/azure_job.py
+++ b/mash/services/deprecation/azure_job.py
@@ -27,11 +27,14 @@ class AzureDeprecationJob(DeprecationJob):
 
     def __init__(
         self, id, last_service, cloud, utctime,
-        old_cloud_image_name=None, job_file=None
+        old_cloud_image_name=None, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(AzureDeprecationJob, self).__init__(
             id, last_service, cloud, utctime,
-            old_cloud_image_name=old_cloud_image_name, job_file=job_file
+            old_cloud_image_name=old_cloud_image_name, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         # Skip credential request since there is no deprecation in Azure

--- a/mash/services/deprecation/deprecation_job.py
+++ b/mash/services/deprecation/deprecation_job.py
@@ -26,10 +26,13 @@ class DeprecationJob(MashJob):
     """
     def __init__(
         self, id, last_service, cloud, utctime,
-        old_cloud_image_name=None, job_file=None
+        old_cloud_image_name=None, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(DeprecationJob, self).__init__(
-            id, last_service, cloud, utctime, job_file
+            id, last_service, cloud, utctime, job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.old_cloud_image_name = old_cloud_image_name

--- a/mash/services/deprecation/ec2_job.py
+++ b/mash/services/deprecation/ec2_job.py
@@ -30,11 +30,14 @@ class EC2DeprecationJob(DeprecationJob):
 
     def __init__(
         self, id, deprecation_regions, last_service, cloud, utctime,
-        old_cloud_image_name=None, job_file=None
+        old_cloud_image_name=None, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(EC2DeprecationJob, self).__init__(
             id, last_service, cloud, utctime,
-            old_cloud_image_name=old_cloud_image_name, job_file=job_file
+            old_cloud_image_name=old_cloud_image_name, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.deprecation_regions = deprecation_regions

--- a/mash/services/deprecation/gce_job.py
+++ b/mash/services/deprecation/gce_job.py
@@ -35,11 +35,14 @@ class GCEDeprecationJob(DeprecationJob):
 
     def __init__(
         self, id, deprecation_accounts, last_service, cloud, utctime,
-        old_cloud_image_name=None, job_file=None, months_to_deletion=6
+        old_cloud_image_name=None, job_file=None, months_to_deletion=6,
+        notification_email=None, notification_type='single'
     ):
         super(GCEDeprecationJob, self).__init__(
             id, last_service, cloud, utctime,
-            old_cloud_image_name=old_cloud_image_name, job_file=job_file
+            old_cloud_image_name=old_cloud_image_name, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.deprecation_accounts = deprecation_accounts

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -32,7 +32,8 @@ class AzureJob(BaseJob):
         tests=None, conditions=None, instance_type=None,
         old_cloud_image_name=None, cleanup_images=True,
         cloud_architecture='x86_64', version_key=None,
-        cloud_accounts=None, cloud_groups=None
+        cloud_accounts=None, cloud_groups=None,
+        notification_email=None, notification_type='single'
     ):
         self.target_account_info = {}
 
@@ -41,7 +42,8 @@ class AzureJob(BaseJob):
             requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
             conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups
+            cloud_architecture, cloud_accounts, cloud_groups,
+            notification_email, notification_type
         )
 
         self.emails = emails

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -31,7 +31,8 @@ class BaseJob(object):
         utctime, image, cloud_image_name, image_description, distro,
         download_url, tests=None, conditions=None, instance_type=None,
         old_cloud_image_name=None, cleanup_images=True,
-        cloud_architecture='x86_64', cloud_accounts=None, cloud_groups=None
+        cloud_architecture='x86_64', cloud_accounts=None, cloud_groups=None,
+        notification_email=None, notification_type='single'
     ):
         self.id = job_id
         self.accounts_info = accounts_info
@@ -53,12 +54,18 @@ class BaseJob(object):
         self.instance_type = instance_type
         self.cloud_architecture = cloud_architecture
         self.utctime = utctime
+        self.notification_email = notification_email
+        self.notification_type = notification_type
 
         self.base_message = {
             'id': self.id,
             'utctime': self.utctime,
             'last_service': self.last_service
         }
+
+        if self.notification_email:
+            self.base_message['notification_email'] = self.notification_email
+            self.base_message['notification_type'] = self.notification_type
 
         self.post_init()
 

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -33,7 +33,8 @@ class EC2Job(BaseJob):
         download_url, tests=None, allow_copy=True, conditions=None,
         instance_type=None, share_with='all', old_cloud_image_name=None,
         cleanup_images=True, cloud_architecture='x86_64',
-        cloud_accounts=None, cloud_groups=None
+        cloud_accounts=None, cloud_groups=None,
+        notification_email=None, notification_type='single'
     ):
         self.share_with = share_with
         self.allow_copy = allow_copy
@@ -44,7 +45,8 @@ class EC2Job(BaseJob):
             requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
             conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups
+            cloud_architecture, cloud_accounts, cloud_groups,
+            notification_email, notification_type
         )
 
     def _get_account_info(self):

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -31,7 +31,8 @@ class GCEJob(BaseJob):
         download_url, tests=None, conditions=None, instance_type=None,
         family=None, old_cloud_image_name=None, cleanup_images=True,
         cloud_architecture='x86_64', months_to_deletion=6,
-        cloud_accounts=None, cloud_groups=None
+        cloud_accounts=None, cloud_groups=None,
+        notification_email=None, notification_type='single'
     ):
         self.family = family
         self.target_account_info = {}
@@ -41,7 +42,8 @@ class GCEJob(BaseJob):
             requesting_user, last_service, utctime, image,
             cloud_image_name, image_description, distro, download_url, tests,
             conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups
+            cloud_architecture, cloud_accounts, cloud_groups,
+            notification_email, notification_type
         )
 
         self.months_to_deletion = months_to_deletion

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -24,7 +24,8 @@ class MashJob(object):
     Class for an individual mash job.
     """
     def __init__(
-        self, id, last_service, cloud, utctime, job_file=None
+        self, id, last_service, cloud, utctime, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         # Properties
         self._cloud_image_name = None
@@ -39,6 +40,8 @@ class MashJob(object):
         self.last_service = last_service
         self.cloud = cloud
         self.utctime = utctime
+        self.notification_email = notification_email
+        self.notification_type = notification_type
 
     def get_job_id(self):
         """

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -87,6 +87,7 @@ class MashService(object):
         self.smtp_ssl = self.config.get_smtp_ssl()
         self.smtp_user = self.config.get_smtp_user()
         self.smtp_pass = self.config.get_smtp_pass()
+        self.notification_subject = self.config.get_notification_subject()
 
         # setup service data directory
         self.job_directory = Defaults.get_job_directory(self.service_exchange)

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -503,7 +503,7 @@ class MashService(object):
 
     def _create_email_message(self, msg, subject, to_email, from_email):
         """
-        Return email message object.
+        Return notification email message object.
         """
         email_msg = EmailMessage()
 

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -147,7 +147,9 @@ class OBSImageBuildResultService(MashService):
                     "condition": ">="
                   },
                   {"image": "1.42.1"}
-              ]
+              ],
+              "notification_email": "test@fake.com",
+              "notification_type": "single"
           }
         }
         """
@@ -209,6 +211,7 @@ class OBSImageBuildResultService(MashService):
             'job_file': job['job_file'],
             'download_url': job['download_url'],
             'image_name': job['image'],
+            'last_service': job['last_service'],
             'download_directory': self.download_directory
         }
 
@@ -218,9 +221,14 @@ class OBSImageBuildResultService(MashService):
         if 'cloud_architecture' in job:
             kwargs['arch'] = job['cloud_architecture']
 
+        if 'notification_email' in job:
+            kwargs['notification_email'] = job['notification_email']
+            kwargs['notification_type'] = job['notification_type']
+
         job_worker = OBSImageBuildResult(**kwargs)
         job_worker.set_log_handler(self._send_job_response)
         job_worker.set_result_handler(self._send_job_result_for_uploader)
+        job_worker.set_notification_handler(self.send_email_notification)
         job_worker.start_watchdog(
             nonstop=nonstop, isotime=time
         )

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -260,6 +260,13 @@ class PipelineService(MashService):
         if (job.utctime != 'always' or job.status == SUCCESS) \
                 and job.last_service != self.service_exchange:
             self._publish_message(job)
+
+        self.send_email_notification(
+            job.id, job.notification_email, job.notification_type, job.status,
+            job.utctime, job.last_service, job.iteration_count,
+            event.exception
+        )
+
         job.listener_msg.ack()
 
     def _publish_message(self, job):

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -39,10 +39,13 @@ class AzurePublisherJob(PublisherJob):
     def __init__(
         self, emails, id, image_description, label,
         last_service, offer_id, cloud, publish_regions, publisher_id, sku,
-        utctime, job_file=None, version_key=None
+        utctime, job_file=None, version_key=None,
+        notification_email=None, notification_type='single'
     ):
         super(AzurePublisherJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.emails = emails

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -30,10 +30,13 @@ class EC2PublisherJob(PublisherJob):
 
     def __init__(
         self, id, last_service, cloud, publish_regions, utctime,
-        allow_copy=True, job_file=None, share_with='all'
+        allow_copy=True, job_file=None, share_with='all',
+        notification_email=None, notification_type='single'
     ):
         super(EC2PublisherJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.allow_copy = allow_copy

--- a/mash/services/publisher/gce_job.py
+++ b/mash/services/publisher/gce_job.py
@@ -26,10 +26,13 @@ class GCEPublisherJob(PublisherJob):
     """
 
     def __init__(
-        self, id, last_service, cloud, utctime, job_file=None
+        self, id, last_service, cloud, utctime, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(GCEPublisherJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         # Skip credential request since there is no publishing in GCE

--- a/mash/services/publisher/publisher_job.py
+++ b/mash/services/publisher/publisher_job.py
@@ -26,10 +26,13 @@ class PublisherJob(MashJob):
     """
 
     def __init__(
-        self, id, last_service, cloud, utctime, job_file=None
+        self, id, last_service, cloud, utctime, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(PublisherJob, self).__init__(
-            id, last_service, cloud, utctime, job_file
+            id, last_service, cloud, utctime, job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
     def _publish(self):

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -34,10 +34,13 @@ class AzureReplicationJob(ReplicationJob):
 
     def __init__(
         self, id, image_description, last_service, cloud, utctime,
-        replication_source_regions, cleanup_images=True, job_file=None
+        replication_source_regions, cleanup_images=True, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(AzureReplicationJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.cleanup_images = cleanup_images

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -33,10 +33,13 @@ class EC2ReplicationJob(ReplicationJob):
 
     def __init__(
         self, id, image_description, last_service, cloud, utctime,
-        replication_source_regions, job_file=None
+        replication_source_regions, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(EC2ReplicationJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self.image_description = image_description

--- a/mash/services/replication/gce_job.py
+++ b/mash/services/replication/gce_job.py
@@ -26,10 +26,13 @@ class GCEReplicationJob(ReplicationJob):
     """
 
     def __init__(
-        self, id, last_service, cloud, utctime, job_file=None
+        self, id, last_service, cloud, utctime, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(GCEReplicationJob, self).__init__(
-            id, last_service, cloud, utctime, job_file=job_file
+            id, last_service, cloud, utctime, job_file=job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         # Skip credential request since there is no replication in GCE

--- a/mash/services/replication/replication_job.py
+++ b/mash/services/replication/replication_job.py
@@ -26,10 +26,13 @@ class ReplicationJob(MashJob):
     """
 
     def __init__(
-        self, id, last_service, cloud, utctime, job_file=None
+        self, id, last_service, cloud, utctime, job_file=None,
+        notification_email=None, notification_type='single'
     ):
         super(ReplicationJob, self).__init__(
-            id, last_service, cloud, utctime, job_file
+            id, last_service, cloud, utctime, job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         self._source_regions = None

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -39,7 +39,8 @@ class AzureTestingJob(TestingJob):
         self, id, last_service, cloud, ssh_private_key_file, test_regions,
         tests, utctime, job_file=None, description=None,
         distro='sles', instance_type=None, ipa_timeout=None,
-        ssh_user='azureuser'
+        ssh_user='azureuser', notification_email=None,
+        notification_type='single'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -48,7 +49,9 @@ class AzureTestingJob(TestingJob):
             id, last_service, cloud, ssh_private_key_file, test_regions,
             tests, utctime, job_file=job_file, description=description,
             distro=distro, instance_type=instance_type,
-            ipa_timeout=ipa_timeout, ssh_user=ssh_user
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
     def _add_cloud_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -42,7 +42,8 @@ class EC2TestingJob(TestingJob):
         self, id, last_service, cloud, ssh_private_key_file, test_regions,
         tests, utctime, job_file=None, description=None,
         distro='sles', instance_type=None, ipa_timeout=None,
-        ssh_user='ec2-user'
+        ssh_user='ec2-user', notification_email=None,
+        notification_type='single'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -51,7 +52,9 @@ class EC2TestingJob(TestingJob):
             id, last_service, cloud, ssh_private_key_file, test_regions,
             tests, utctime, job_file=job_file, description=description,
             distro=distro, instance_type=instance_type,
-            ipa_timeout=ipa_timeout, ssh_user=ssh_user
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
     def _add_cloud_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -38,7 +38,8 @@ class GCETestingJob(TestingJob):
     def __init__(
         self, id, last_service, cloud, ssh_private_key_file, test_regions,
         tests, utctime, job_file=None, description=None,
-        distro='sles', instance_type=None, ipa_timeout=None, ssh_user='root'
+        distro='sles', instance_type=None, ipa_timeout=None, ssh_user='root',
+        notification_email=None, notification_type='single'
     ):
         if not instance_type:
             instance_type = random.choice(instance_types)
@@ -47,7 +48,9 @@ class GCETestingJob(TestingJob):
             id, last_service, cloud, ssh_private_key_file, test_regions,
             tests, utctime, job_file=job_file, description=description,
             distro=distro, instance_type=instance_type,
-            ipa_timeout=ipa_timeout, ssh_user=ssh_user
+            ipa_timeout=ipa_timeout, ssh_user=ssh_user,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
     def _add_cloud_creds(self, creds, ipa_kwargs):

--- a/mash/services/testing/testing_job.py
+++ b/mash/services/testing/testing_job.py
@@ -34,10 +34,13 @@ class TestingJob(MashJob):
     def __init__(
         self, id, last_service, cloud, ssh_private_key_file, test_regions,
         tests, utctime, job_file=None, description=None, distro='sles',
-        instance_type=None, ipa_timeout=None, ssh_user=None
+        instance_type=None, ipa_timeout=None, ssh_user=None,
+        notification_email=None, notification_type='single'
     ):
         super(TestingJob, self).__init__(
-            id, last_service, cloud, utctime, job_file
+            id, last_service, cloud, utctime, job_file,
+            notification_email=notification_email,
+            notification_type=notification_type
         )
 
         # properties

--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -74,6 +74,7 @@ class UploadImage(object):
         self.upload_region = None
         self.iteration_count = 0
         self.uploader = None
+        self.error_msg = None
 
     def set_image_file(self, system_image_file):
         self.system_image_file = system_image_file
@@ -111,6 +112,7 @@ class UploadImage(object):
                 )
             except Exception as e:
                 self._log_callback(format(e))
+                self.error_msg = e
 
             self._result_callback()
 
@@ -134,7 +136,8 @@ class UploadImage(object):
                     'csp_name': self.csp_name,
                     'cloud_image_id': self.cloud_image_id,
                     'upload_region': self.upload_region,
-                    'job_status': job_status
+                    'job_status': job_status,
+                    'error_msg': self.error_msg
                 }
             )
 

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -34,5 +34,6 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "version_key": "key123"
+  "version_key": "key123",
+  "notification_email": "test@fake.com"
 }

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -25,5 +25,6 @@
   "instance_type": "t2.micro",
   "family": "sles-15",
   "months_to_deletion": 5,
-  "tests": ["test_stuff"]
+  "tests": ["test_stuff"],
+  "notification_email": "test@fake.com"
 }

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -23,5 +23,6 @@
   "instance_type": "t2.micro",
   "tests": ["test_stuff"],
   "cleanup_images": true,
-  "cloud_architecture": "aarch64"
+  "cloud_architecture": "aarch64",
+  "notification_email": "test@fake.com"
 }

--- a/test/data/job1.json
+++ b/test/data/job1.json
@@ -7,6 +7,8 @@
     "conditions": [
       {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},
       {"image": "1.42.1"}
-    ]
+    ],
+    "notification_email": "test@fake.com",
+    "notification_type": "single"
   }
 }

--- a/test/data/job2.json
+++ b/test/data/job2.json
@@ -3,6 +3,8 @@
     "id": "123",
     "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
     "image": "test-image-oem",
-    "utctime": "always"
+    "utctime": "always",
+    "notification_email": "test@fake.com",
+    "notification_type": "single"
   }
 }

--- a/test/data/job3.json
+++ b/test/data/job3.json
@@ -3,6 +3,8 @@
     "id": "123",
     "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
     "image": "test-image-oem",
-    "utctime": "Wed Oct 11 17:50:26 UTC 2017"
+    "utctime": "Wed Oct 11 17:50:26 UTC 2017",
+    "notification_email": "test@fake.com",
+    "notification_type": "single"
   }
 }

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -4,6 +4,8 @@ ssh_private_key_file: /var/lib/mash/ssh_key
 amqp_host: localhost
 amqp_user: guest
 amqp_pass: guest
+smtp_user: user@test.com
+smtp_pass: super.secret
 services:
   - obs
   - uploader

--- a/test/data/upload_job1.json
+++ b/test/data/upload_job1.json
@@ -7,6 +7,8 @@
             "region": "eu-central-1"
         },
         "id": "123",
-        "utctime": "now"
+        "utctime": "now",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/test/data/upload_job2.json
+++ b/test/data/upload_job2.json
@@ -4,6 +4,8 @@
         "cloud_image_name": "b",
         "ec2": {},
         "id": "123",
-        "utctime": "always"
+        "utctime": "always",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/test/data/upload_job3.json
+++ b/test/data/upload_job3.json
@@ -4,6 +4,8 @@
         "cloud_image_name": "b",
         "ec2": {},
         "id": "123",
-        "utctime": "Wed Oct 11 17:50:26 UTC 2017"
+        "utctime": "Wed Oct 11 17:50:26 UTC 2017",
+        "notification_email": "test@fake.com",
+        "notification_type": "single"
     }
 }

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -75,3 +75,29 @@ class TestBaseConfig(object):
     def test_get_amqp_pass(self):
         password = self.empty_config.get_amqp_pass()
         assert password == 'guest'
+
+    def test_get_smtp_host(self):
+        host = self.empty_config.get_smtp_host()
+        assert host == 'localhost'
+
+    def test_get_smtp_port(self):
+        port = self.empty_config.get_smtp_port()
+        assert port == 25
+
+    def test_get_smtp_ssl(self):
+        ssl = self.empty_config.get_smtp_ssl()
+        assert not ssl
+
+    def test_get_smtp_user(self):
+        user = self.config.get_smtp_user()
+        assert user == 'user@test.com'
+
+        user = self.empty_config.get_smtp_user()
+        assert user is None
+
+    def test_get_smtp_pass(self):
+        password = self.config.get_smtp_pass()
+        assert password == 'super.secret'
+
+        password = self.empty_config.get_smtp_pass()
+        assert password is None

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -104,3 +104,7 @@ class TestBaseConfig(object):
 
         password = self.empty_config.get_smtp_pass()
         assert password is None
+
+    def test_get_notification_subject(self):
+        subject = self.empty_config.get_notification_subject()
+        assert subject == '[MASH] Job Status Update'

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -92,8 +92,11 @@ class TestBaseConfig(object):
         user = self.config.get_smtp_user()
         assert user == 'user@test.com'
 
-        user = self.empty_config.get_smtp_user()
-        assert user is None
+        with raises(MashConfigException) as error:
+            self.empty_config.get_smtp_user()
+
+        msg = 'smtp_user is required in MASH configuration file.'
+        assert str(error.value) == msg
 
     def test_get_smtp_pass(self):
         password = self.config.get_smtp_pass()

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -198,7 +198,9 @@ class TestCredentialsService(object):
         )
         mock_publish.assert_called_once_with(
             'jobcreator', 'job_document',
-            JsonFormat.json_message({"invalid_job": "123"})
+            JsonFormat.json_message(
+                {"error_msg": "missing account", "invalid_job": "123"}
+            )
         )
 
     @patch.object(CredentialsService, '_generate_encryption_key')

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -153,6 +153,8 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
                     "last_service": "pint",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })
@@ -162,12 +164,14 @@ class TestJobCreatorService(object):
             'uploader', 'job_document',
             JsonFormat.json_message({
                 "uploader_job": {
+                    "cloud": "ec2",
                     "cloud_architecture": "aarch64",
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "pint",
-                    "cloud": "ec2",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "target_regions": {
                         "ap-northeast-1": {
                             "account": "test-aws",
@@ -186,11 +190,13 @@ class TestJobCreatorService(object):
             'testing', 'job_document',
             JsonFormat.json_message({
                 "testing_job": {
+                    "cloud": "ec2",
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
                     "last_service": "pint",
-                    "cloud": "ec2",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "test_regions": {
                         "ap-northeast-1": "test-aws",
                         "us-gov-west-1": "test-aws-gov"
@@ -204,10 +210,12 @@ class TestJobCreatorService(object):
             'replication', 'job_document',
             JsonFormat.json_message({
                 "replication_job": {
+                    "cloud": "ec2",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "pint",
-                    "cloud": "ec2",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "replication_source_regions": {
                         "ap-northeast-1": {
                             "account": "test-aws",
@@ -269,11 +277,13 @@ class TestJobCreatorService(object):
             'pint', 'job_document',
             JsonFormat.json_message({
                 "pint_job": {
+                    "cloud": "ec2",
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "last_service": "pint",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "old_cloud_image_name": "old_new_image_123",
-                    "cloud": "ec2",
                     "utctime": "now"
                 }
             })
@@ -358,6 +368,8 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
                     "last_service": "deprecation",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })
@@ -366,12 +378,14 @@ class TestJobCreatorService(object):
             'uploader', 'job_document',
             JsonFormat.json_message({
                 "uploader_job": {
+                    "cloud": "azure",
                     "cloud_architecture": "x86_64",
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "deprecation",
-                    "cloud": "azure",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "target_regions": {
                         "centralus": {
                             "account": "test-azure2",
@@ -394,11 +408,13 @@ class TestJobCreatorService(object):
             'testing', 'job_document',
             JsonFormat.json_message({
                 "testing_job": {
+                    "cloud": "azure",
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
                     "last_service": "deprecation",
-                    "cloud": "azure",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "test_regions": {
                         "centralus": "test-azure2",
                         "southcentralus": "test-azure"
@@ -413,10 +429,12 @@ class TestJobCreatorService(object):
             JsonFormat.json_message({
                 "replication_job": {
                     "cleanup_images": True,
+                    "cloud": "azure",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "deprecation",
-                    "cloud": "azure",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "replication_source_regions": {
                         "centralus": {
                             "account": "test-azure2",
@@ -454,6 +472,8 @@ class TestJobCreatorService(object):
         assert data['sku'] == '123'
         assert data['utctime'] == 'now'
         assert data['version_key'] == 'key123'
+        assert data['notification_email'] == 'test@fake.com'
+        assert data['notification_type'] == 'single'
         for region in data['publish_regions']:
             assert region['account'] in ('test-azure', 'test-azure2')
             if region['account'] == 'test-azure':
@@ -469,9 +489,11 @@ class TestJobCreatorService(object):
             'deprecation', 'job_document',
             JsonFormat.json_message({
                 "deprecation_job": {
+                    "cloud": "azure",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "last_service": "deprecation",
-                    "cloud": "azure",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })
@@ -546,6 +568,8 @@ class TestJobCreatorService(object):
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image": "test_image_oem",
                     "last_service": "deprecation",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })
@@ -554,12 +578,14 @@ class TestJobCreatorService(object):
             'uploader', 'job_document',
             JsonFormat.json_message({
                 "uploader_job": {
+                    "cloud": "gce",
                     "cloud_architecture": "x86_64",
                     "cloud_image_name": "new_image_123",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "image_description": "New Image #123",
                     "last_service": "deprecation",
-                    "cloud": "gce",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "target_regions": {
                         "us-west2": {
                             "account": "test-gce2",
@@ -580,11 +606,13 @@ class TestJobCreatorService(object):
             'testing', 'job_document',
             JsonFormat.json_message({
                 "testing_job": {
+                    "cloud": "gce",
                     "distro": "sles",
                     "id": "12345678-1234-1234-1234-123456789012",
                     "instance_type": "t2.micro",
                     "last_service": "deprecation",
-                    "cloud": "gce",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "test_regions": {
                         "us-west2": "test-gce2",
                         "us-west1": "test-gce"
@@ -599,8 +627,10 @@ class TestJobCreatorService(object):
             JsonFormat.json_message({
                 "replication_job": {
                     "id": "12345678-1234-1234-1234-123456789012",
-                    "last_service": "deprecation",
                     "cloud": "gce",
+                    "last_service": "deprecation",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })
@@ -610,8 +640,10 @@ class TestJobCreatorService(object):
             JsonFormat.json_message({
                 "publisher_job": {
                     "id": "12345678-1234-1234-1234-123456789012",
-                    "last_service": "deprecation",
                     "cloud": "gce",
+                    "last_service": "deprecation",
+                    "notification_email": "test@fake.com",
+                    "notification_type": "single",
                     "utctime": "now"
                 }
             })

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -179,6 +179,7 @@ class TestOBSImageBuildResultService(object):
                 "download_url": "http://download.suse.de/ibs/Devel:/"
                                 "PubCloud:/Stable:/Images12/images",
                 "image": "test-image-oem",
+                "last_service": "publisher",
                 "utctime": "now",
                 "conditions": [
                     {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},
@@ -222,12 +223,15 @@ class TestOBSImageBuildResultService(object):
             "download_url": "http://download.suse.de/ibs/Devel:/"
                             "PubCloud:/Stable:/Images12/images",
             "image": "test-image-oem",
+            "last_service": "publisher",
             "utctime": "now",
             "conditions": [
                 {"package": ["kernel-default", ">=4.13.1", ">=1.1"]},
                 {"image": "1.42.1"}
             ],
-            "cloud_architecture": "aarch64"
+            "cloud_architecture": "aarch64",
+            "notification_email": "test@fake.com",
+            "notification_type": "single"
         }
         self.obs_result._start_job(data)
         job_worker.set_log_handler.assert_called_once_with(
@@ -250,6 +254,7 @@ class TestOBSImageBuildResultService(object):
             "download_url": "http://download.suse.de/ibs/Devel:/"
                             "PubCloud:/Stable:/Images12/images",
             "image": "test-image-oem",
+            "last_service": "publisher",
             "utctime": "always"
         }
         self.obs_result._start_job(data)
@@ -267,6 +272,7 @@ class TestOBSImageBuildResultService(object):
             "download_url": "http://download.suse.de/ibs/Devel:/"
                             "PubCloud:/Stable:/Images12/images",
             "image": "test-image-oem",
+            "last_service": "publisher",
             "utctime": "Wed Oct 11 17:50:26 UTC 2017"
         }
         self.obs_result._start_job(data)

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -295,10 +295,12 @@ class TestPipelineService(object):
             ' line 1 column 1 (char 0).'
         )
 
+    @patch.object(PipelineService, 'send_email_notification')
     @patch.object(PipelineService, '_delete_job')
     @patch.object(PipelineService, '_publish_message')
     def test_service_process_job_result(
-        self, mock_publish_message, mock_delete_job
+        self, mock_publish_message, mock_delete_job,
+        mock_send_email_notification
     ):
         event = Mock()
         event.job_id = '1'
@@ -325,10 +327,12 @@ class TestPipelineService(object):
         mock_publish_message.assert_called_once_with(job)
         msg.ack.assert_called_once_with()
 
+    @patch.object(PipelineService, 'send_email_notification')
     @patch.object(PipelineService, '_delete_job')
     @patch.object(PipelineService, '_publish_message')
     def test_service_process_job_result_exception(
-        self, mock_publish_message, mock_delete_job
+        self, mock_publish_message, mock_delete_job,
+        mock_send_email_notification
     ):
         event = Mock()
         event.job_id = '1'
@@ -350,10 +354,12 @@ class TestPipelineService(object):
         )
         mock_publish_message.assert_called_once_with(job)
 
+    @patch.object(PipelineService, 'send_email_notification')
     @patch.object(PipelineService, '_delete_job')
     @patch.object(PipelineService, '_publish_message')
     def test_publishing_process_job_result_fail(
-        self, mock_publish_message, mock_delete_job
+        self, mock_publish_message, mock_delete_job,
+        mock_send_email_notification
     ):
         event = Mock()
         event.job_id = '1'

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -91,7 +91,8 @@ class TestUploadImage(object):
                 'cloud_image_id': 'id',
                 'upload_region': None,
                 'csp_name': 'ec2',
-                'job_status': 'success'
+                'job_status': 'success',
+                'error_msg': None
             }
         )
         self.upload_image.result_callback.reset_mock()
@@ -103,6 +104,7 @@ class TestUploadImage(object):
                 'cloud_image_id': None,
                 'upload_region': 'eu-central-1',
                 'csp_name': 'ec2',
-                'job_status': 'failed'
+                'job_status': 'failed',
+                'error_msg': None
             }
         )


### PR DESCRIPTION
Email notifications can be enabled with two new job arguments:

- notification_email
- notification_type (default: single)

Emails are sent based on:

- When a job fails. The error message is appended if available.
- If a job is onetime and passes final service.
- If onetime job and notification_type is periodic an email is sent when each service finishes.