### PR TITLE
Handle any uncaught exceptions from datastore.

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -356,10 +356,15 @@ class CredentialsService(MashService):
         requesting_user = message['requesting_user']
         group_name = message.get('group')
 
-        self.account_datastore.add_account(
-            account_info, cloud, account_name, requesting_user, credentials,
-            group_name
-        )
+        try:
+            self.account_datastore.add_account(
+                account_info, cloud, account_name, requesting_user, credentials,
+                group_name
+            )
+        except Exception as error:
+            self.log.warning(
+                'Unable to add account: {0}'.format(error)
+            )
 
     def delete_account(self, message):
         """
@@ -369,9 +374,14 @@ class CredentialsService(MashService):
         cloud = message['cloud']
         requesting_user = message['requesting_user']
 
-        self.account_datastore.delete_account(
-            requesting_user, account_name, cloud
-        )
+        try:
+            self.account_datastore.delete_account(
+                requesting_user, account_name, cloud
+            )
+        except Exception as error:
+            self.log.warning(
+                'Unable to delete account: {0}'.format(error)
+            )
 
     def start(self):
         """

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -479,6 +479,27 @@ class TestCredentialsService(object):
             'Failed to add account to database: CSP fake is not supported.'
         )
 
+    @patch.object(AccountDatastore, 'add_account')
+    def test_credentials_add_account_exception(self, mock_add_account):
+        message = {
+            'account_name': 'acnt123',
+            'credentials': {'creds': 'data'},
+            'partition': 'aws',
+            'cloud': 'ec2',
+            'requesting_user': 'user1',
+            'region': 'us-east-1',
+            'group': 'group123'
+        }
+
+        mock_add_account.side_effect = Exception('Forbidden!')
+
+        self.service.add_account(message)
+        assert mock_add_account.call_count == 1
+
+        self.service.log.warning.assert_called_once_with(
+            'Unable to add account: Forbidden!'
+        )
+
     @patch.object(AccountDatastore, 'delete_account')
     def test_credentials_delete_account(self, mock_delete_account):
         message = {
@@ -491,6 +512,26 @@ class TestCredentialsService(object):
 
         mock_delete_account.assert_called_once_with(
             'user2', 'test-aws', 'ec2'
+        )
+
+    @patch.object(AccountDatastore, 'delete_account')
+    def test_credentials_delete_account_exception(self, mock_delete_account):
+        message = {
+            'account_name': 'test-aws',
+            'cloud': 'ec2',
+            'requesting_user': 'user2'
+        }
+
+        mock_delete_account.side_effect = Exception('Forbidden!')
+
+        self.service.delete_account(message)
+
+        mock_delete_account.assert_called_once_with(
+            'user2', 'test-aws', 'ec2'
+        )
+
+        self.service.log.warning.assert_called_once_with(
+            'Unable to delete account: Forbidden!'
         )
 
     @patch.object(CredentialsService, 'consume_queue')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Handle any uncaught exceptions from datastore. Catch and log the exception. This prevents the service from crashing and also ensures the messages are ack'ed if there is a failure.