### PR TITLE
Use full extension for ec2 and azure image files.

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -208,15 +208,8 @@ class OBSImageBuildResult(object):
         mkpath(self.download_directory)
         file_prefix = self.image_metadata_name.replace('.packages', '')
         image_files = self.remote.fetch_files(
-            ''.join([self.image_name, '.']),
-            [
-                ''.join([file_prefix, '.raw.xz.sha256']),
-                ''.join([file_prefix, '.raw.xz']),
-                ''.join([file_prefix, '.vhdfixed.xz.sha256']),
-                ''.join([file_prefix, '.vhdfixed.xz']),
-                ''.join([file_prefix, '.tar.gz.sha256']),
-                ''.join([file_prefix, '.tar.gz'])
-            ],
+            file_prefix,
+            ['.xz', 'xz.sha256', '.tar.gz', '.tar.gz.sha256'],
             self.download_directory
         )
 

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -210,8 +210,10 @@ class OBSImageBuildResult(object):
         image_files = self.remote.fetch_files(
             ''.join([self.image_name, '.']),
             [
-                ''.join([file_prefix, '.xz.sha256']),
-                ''.join([file_prefix, '.xz']),
+                ''.join([file_prefix, '.raw.xz.sha256']),
+                ''.join([file_prefix, '.raw.xz']),
+                ''.join([file_prefix, '.vhdfixed.xz.sha256']),
+                ''.join([file_prefix, '.vhdfixed.xz']),
                 ''.join([file_prefix, '.tar.gz.sha256']),
                 ''.join([file_prefix, '.tar.gz'])
             ],


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Fix image retrieval for ec2 and azure. Use full extension for xz (vhdfixed, raw) image files.

### How will these changes be tested?

Unit & integration tests.