### PR TITLE
Azure publishing and deprecation

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -35,5 +35,6 @@
   "label": "New Image 123",
   "sku": "123",
   "vm_images_key": "key123",
-  "notification_email": "test@fake.com"
+  "notification_email": "test@fake.com",
+  "publish_offer": true
 }

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -34,6 +34,6 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "version_key": "key123",
+  "vm_images_key": "key123",
   "notification_email": "test@fake.com"
 }

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -343,7 +343,7 @@ azure_job_message['properties']['publisher_id'] = {
 azure_job_message['properties']['sku'] = {
     '$ref': '#/definitions/non_empty_string'
 }
-azure_job_message['properties']['version_key'] = {
+azure_job_message['properties']['vm_images_key'] = {
     '$ref': '#/definitions/non_empty_string'
 }
 azure_job_message['required'].append('emails')

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -346,6 +346,7 @@ azure_job_message['properties']['sku'] = {
 azure_job_message['properties']['vm_images_key'] = {
     '$ref': '#/definitions/non_empty_string'
 }
+azure_job_message['properties']['publish_offer'] = {'type': 'boolean'}
 azure_job_message['required'].append('emails')
 azure_job_message['required'].append('label')
 azure_job_message['required'].append('offer_id')

--- a/mash/services/azure_utils.py
+++ b/mash/services/azure_utils.py
@@ -430,7 +430,7 @@ def request_cloud_partner_offer_doc(credentials, offer_id, publisher_id):
 
 def update_cloud_partner_offer_doc(
     doc, blob_url, description, image_name, label, sku,
-    version_key='microsoft-azure-corevm.vmImagesPublicAzure'
+    vm_images_key='microsoft-azure-corevm.vmImagesPublicAzure'
 ):
     """
     Update the cloud partner offer doc with a new version of the given sku.
@@ -456,10 +456,10 @@ def update_cloud_partner_offer_doc(
         if doc_sku['planId'] == sku:
             release = release_date.strftime("%Y.%m.%d")
 
-            if version_key not in doc_sku:
-                doc_sku[version_key] = {}
+            if vm_images_key not in doc_sku:
+                doc_sku[vm_images_key] = {}
 
-            doc_sku[version_key][release] = version
+            doc_sku[vm_images_key][release] = version
             break
 
     return doc

--- a/mash/services/azure_utils.py
+++ b/mash/services/azure_utils.py
@@ -465,6 +465,34 @@ def update_cloud_partner_offer_doc(
     return doc
 
 
+def deprecate_image_in_offer_doc(
+    doc, image_name, sku,
+    vm_images_key='microsoft-azure-corevm.vmImagesPublicAzure'
+):
+    """
+    Deprecate the image in the cloud partner offer doc.
+
+    The image is set to not show in gui.
+    """
+    matches = re.findall(r'\d{8}', image_name)
+
+    if matches:
+        release_date = datetime.strptime(matches[0], '%Y%m%d').date()
+        release = release_date.strftime("%Y.%m.%d")
+    else:
+        # image name must have a date to generate release key
+        return doc
+
+    for doc_sku in doc['definition']['plans']:
+        if doc_sku['planId'] == sku:
+            if vm_images_key in doc_sku \
+                    and doc_sku[vm_images_key].get(release):
+                doc_sku[vm_images_key][release]['showInGui'] = False
+            break
+
+    return doc
+
+
 def wait_on_cloud_partner_operation(
     credentials, operation, log_callback, wait_time=60 * 60 * 4
 ):

--- a/mash/services/azure_utils.py
+++ b/mash/services/azure_utils.py
@@ -466,7 +466,7 @@ def update_cloud_partner_offer_doc(
 
 
 def deprecate_image_in_offer_doc(
-    doc, image_name, sku,
+    doc, image_name, sku, log_callback,
     vm_images_key='microsoft-azure-corevm.vmImagesPublicAzure'
 ):
     """
@@ -484,10 +484,23 @@ def deprecate_image_in_offer_doc(
         return doc
 
     for doc_sku in doc['definition']['plans']:
-        if doc_sku['planId'] == sku:
-            if vm_images_key in doc_sku \
-                    and doc_sku[vm_images_key].get(release):
-                doc_sku[vm_images_key][release]['showInGui'] = False
+        if doc_sku['planId'] == sku \
+                and doc_sku.get(vm_images_key) \
+                and doc_sku[vm_images_key].get(release):
+
+            image = doc_sku[vm_images_key][release]
+
+            if image['mediaName'] == image_name:
+                image['showInGui'] = False
+            else:
+                log_callback(
+                    'Deprecation image name, {0} does match the mediaName '
+                    'attribute, {1}.'.format(
+                        image_name,
+                        image['mediaName']
+                    )
+                )
+
             break
 
     return doc

--- a/mash/services/deprecation/azure_job.py
+++ b/mash/services/deprecation/azure_job.py
@@ -85,6 +85,7 @@ class AzureDeprecationJob(DeprecationJob):
                     offer_doc,
                     self.old_cloud_image_name,
                     self.sku,
+                    self.send_log,
                     kwargs
                 )
                 put_cloud_partner_offer_doc(

--- a/mash/services/deprecation/azure_job.py
+++ b/mash/services/deprecation/azure_job.py
@@ -16,8 +16,14 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from mash.services.azure_utils import (
+    deprecate_image_in_offer_doc,
+    put_cloud_partner_offer_doc,
+    request_cloud_partner_offer_doc
+)
+
 from mash.services.deprecation.deprecation_job import DeprecationJob
-from mash.services.status_levels import SUCCESS
+from mash.services.status_levels import FAILED, SUCCESS
 
 
 class AzureDeprecationJob(DeprecationJob):
@@ -26,9 +32,10 @@ class AzureDeprecationJob(DeprecationJob):
     """
 
     def __init__(
-        self, id, last_service, cloud, utctime,
-        old_cloud_image_name=None, job_file=None,
-        notification_email=None, notification_type='single'
+        self, emails, id, last_service, cloud, deprecation_regions, offer_id,
+        publisher_id, sku, utctime, old_cloud_image_name, job_file=None,
+        notification_email=None, notification_type='single',
+        vm_images_key=None
     ):
         super(AzureDeprecationJob, self).__init__(
             id, last_service, cloud, utctime,
@@ -37,11 +44,67 @@ class AzureDeprecationJob(DeprecationJob):
             notification_type=notification_type
         )
 
-        # Skip credential request since there is no deprecation in Azure
-        self.credentials = {'status': 'no deprecation'}
+        self.emails = emails
+        self.offer_id = offer_id
+        self.publisher_id = publisher_id
+        self.deprecation_regions = deprecation_regions
+        self.sku = sku
+        self.vm_images_key = vm_images_key
 
     def _deprecate(self):
         """
-        There is no deprecation process in Azure.
+        Update deprecated image in offer doc.
+
+        The deprecated image is no longer shown in gui.
         """
         self.status = SUCCESS
+
+        for account in self.deprecation_regions:
+            credential = self.credentials[account]
+
+            self.send_log(
+                'Deprecating image for account: {0},'
+                ' using cloud partner API.'.format(
+                    account
+                )
+            )
+
+            try:
+                offer_doc = request_cloud_partner_offer_doc(
+                    credential,
+                    self.offer_id,
+                    self.publisher_id
+                )
+
+                if self.vm_images_key:
+                    kwargs = {'vm_images_key': self.vm_images_key}
+                else:
+                    kwargs = {}
+
+                offer_doc = deprecate_image_in_offer_doc(
+                    offer_doc,
+                    self.old_cloud_image_name,
+                    self.sku,
+                    kwargs
+                )
+                put_cloud_partner_offer_doc(
+                    credential,
+                    offer_doc,
+                    self.offer_id,
+                    self.publisher_id
+                )
+                self.send_log(
+                    'Deprecation finished for account: '
+                    '{}.'.format(
+                        account
+                    )
+                )
+            except Exception as error:
+                self.send_log(
+                    'There was an error deprecating image in {0}:'
+                    ' {1}'.format(
+                        account, error
+                    ),
+                    False
+                )
+                self.status = FAILED

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -33,7 +33,8 @@ class AzureJob(BaseJob):
         old_cloud_image_name=None, cleanup_images=True,
         cloud_architecture='x86_64', vm_images_key=None,
         cloud_accounts=None, cloud_groups=None,
-        notification_email=None, notification_type='single'
+        notification_email=None, notification_type='single',
+        publish_offer=False
     ):
         super(AzureJob, self).__init__(
             accounts_info, cloud_data, job_id, cloud,
@@ -50,6 +51,7 @@ class AzureJob(BaseJob):
         self.publisher_id = publisher_id
         self.sku = sku
         self.vm_images_key = vm_images_key
+        self.publish_offer = publish_offer
 
     def _get_account_info(self):
         """
@@ -125,7 +127,8 @@ class AzureJob(BaseJob):
                 'cloud': self.cloud,
                 'publish_regions': self.get_publisher_regions(),
                 'publisher_id': self.publisher_id,
-                'sku': self.sku
+                'sku': self.sku,
+                'publish_offer': self.publish_offer
             }
         }
 

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -31,7 +31,7 @@ class AzureJob(BaseJob):
         download_url, offer_id, publisher_id, sku, emails, label,
         tests=None, conditions=None, instance_type=None,
         old_cloud_image_name=None, cleanup_images=True,
-        cloud_architecture='x86_64', version_key=None,
+        cloud_architecture='x86_64', vm_images_key=None,
         cloud_accounts=None, cloud_groups=None,
         notification_email=None, notification_type='single'
     ):
@@ -49,7 +49,7 @@ class AzureJob(BaseJob):
         self.offer_id = offer_id
         self.publisher_id = publisher_id
         self.sku = sku
-        self.version_key = version_key
+        self.vm_images_key = vm_images_key
 
     def _get_account_info(self):
         """
@@ -129,9 +129,9 @@ class AzureJob(BaseJob):
             }
         }
 
-        if self.version_key:
-            publisher_message['publisher_job']['version_key'] = \
-                self.version_key
+        if self.vm_images_key:
+            publisher_message['publisher_job']['vm_images_key'] = \
+                self.vm_images_key
 
         publisher_message['publisher_job'].update(self.base_message)
 

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -107,12 +107,37 @@ class AzureJob(BaseJob):
         """
         deprecation_message = {
             'deprecation_job': {
-                'cloud': self.cloud
+                'cloud': self.cloud,
+                'emails': self.emails,
+                'offer_id': self.offer_id,
+                'deprecation_regions': self.get_deprecation_regions(),
+                'publisher_id': self.publisher_id,
+                'sku': self.sku
             }
         }
         deprecation_message['deprecation_job'].update(self.base_message)
 
+        if self.old_cloud_image_name:
+            deprecation_message['deprecation_job']['old_cloud_image_name'] = \
+                self.old_cloud_image_name
+
+        if self.vm_images_key:
+            deprecation_message['deprecation_job']['vm_images_key'] = \
+                self.vm_images_key
+
         return JsonFormat.json_message(deprecation_message)
+
+    def get_deprecation_regions(self):
+        """
+        Return list of deprecation region info.
+
+        """
+        regions = []
+
+        for source_region, value in self.target_account_info.items():
+            regions.append(value['account'])
+
+        return regions
 
     def get_publisher_message(self):
         """

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -40,7 +40,8 @@ class AzurePublisherJob(PublisherJob):
         self, emails, id, image_description, label,
         last_service, offer_id, cloud, publish_regions, publisher_id, sku,
         utctime, job_file=None, vm_images_key=None,
-        notification_email=None, notification_type='single'
+        notification_email=None, notification_type='single',
+        publish_offer=False
     ):
         super(AzurePublisherJob, self).__init__(
             id, last_service, cloud, utctime, job_file=job_file,
@@ -56,6 +57,7 @@ class AzurePublisherJob(PublisherJob):
         self.publish_regions = publish_regions
         self.sku = sku
         self.vm_images_key = vm_images_key
+        self.publish_offer = publish_offer
 
     def _publish(self):
         """
@@ -115,17 +117,20 @@ class AzurePublisherJob(PublisherJob):
                             region_info['account']
                         )
                     )
