### PR TITLE
Check each key in job creator tests.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -27,7 +27,7 @@
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "image_description": "New Image #123",
   "distro": "sles",
-  "instance_type": "t2.micro",
+  "instance_type": "Basic_A2",
   "tests": ["test_stuff"],
   "emails": "jdoe@fake.com",
   "offer_id": "sles",

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -18,7 +18,7 @@
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "image_description": "New Image #123",
   "distro": "sles",
-  "instance_type": "t2.micro",
+  "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
   "notification_email": "test@fake.com"

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -27,7 +27,7 @@
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "image_description": "New Image #123",
   "distro": "sles",
-  "instance_type": "t2.micro",
+  "instance_type": "Basic_A2",
   "tests": ["test_stuff"],
   "emails": "jdoe@fake.com",
   "offer_id": "sles",

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -22,7 +22,7 @@
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "image_description": "New Image #123",
   "distro": "sles",
-  "instance_type": "t2.micro",
+  "instance_type": "n1-standard-1",
   "family": "sles-15",
   "months_to_deletion": 5,
   "tests": ["test_stuff"],


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Check each key in job creator tests. Instead of comparing the entire json string. This makes finding an issue much easier and allows for a single method to check all base attributes.

Cleanup instance types for azure and gce.

### How will these changes be tested?

Unit testing.