### PR TITLE
No need for instance var to hold msg properties.

### DIFF
--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -56,11 +56,6 @@ class MashService(object):
         self.channel = None
         self.connection = None
 
-        self.msg_properties = {
-            'content_type': 'application/json',
-            'delivery_mode': 2
-        }
-
         self.service_exchange = service_exchange
         self.service_queue = 'service'
         self.listener_queue = 'listener'
@@ -224,7 +219,10 @@ class MashService(object):
             body=message,
             routing_key=routing_key,
             exchange=exchange,
-            properties=self.msg_properties,
+            properties={
+                'content_type': 'application/json',
+                'delivery_mode': 2
+            },
             mandatory=True
         )
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Remove msg_properties and directly set it in method.