### PR TITLE
Remove last region handling.

### DIFF
--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -52,7 +52,7 @@ class UploadImage(object):
     """
     def __init__(
         self, job_id, job_file, csp_name, credentials_token,
-        cloud_image_name, cloud_image_description, last_upload_region,
+        cloud_image_name, cloud_image_description,
         custom_uploader_args=None, arch='x86_64'
     ):
         self.job_id = job_id
@@ -63,7 +63,6 @@ class UploadImage(object):
         self.cloud_image_name = cloud_image_name
         self.cloud_image_description = cloud_image_description
         self.custom_uploader_args = custom_uploader_args
-        self.last_upload_region = last_upload_region
 
         self.credentials_token = credentials_token
 
@@ -133,7 +132,7 @@ class UploadImage(object):
             else:
                 job_status = 'failed'
             self.result_callback(
-                self.job_id, self.last_upload_region, {
+                self.job_id, {
                     'csp_name': self.csp_name,
                     'cloud_image_id': self.cloud_image_id,
                     'upload_region': self.upload_region,

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -210,11 +210,18 @@ class TestUploadImageService(object):
         self.uploader._init_job(self.job_data_ec2)
         trigger_info = {
             'job_status': 'success',
-            'upload_region': 'region',
+            'upload_region': 'eu-central-2',
             'cloud_image_id': 'image_id',
             'error_msg': 'Job failed'
         }
-        self.uploader._send_job_result('123', True, trigger_info)
+        self.uploader._send_job_result('123', trigger_info)
+        trigger_info = {
+            'job_status': 'success',
+            'upload_region': 'eu-central-1',
+            'cloud_image_id': 'image_id',
+            'error_msg': 'Job failed'
+        }
+        self.uploader._send_job_result('123', trigger_info)
         mock_publish_job_result.assert_called_once_with(
             '123', publish_on_failed_job=True
         )
@@ -228,7 +235,7 @@ class TestUploadImageService(object):
         uploader = [mock_count]
         self.uploader.jobs['123']['uploader'] = uploader
         self.uploader.jobs['123']['utctime'] = 'always'
-        self.uploader._send_job_result('123', True, trigger_info)
+        self.uploader._send_job_result('123', trigger_info)
         mock_publish_job_result.assert_called_once_with(
             '123', publish_on_failed_job=False
         )
@@ -413,7 +420,7 @@ class TestUploadImageService(object):
                     'account': 'test-aws',
                     'region': 'eu-central-1',
                     'billing_codes': 'ab-1ab12345'
-                }, True
+                }
             ]
         )
 
@@ -432,7 +439,7 @@ class TestUploadImageService(object):
                     'storage_account': 'ms1storage',
                     'account': 'test-azure',
                     'region': 'westeurope'
-                }, True
+                }
             ]
         )
 
@@ -450,7 +457,7 @@ class TestUploadImageService(object):
                     'bucket': 'images',
                     'family': 'sles-15',
                     'region': 'us-east1'
-                }, True
+                }
             ]
         )
 
@@ -473,13 +480,13 @@ class TestUploadImageService(object):
                 'launch_ami': 'ami-bc5b48d0',
                 'account': 'test-aws',
                 'region': 'eu-central-1'
-            }, True
+            }
         )
         image_name = 'name-{}'.format(
             datetime.date.today().strftime("%Y%m%d")
         )
         mock_UploadImage.assert_called_once_with(
-            '123', 'job_file', 'ec2', {}, image_name, 'description', True, {
+            '123', 'job_file', 'ec2', {}, image_name, 'description', {
                 'launch_ami': 'ami-bc5b48d0', 'region': 'eu-central-1',
                 'account': 'test-aws'
             }, 'x86_64'

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -13,7 +13,6 @@ class TestUploadImage(object):
             '123', 'job_file', 'ec2',
             'token', 'cloud_image_name_at_080808',
             'cloud_image_description',
-            last_upload_region=False,
             custom_uploader_args=self.custom_uploader_args,
             arch='arch'
         )
@@ -87,7 +86,7 @@ class TestUploadImage(object):
         self.upload_image.cloud_image_id = 'id'
         self.upload_image._result_callback()
         self.upload_image.result_callback.assert_called_once_with(
-            '123', False, {
+            '123', {
                 'cloud_image_id': 'id',
                 'upload_region': None,
                 'csp_name': 'ec2',
@@ -100,7 +99,7 @@ class TestUploadImage(object):
         self.upload_image.upload_region = 'eu-central-1'
         self.upload_image._result_callback()
         self.upload_image.result_callback.assert_called_once_with(
-            '123', False, {
+            '123', {
                 'cloud_image_id': None,
                 'upload_region': 'eu-central-1',
                 'csp_name': 'ec2',


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The final region in the list may finish before the others causing
results to be sent to testing service before all regions uploaded.

Set upload finished flag when each region is finished.

### How will these changes be tested?

Unit & integration tests.

### Additional Information

I see this as a temporary fix. It still has the chance for a race condition on updating the finished flag in dictionary however it is much less likely to happen. Eventually uploader will need a way to correlate a set of region tasks with each other. I.e. the job could be started in background scheduler which itself spawns the region threads. That way you can join to the threads and be sure they finish without race conditions. But this will take a significant amount of rework so I think the temporary fix is sufficient for now.

Fixes #420 