### PR TITLE
UploadImage class requires region.

### DIFF
--- a/mash/services/uploader/cloud/amazon.py
+++ b/mash/services/uploader/cloud/amazon.py
@@ -160,7 +160,7 @@ class UploadAmazon(UploadBase):
             ami_id = ec2_upload.create_image(
                 self.system_image_file
             )
-            return ami_id, self.region
+            return ami_id
         except Exception as e:
             raise MashUploadException(
                 'Upload to Amazon EC2 failed with: {0}'.format(e)

--- a/mash/services/uploader/cloud/azure.py
+++ b/mash/services/uploader/cloud/azure.py
@@ -138,7 +138,7 @@ class UploadAzure(UploadBase):
             }
         )
         async_create_image.wait()
-        return self.cloud_image_name, self.region
+        return self.cloud_image_name
 
     def _create_auth_file(self):
         self.auth_file = NamedTemporaryFile()

--- a/mash/services/uploader/cloud/gce.py
+++ b/mash/services/uploader/cloud/gce.py
@@ -115,7 +115,7 @@ class UploadGCE(UploadBase):
             description=desc,
             family=self.family
         )
-        return self.cloud_image_name, self.region
+        return self.cloud_image_name
 
     def _create_auth_file(self):
         self.auth_file = NamedTemporaryFile()

--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -399,6 +399,7 @@ class UploadImageService(MashService):
             self.jobs[job_id]['credentials'][uploader_args['account']],
             self.jobs[job_id]['job_config']['cloud_image_name'],
             self.jobs[job_id]['job_config']['image_description'],
+            uploader_args['region'],
             uploader_args,
             arch
         )

--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -52,7 +52,7 @@ class UploadImage(object):
     """
     def __init__(
         self, job_id, job_file, csp_name, credentials_token,
-        cloud_image_name, cloud_image_description,
+        cloud_image_name, cloud_image_description, region,
         custom_uploader_args=None, arch='x86_64'
     ):
         self.job_id = job_id
@@ -70,7 +70,7 @@ class UploadImage(object):
         self.result_callback = None
         self.log_callback = None
         self.cloud_image_id = None
-        self.upload_region = None
+        self.upload_region = region
         self.iteration_count = 0
         self.uploader = None
         self.error_msg = None
@@ -104,8 +104,7 @@ class UploadImage(object):
                     self.custom_uploader_args,
                     self.arch
                 )
-                self.cloud_image_id, self.upload_region = \
-                    self.uploader.upload()
+                self.cloud_image_id = self.uploader.upload()
                 self._log_callback(
                     'Uploaded image has ID: {0} in region {1}'.format(
                         self.cloud_image_id, self.upload_region)

--- a/test/unit/services/uploader/cloud/amazon_test.py
+++ b/test/unit/services/uploader/cloud/amazon_test.py
@@ -60,7 +60,7 @@ class TestUploadAmazon(object):
         ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
         ec2_setup.create_security_group.return_value = 'sg-123456789'
         mock_ec2_setup.return_value = ec2_setup
-        assert self.uploader.upload() == ('ami_id', 'us-east-1')
+        assert self.uploader.upload() == 'ami_id'
         mock_get_client.assert_called_once_with(
             'ec2', 'access-key', 'secret-access-key', 'us-east-1'
         )

--- a/test/unit/services/uploader/cloud/azure_test.py
+++ b/test/unit/services/uploader/cloud/azure_test.py
@@ -141,7 +141,7 @@ class TestUploadAzure(object):
         system_image_file_type.is_xz.return_value = True
         mock_FileType.return_value = system_image_file_type
 
-        assert self.uploader.upload() == ('name', 'region')
+        assert self.uploader.upload() == 'name'
 
         assert mock_get_client_from_auth_file.call_args_list == [
             call(StorageManagementClient, auth_path='tempfile'),

--- a/test/unit/services/uploader/cloud/gce_test.py
+++ b/test/unit/services/uploader/cloud/gce_test.py
@@ -113,7 +113,7 @@ class TestUploadGCE(object):
         storage_driver = Mock()
         mock_storage_driver.return_value = storage_driver
 
-        assert self.uploader.upload() == ('sles-12-sp4-v20180909', 'region')
+        assert self.uploader.upload() == 'sles-12-sp4-v20180909'
 
         storage_driver.get_container.assert_called_once_with('images')
         assert storage_driver.upload_object_via_stream.call_count == 1

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -486,7 +486,8 @@ class TestUploadImageService(object):
             datetime.date.today().strftime("%Y%m%d")
         )
         mock_UploadImage.assert_called_once_with(
-            '123', 'job_file', 'ec2', {}, image_name, 'description', {
+            '123', 'job_file', 'ec2', {}, image_name, 'description',
+            'eu-central-1', {
                 'launch_ami': 'ami-bc5b48d0', 'region': 'eu-central-1',
                 'account': 'test-aws'
             }, 'x86_64'

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -12,7 +12,7 @@ class TestUploadImage(object):
         self.upload_image = UploadImage(
             '123', 'job_file', 'ec2',
             'token', 'cloud_image_name_at_080808',
-            'cloud_image_description',
+            'cloud_image_description', 'us-west-3',
             custom_uploader_args=self.custom_uploader_args,
             arch='arch'
         )
@@ -25,7 +25,7 @@ class TestUploadImage(object):
         self, mock_result_callback, mock_log_callback, mock_Upload
     ):
         uploader = Mock()
-        uploader.upload.return_value = ('image_id', 'region')
+        uploader.upload.return_value = 'image_id'
         mock_Upload.return_value = uploader
         self.upload_image.upload()
         mock_Upload.assert_called_once_with(
@@ -42,7 +42,7 @@ class TestUploadImage(object):
                     self.custom_uploader_args
                 )
             ),
-            call('Uploaded image has ID: image_id in region region')
+            call('Uploaded image has ID: image_id in region us-west-3')
         ]
         mock_result_callback.assert_called_once_with()
 
@@ -88,7 +88,7 @@ class TestUploadImage(object):
         self.upload_image.result_callback.assert_called_once_with(
             '123', {
                 'cloud_image_id': 'id',
-                'upload_region': None,
+                'upload_region': 'us-west-3',
                 'csp_name': 'ec2',
                 'job_status': 'success',
                 'error_msg': None


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Fix the error case when uploading image. If there's an error there's no region and the job gets stuck. Region is used to track the status of each account in a mash job. So pass region to constructor instead of from upload method result. This ensures the region is provided in result_callback on pass and fail.