### PR TITLE
Job creator classes don't override init method.

### DIFF
--- a/mash/services/jobcreator/__init__.py
+++ b/mash/services/jobcreator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -40,4 +40,4 @@ def create_job(job_doc, accounts_info, cloud_data):
             )
         )
 
-    return job_class(accounts_info, cloud_data, **job_doc)
+    return job_class(accounts_info, cloud_data, job_doc)

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from mash.mash_exceptions import MashJobCreatorException
 from mash.services.jobcreator.base_job import BaseJob
 from mash.utils.json_format import JsonFormat
 
@@ -24,36 +25,28 @@ class AzureJob(BaseJob):
     """
     Azure job message class.
     """
-    def __init__(
-        self, accounts_info, cloud_data, job_id, cloud,
-        requesting_user, last_service,
-        utctime, image, cloud_image_name, image_description, distro,
-        download_url, offer_id, publisher_id, sku, emails, label,
-        tests=None, conditions=None, instance_type=None,
-        old_cloud_image_name=None, cleanup_images=True,
-        cloud_architecture='x86_64', vm_images_key=None,
-        cloud_accounts=None, cloud_groups=None,
-        notification_email=None, notification_type='single',
-        publish_offer=False
-    ):
-        super(AzureJob, self).__init__(
-            accounts_info, cloud_data, job_id, cloud,
-            requesting_user, last_service, utctime, image,
-            cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups,
-            notification_email, notification_type
-        )
 
-        self.emails = emails
-        self.label = label
-        self.offer_id = offer_id
-        self.publisher_id = publisher_id
-        self.sku = sku
-        self.vm_images_key = vm_images_key
-        self.publish_offer = publish_offer
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        try:
+            self.emails = self.kwargs['emails']
+            self.label = self.kwargs['label']
+            self.offer_id = self.kwargs['offer_id']
+            self.publisher_id = self.kwargs['publisher_id']
+            self.sku = self.kwargs['sku']
+        except KeyError as error:
+            raise MashJobCreatorException(
+                'Azure jobs require a(n) {0} key in the job doc.'.format(
+                    error
+                )
+            )
 
-    def _get_account_info(self):
+        self.vm_images_key = self.kwargs.get('vm_images_key')
+        self.publish_offer = self.kwargs.get('publish_offer', False)
+
+    def get_account_info(self):
         """
         Returns a dictionary of accounts and regions.
 
@@ -236,9 +229,3 @@ class AzureJob(BaseJob):
                 value['source_resource_group']
 
         return target_regions
-
-    def post_init(self):
-        """
-        Post initialization method.
-        """
-        self._get_account_info()

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -86,7 +86,7 @@ class BaseJob(object):
         """
         raise NotImplementedError(
             'This {0} class does not implement the '
-            '_get_account_info method.'.format(
+            'get_account_info method.'.format(
                 self.__class__.__name__
             )
         )

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -28,31 +28,16 @@ class EC2Job(BaseJob):
 
     Handles incoming job requests.
     """
-    def __init__(
-        self, accounts_info, cloud_data, job_id, cloud,
-        requesting_user, last_service,
-        utctime, image, cloud_image_name, image_description, distro,
-        download_url, tests=None, allow_copy=True, conditions=None,
-        instance_type=None, share_with='all', old_cloud_image_name=None,
-        cleanup_images=True, cloud_architecture='x86_64',
-        cloud_accounts=None, cloud_groups=None,
-        notification_email=None, notification_type='single',
-        billing_codes=None
-    ):
-        self.share_with = share_with
-        self.allow_copy = allow_copy
-        self.billing_codes = billing_codes
 
-        super(EC2Job, self).__init__(
-            accounts_info, cloud_data, job_id, cloud,
-            requesting_user, last_service, utctime, image,
-            cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups,
-            notification_email, notification_type
-        )
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        self.share_with = self.kwargs.get('share_with', 'all')
+        self.allow_copy = self.kwargs.get('allow_copy', True)
+        self.billing_codes = self.kwargs.get('billing_codes')
 
-    def _get_account_info(self):
+    def get_account_info(self):
         """
         Returns a dictionary mapping target region info.
 
@@ -213,9 +198,3 @@ class EC2Job(BaseJob):
             }
 
         return target_regions
-
-    def post_init(self):
-        """
-        Post initialization method.
-        """
-        self._get_account_info()

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -24,30 +24,17 @@ class GCEJob(BaseJob):
     """
     GCE job message class.
     """
-    def __init__(
-        self, accounts_info, cloud_data, job_id, cloud,
-        requesting_user, last_service,
-        utctime, image, cloud_image_name, image_description, distro,
-        download_url, tests=None, conditions=None, instance_type=None,
-        family=None, old_cloud_image_name=None, cleanup_images=True,
-        cloud_architecture='x86_64', months_to_deletion=6,
-        cloud_accounts=None, cloud_groups=None,
-        notification_email=None, notification_type='single'
-    ):
-        self.family = family
 
-        super(GCEJob, self).__init__(
-            accounts_info, cloud_data, job_id, cloud,
-            requesting_user, last_service, utctime, image,
-            cloud_image_name, image_description, distro, download_url, tests,
-            conditions, instance_type, old_cloud_image_name, cleanup_images,
-            cloud_architecture, cloud_accounts, cloud_groups,
-            notification_email, notification_type
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        self.family = self.kwargs.get('family')
+        self.months_to_deletion = self.kwargs.get(
+            'months_to_deletion', 6
         )
 
-        self.months_to_deletion = months_to_deletion
-
-    def _get_account_info(self):
+    def get_account_info(self):
         """
         Returns a dictionary of regions to accounts.
 
@@ -154,9 +141,3 @@ class GCEJob(BaseJob):
         Return a dictionary of target uploader regions.
         """
         return self.target_account_info
-
-    def post_init(self):
-        """
-        Post initialization method.
-        """
-        self._get_account_info()

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from unittest.mock import patch
+
+from mash.mash_exceptions import MashJobCreatorException
+from mash.services.jobcreator.azure_job import AzureJob
+
+
+@patch.object(AzureJob, '__init__')
+def test_azure_job_missing_keys(mock_init):
+    mock_init.return_value = None
+
+    job = AzureJob(
+        {}, {}, {
+            'job_id': '123',
+            'cloud': 'azure',
+            'requesting_user': 'test-user',
+            'last_service': 'pint',
+            'utctime': 'now',
+            'image': 'test-image',
+            'cloud_image_name': 'test-cloud-image',
+            'image_description': 'image description',
+            'distro': 'sles',
+            'download_url': 'https://download.here'
+        }
+    )
+    job.kwargs = {}
+
+    with pytest.raises(MashJobCreatorException):
+        job.post_init()


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Job creator classes don't override base `__init__` method. Instead use `post_init` to setup custom args per cloud.

- Pass in job doc as dictionary instead of expanding kwargs to allow for `post_init` workflow.
- Rename and move `get_account_info` call to base `__init__` after `post_init`.
- Raise `NotImplementedError` in all base methods that must be overridden with clear message.

### How will these changes be tested?

Tested with unit tests plus local integration runs with each cloud framework.