### PR TITLE
Move get job log file method to base config.

### DIFF
--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+
+import os
 import yaml
 
 from mash.mash_exceptions import MashConfigException
@@ -101,6 +103,17 @@ class BaseConfig(object):
         return '{dir}{service}_service.log'.format(
             dir=log_dir, service=service
         )
+
+    def get_job_log_file(self, job_id):
+        """
+        Return log file given the job_id.
+
+        :rtype: string
+        """
+        log_file = os.path.join(
+            self.get_log_directory(), 'jobs', ''.join([job_id, '.log'])
+        )
+        return os.path.expanduser(os.path.normpath(log_file))
 
     def get_cloud_data(self):
         """

--- a/mash/services/logger/config.py
+++ b/mash/services/logger/config.py
@@ -16,8 +16,6 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import os
-
 from mash.services.base_config import BaseConfig
 
 
@@ -32,14 +30,3 @@ class LoggerConfig(BaseConfig):
     """
     def __init__(self, config_file=None):
         super(LoggerConfig, self).__init__(config_file)
-
-    def get_job_log_file(self, job_id):
-        """
-        Return log file given the job_id.
-
-        :rtype: string
-        """
-        log_file = os.path.join(
-            self.get_log_directory(), 'jobs', ''.join([job_id, '.log'])
-        )
-        return os.path.expanduser(os.path.normpath(log_file))

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -556,16 +556,6 @@ class MashService(object):
 
         return False
 
-    def _get_job_log_path(self, job_id):
-        """
-        Return the path to log for given job.
-        """
-        path = os.path.normpath(
-            '{0}/jobs/{1}.log'.format(self.config.get_log_directory(), job_id)
-        )
-
-        return path
-
     def _create_notification_content(
         self, job_id, status, utctime, last_service,
         iteration_count=None, error=None
@@ -600,7 +590,7 @@ class MashService(object):
         return msg.format(
             job_id=job_id,
             service=self.service_exchange,
-            job_log=self._get_job_log_path(job_id),
+            job_log=self.config.get_job_log_file(job_id),
             iteration_count=str(iteration_count),
             error=error
         )

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from mash.mash_exceptions import MashConfigException
 from mash.services.base_config import BaseConfig
 from pytest import raises
@@ -108,3 +110,13 @@ class TestBaseConfig(object):
     def test_get_notification_subject(self):
         subject = self.empty_config.get_notification_subject()
         assert subject == '[MASH] Job Status Update'
+
+    def test_get_log_dir(self):
+        assert self.config.get_log_directory() == '/var/log/mash/'
+        assert self.empty_config.get_log_directory() == '/var/log/mash/'
+
+    @patch.object(BaseConfig, 'get_log_directory')
+    def test_get_job_log_file(self, mock_get_log_dir):
+        mock_get_log_dir.return_value = '/var/log/mash/'
+        assert self.empty_config.get_job_log_file('1234') == \
+            '/var/log/mash/jobs/1234.log'

--- a/test/unit/services/logger/config_test.py
+++ b/test/unit/services/logger/config_test.py
@@ -1,19 +1,10 @@
-from unittest.mock import patch
-
 from mash.services.logger.config import LoggerConfig
 
 
 class TestLoggerConfig(object):
     def setup(self):
-        self.config = LoggerConfig('../data/mash_config.yaml')
         self.empty_config = LoggerConfig('../data/empty_mash_config.yaml')
 
-    def test_get_log_dir(self):
-        assert self.config.get_log_directory() == '/var/log/mash/'
-        assert self.empty_config.get_log_directory() == '/var/log/mash/'
-
-    @patch.object(LoggerConfig, 'get_log_directory')
-    def test_get_job_log_file(self, mock_get_log_dir):
-        mock_get_log_dir.return_value = '/var/log/mash/'
-        assert self.empty_config.get_job_log_file('1234') == \
-            '/var/log/mash/jobs/1234.log'
+    def test_get_log_file(self):
+        assert self.empty_config.get_log_file('logger') == \
+            '/var/log/mash/logger_service.log'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Move get job log file method to base config. and remove duplicate base service method.
