### PR TITLE
Rename test_deprecation_start_job.

### DIFF
--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -563,7 +563,7 @@ class TestPipelineService(object):
         )
         assert result is False
 
-    def test_deprecation_start_job(self):
+    def test_service_start_job(self):
         job = Mock()
         self.service.jobs['1'] = job
         self.service.host = 'localhost'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Rename test_deprecation_start_job. Copy/paste typo deprecation should be service.