### PR TITLE
Move account keys to jc and creds services.

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -60,6 +60,9 @@ class CredentialsService(MashService):
         if not os.path.exists(self.accounts_file):
             self._write_accounts_to_file(accounts_template)
 
+        self.add_account_key = 'add_account'
+        self.delete_account_key = 'delete_account'
+
         self.bind_queue(
             self.service_exchange, self.add_account_key, self.listener_queue
         )

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -38,6 +38,9 @@ class JobCreatorService(MashService):
         self.cloud_data = self.config.get_cloud_data()
         self.services = self.config.get_service_names()
 
+        self.add_account_key = 'add_account'
+        self.delete_account_key = 'delete_account'
+
         self.bind_queue(
             self.service_exchange, self.add_account_key, self.listener_queue
         )

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -108,9 +108,6 @@ class MashService(object):
             self.service_exchange
         )
 
-        self.add_account_key = 'add_account'
-        self.delete_account_key = 'delete_account'
-
         logging.basicConfig()
         self.log = logging.getLogger(self.__class__.__name__)
         self.log.setLevel(logging.DEBUG)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Move account keys to jc and creds services. These keys are not used by any other services.