### PR TITLE
Fix fetch index list href retrieval.

### DIFF
--- a/mash/utils/web_content.py
+++ b/mash/utils/web_content.py
@@ -41,14 +41,10 @@ class WebContent(object):
             location = urlopen(request)
             tree = html.fromstring(location.read())
             index_list = tree.xpath(
-                '//pre/a', namespaces=self.namespace_map
+                '//a[starts-with(@href, "{0}")]/@href'.format(base_name),
+                namespaces=self.namespace_map
             )
-            result = []
-            for element in index_list:
-                list_entry = element.get('href')
-                if list_entry.startswith(base_name):
-                    result.append(list_entry)
-            return sorted(list(set(result)))
+            return sorted(list(set(index_list)))
         except Exception as issue:
             raise MashWebContentException(
                 'Fetching index list from {0} failed with {1}: {2}'.format(


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Get all link tags that have href that starts with base_name and only return a list of href strings to simplify method.

### How will these changes be tested?

Integration testing locally.