-                    operation = publish_cloud_partner_offer(
-                        credential,
-                        self.emails,
-                        self.offer_id,
-                        self.publisher_id
-                    )
-                    wait_on_cloud_partner_operation(
-                        credential,
-                        operation,
-                        self.send_log
-                    )
+
+                    if self.publish_offer:
+                        operation = publish_cloud_partner_offer(
+                            credential,
+                            self.emails,
+                            self.offer_id,
+                            self.publisher_id
+                        )
+                        wait_on_cloud_partner_operation(
+                            credential,
+                            operation,
+                            self.send_log
+                        )
+
                     self.send_log(
                         'Publishing finished for account: '
                         '{}.'.format(

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -39,7 +39,7 @@ class AzurePublisherJob(PublisherJob):
     def __init__(
         self, emails, id, image_description, label,
         last_service, offer_id, cloud, publish_regions, publisher_id, sku,
-        utctime, job_file=None, version_key=None,
+        utctime, job_file=None, vm_images_key=None,
         notification_email=None, notification_type='single'
     ):
         super(AzurePublisherJob, self).__init__(
@@ -55,7 +55,7 @@ class AzurePublisherJob(PublisherJob):
         self.publisher_id = publisher_id
         self.publish_regions = publish_regions
         self.sku = sku
-        self.version_key = version_key
+        self.vm_images_key = vm_images_key
 
     def _publish(self):
         """
@@ -89,8 +89,8 @@ class AzurePublisherJob(PublisherJob):
                         self.publisher_id
                     )
 
-                    if self.version_key:
-                        kwargs = {'version_key': self.version_key}
+                    if self.vm_images_key:
+                        kwargs = {'vm_images_key': self.vm_images_key}
                     else:
                         kwargs = {}
 

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -35,5 +35,6 @@
   "label": "New Image 123",
   "sku": "123",
   "vm_images_key": "key123",
-  "notification_email": "test@fake.com"
+  "notification_email": "test@fake.com",
+  "publish_offer": true
 }

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -34,6 +34,6 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "version_key": "key123",
+  "vm_images_key": "key123",
   "notification_email": "test@fake.com"
 }

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -363,7 +363,7 @@ def test_request_cloud_partner_offer_doc(
 def test_update_cloud_partner_offer_doc():
     today = date.today()
     release = today.strftime("%Y.%m.%d")
-    version_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+    vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
 
     doc = {
         'definition': {
@@ -382,12 +382,12 @@ def test_update_cloud_partner_offer_doc():
         '123'
     )
 
-    assert doc['definition']['plans'][0][version_key][release]['label'] == \
+    assert doc['definition']['plans'][0][vm_images_key][release]['label'] == \
         'New Image 123'
 
 
 def test_update_cloud_partner_offer_doc_existing_date():
-    version_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+    vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
 
     doc = {
         'definition': {
@@ -406,7 +406,7 @@ def test_update_cloud_partner_offer_doc_existing_date():
         '123'
     )
 
-    label = doc['definition']['plans'][0][version_key]['2018.09.09']['label']
+    label = doc['definition']['plans'][0][vm_images_key]['2018.09.09']['label']
     assert label == 'New Image 123'
 
 

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -462,6 +462,7 @@ def test_wait_on_cloud_partner_operation_failed(
 
 def test_deprecate_image_in_offer():
     vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+    callback = MagicMock()
 
     doc = {
         'definition': {
@@ -470,7 +471,8 @@ def test_deprecate_image_in_offer():
                     'planId': '123',
                     vm_images_key: {
                         '2018.09.09': {
-                            'label': 'New Image 20180909'
+                            'label': 'New Image 20180909',
+                            'mediaName': 'new_image_20180909'
                         }
                     }
                 }
@@ -481,7 +483,8 @@ def test_deprecate_image_in_offer():
     doc = deprecate_image_in_offer_doc(
         doc,
         'new_image_20180909',
-        '123'
+        '123',
+        callback
     )
 
     release = doc['definition']['plans'][0][vm_images_key]['2018.09.09']
@@ -489,6 +492,9 @@ def test_deprecate_image_in_offer():
 
 
 def test_deprecate_image_in_offer_invalid():
+    vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+    callback = MagicMock()
+
     doc = {
         'definition': {
             'plans': [
@@ -502,5 +508,34 @@ def test_deprecate_image_in_offer_invalid():
     deprecate_image_in_offer_doc(
         doc,
         'new_image',
-        '123'
+        '123',
+        callback
+    )
+
+    doc = {
+        'definition': {
+            'plans': [
+                {
+                    'planId': '123',
+                    vm_images_key: {
+                        '2018.09.09': {
+                            'label': 'New Image 20180909',
+                            'mediaName': 'new_image'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    deprecate_image_in_offer_doc(
+        doc,
+        'new_image_20180909',
+        '123',
+        callback
+    )
+
+    callback.assert_called_once_with(
+        'Deprecation image name, new_image_20180909 does match the '
+        'mediaName attribute, new_image.'
     )

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -9,6 +9,7 @@ from mash.services.azure_utils import (
     acquire_access_token,
     delete_image,
     delete_page_blob,
+    deprecate_image_in_offer_doc,
     get_classic_storage_account_keys,
     get_blob_url,
     go_live_with_cloud_partner_offer,
@@ -457,3 +458,49 @@ def test_wait_on_cloud_partner_operation_failed(
 
     assert str(error.value) == \
         'Cloud partner operation did not finish successfully.'
+
+
+def test_deprecate_image_in_offer():
+    vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+
+    doc = {
+        'definition': {
+            'plans': [
+                {
+                    'planId': '123',
+                    vm_images_key: {
+                        '2018.09.09': {
+                            'label': 'New Image 20180909'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    doc = deprecate_image_in_offer_doc(
+        doc,
+        'new_image_20180909',
+        '123'
+    )
+
+    release = doc['definition']['plans'][0][vm_images_key]['2018.09.09']
+    assert release['showInGui'] is False
+
+
+def test_deprecate_image_in_offer_invalid():
+    doc = {
+        'definition': {
+            'plans': [
+                {
+                    'planId': '123'
+                }
+            ]
+        }
+    }
+
+    deprecate_image_in_offer_doc(
+        doc,
+        'new_image',
+        '123'
+    )

--- a/test/unit/services/deprecation/azure_job_test.py
+++ b/test/unit/services/deprecation/azure_job_test.py
@@ -1,16 +1,121 @@
+from unittest.mock import call, patch
+
 from mash.services.deprecation.azure_job import AzureDeprecationJob
 
 
 class TestAzureDeprecationJob(object):
     def setup(self):
         self.job_config = {
+            'emails': 'jdoe@fake.com',
             'id': '1',
             'last_service': 'publisher',
-            'cloud': 'ec2',
-            'utctime': 'now'
+            'offer_id': 'sles',
+            'cloud': 'azure',
+            'deprecation_regions': ['acnt1'],
+            'old_cloud_image_name': 'old_image_20190909',
+            'publisher_id': 'suse',
+            'sku': '123',
+            'utctime': 'now',
+            'vm_images_key': 'microsoft-azure-corevm.vmImagesPublicAzure'
         }
 
         self.job = AzureDeprecationJob(**self.job_config)
+        self.job.credentials = {
+            "acnt1": {
+                "clientId": "09876543-1234-1234-1234-123456789012",
+                "clientSecret": "09876543-1234-1234-1234-123456789012",
+                "subscriptionId": "09876543-1234-1234-1234-123456789012",
+                "tenantId": "09876543-1234-1234-1234-123456789012",
+                "activeDirectoryEndpointUrl":
+                    "https://login.microsoftonline.com",
+                "resourceManagerEndpointUrl": "https://management.azure.com/",
+                "activeDirectoryGraphResourceId":
+                    "https://graph.windows.net/",
+                "sqlManagementEndpointUrl":
+                    "https://management.core.windows.net:8443/",
+                "galleryEndpointUrl": "https://gallery.azure.com/",
+                "managementEndpointUrl":
+                    "https://management.core.windows.net/"
+            }
+        }
+        self.job.cloud_image_name = 'New Image'
 
-    def test_publish(self):
+    @patch('mash.services.deprecation.azure_job.deprecate_image_in_offer_doc')
+    @patch('mash.services.deprecation.azure_job.put_cloud_partner_offer_doc')
+    @patch(
+        'mash.services.deprecation.azure_job.request_cloud_partner_offer_doc'
+    )
+    @patch.object(AzureDeprecationJob, 'send_log')
+    def test_deprecate(
+        self, mock_send_log, mock_request_doc, mock_put_doc,
+        mock_deprecate_image
+    ):
+        self.job.vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+
+        mock_request_doc.return_value = {
+            'definition': {
+                'plans': [
+                    {
+                        'planId': '123',
+                        self.job.vm_images_key: {
+                            '2018.09.09': {
+                                'label': 'New Image 20180909'
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
         self.job._deprecate()
+
+        mock_send_log.assert_has_calls([
+            call(
+                'Deprecating image for account: '
+                'acnt1, using cloud partner API.'
+            ),
+            call('Deprecation finished for account: acnt1.')
+        ])
+
+    @patch('mash.services.deprecation.azure_job.deprecate_image_in_offer_doc')
+    @patch('mash.services.deprecation.azure_job.put_cloud_partner_offer_doc')
+    @patch(
+        'mash.services.deprecation.azure_job.request_cloud_partner_offer_doc'
+    )
+    @patch.object(AzureDeprecationJob, 'send_log')
+    def test_deprecate_exception(
+        self, mock_send_log, mock_request_doc, mock_put_doc,
+        mock_deprecate_image
+    ):
+        self.job.vm_images_key = None
+
+        mock_request_doc.return_value = {
+            'definition': {
+                'plans': [
+                    {
+                        'planId': '123',
+                        self.job.vm_images_key: {
+                            '2018.09.09': {
+                                'label': 'New Image 20180909'
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+        mock_put_doc.side_effect = Exception('Invalid doc!')
+        self.job.old_cloud_image_name = 'image_123'
+
+        self.job._deprecate()
+
+        mock_send_log.assert_has_calls([
+            call(
+                'Deprecating image for account: '
+                'acnt1, using cloud partner API.'
+            ),
+            call(
+                'There was an error deprecating image in acnt1: Invalid doc!',
+                False
+            )
+        ])

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -463,7 +463,7 @@ class TestJobCreatorService(object):
         assert data['publisher_id'] == 'suse'
         assert data['sku'] == '123'
         assert data['utctime'] == 'now'
-        assert data['version_key'] == 'key123'
+        assert data['vm_images_key'] == 'key123'
         assert data['notification_email'] == 'test@fake.com'
         assert data['notification_type'] == 'single'
         for region in data['publish_regions']:

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -477,19 +477,21 @@ class TestJobCreatorService(object):
                 assert region['destination_resource_group'] == 'c_res_group2'
                 assert region['destination_storage_account'] == 'cstorage2'
 
-        assert mock_publish.mock_calls[6] == call(
-            'deprecation', 'job_document',
-            JsonFormat.json_message({
-                "deprecation_job": {
-                    "cloud": "azure",
-                    "id": "12345678-1234-1234-1234-123456789012",
-                    "last_service": "deprecation",
-                    "notification_email": "test@fake.com",
-                    "notification_type": "single",
-                    "utctime": "now"
-                }
-            })
-        )
+        msg = mock_publish.mock_calls[6][1][2]
+        data = json.loads(msg)['deprecation_job']
+        assert data['emails'] == 'jdoe@fake.com'
+        assert data['id'] == '12345678-1234-1234-1234-123456789012'
+        assert data['last_service'] == 'deprecation'
+        assert data['offer_id'] == 'sles'
+        assert data['cloud'] == 'azure'
+        assert data['publisher_id'] == 'suse'
+        assert data['sku'] == '123'
+        assert data['utctime'] == 'now'
+        assert data['vm_images_key'] == 'key123'
+        assert data['notification_email'] == 'test@fake.com'
+        assert data['notification_type'] == 'single'
+        assert 'test-azure' in data['deprecation_regions']
+        assert 'test-azure2' in data['deprecation_regions']
 
     @patch.object(JobCreatorService, '_publish')
     def test_jobcreator_handle_service_message_gce(

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -24,7 +24,7 @@ class TestAzurePublisherJob(object):
             'publisher_id': 'suse',
             'sku': '123',
             'utctime': 'now',
-            'version_key': 'microsoft-azure-corevm.vmImagesPublicAzure'
+            'vm_images_key': 'microsoft-azure-corevm.vmImagesPublicAzure'
         }
 
         self.job = AzurePublisherJob(**self.job_config)
@@ -64,7 +64,7 @@ class TestAzurePublisherJob(object):
         mock_request_doc, mock_put_doc, mock_publish_offer,
         mock_wait_on_operation
     ):
-        self.job.version_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
+        self.job.vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
         mock_get_blob_url.return_value = 'blob/url/.vhd'
         mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
@@ -98,7 +98,7 @@ class TestAzurePublisherJob(object):
         self, mock_get_blob_url, mock_send_log, mock_create_json_file,
         mock_request_doc, mock_put_doc
     ):
-        self.job.version_key = None
+        self.job.vm_images_key = None
         mock_get_blob_url.return_value = 'blob/url/.vhd'
         mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -24,7 +24,8 @@ class TestAzurePublisherJob(object):
             'publisher_id': 'suse',
             'sku': '123',
             'utctime': 'now',
-            'vm_images_key': 'microsoft-azure-corevm.vmImagesPublicAzure'
+            'vm_images_key': 'microsoft-azure-corevm.vmImagesPublicAzure',
+            'publish_offer': True
         }
 
         self.job = AzurePublisherJob(**self.job_config)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Rename version_key to vm_images_key to prevent confusion
- Add publish_offer option for azure jobs. By default the publish step will not be triggered. This step
publishes the entire offer which will break other jobs that may be updating different skus at the same time.
- Integrate deprecation for azure. If the old image name matches a version in sku set it to not show
in gui.

### How will these changes be tested?

Unit & integration tests.