### PR TITLE
Improve message for uploading

### DIFF
--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -108,7 +108,8 @@ class UploadImage(object):
                 self.cloud_image_id, self.upload_region = \
                     self.uploader.upload()
                 self._log_callback(
-                    'Uploaded image has ID: {0}'.format(self.cloud_image_id)
+                    'Uploaded image has ID: {0} in region {1}'.format(
+                        self.cloud_image_id, self.upload_region)
                 )
             except Exception as e:
                 self._log_callback(format(e))

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -43,7 +43,7 @@ class TestUploadImage(object):
                     self.custom_uploader_args
                 )
             ),
-            call('Uploaded image has ID: image_id')
+            call('Uploaded image has ID: image_id in region region')
         ]
         mock_result_callback.assert_called_once_with()
 


### PR DESCRIPTION
  + When uploading to multiple regions it was not possible to associate
    the logged image ID with the region to which the image was uploaded

### What does this PR do? Why are we making this change?
Closes #416 

### How will these changes be tested?
Unit test updated

### How will this change be deployed? Any special considerations?
Normal process

### Additional Information
