### PR TITLE
Make run_job method public.

### DIFF
--- a/mash/services/deprecation/azure_job.py
+++ b/mash/services/deprecation/azure_job.py
@@ -32,7 +32,7 @@ class AzureDeprecationJob(MashJob):
         # Skip credential request since there is no deprecation in Azure
         self.credentials = {'status': 'no deprecation'}
 
-    def _run_job(self):
+    def run_job(self):
         """
         There is no deprecation process in Azure.
         """

--- a/mash/services/deprecation/ec2_job.py
+++ b/mash/services/deprecation/ec2_job.py
@@ -46,7 +46,7 @@ class EC2DeprecationJob(MashJob):
             'old_cloud_image_name'
         )
 
-    def _run_job(self):
+    def run_job(self):
         """
         Deprecate image in all target regions in each source region.
         """

--- a/mash/services/deprecation/gce_job.py
+++ b/mash/services/deprecation/gce_job.py
@@ -53,7 +53,7 @@ class GCEDeprecationJob(MashJob):
             'old_cloud_image_name'
         )
 
-    def _run_job(self):
+    def run_job(self):
         """
         Deprecate image in all accounts.
         """

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -75,7 +75,7 @@ class MashJob(object):
                 success
             )
 
-    def _run_job(self):
+    def run_job(self):
         """
         Start and run job workflow.
         """
@@ -91,7 +91,7 @@ class MashJob(object):
         Update iteration count and run job.
         """
         self.iteration_count += 1
-        self._run_job()
+        self.run_job()
 
     @property
     def cloud_image_name(self):

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -60,7 +60,7 @@ class AzurePublisherJob(MashJob):
         self.vm_images_key = self.job_config.get('vm_images_key')
         self.publish_offer = self.job_config.get('publish_offer', False)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Publish image and update status.
         """

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -45,7 +45,7 @@ class EC2PublisherJob(MashJob):
         self.allow_copy = self.job_config.get('allow_copy', True)
         self.share_with = self.job_config.get('share_with', 'all')
 
-    def _run_job(self):
+    def run_job(self):
         """
         Publish image and update status.
         """

--- a/mash/services/publisher/gce_job.py
+++ b/mash/services/publisher/gce_job.py
@@ -32,7 +32,7 @@ class GCEPublisherJob(MashJob):
         # Skip credential request since there is no publishing in GCE
         self.credentials = {'status': 'no publishing'}
 
-    def _run_job(self):
+    def run_job(self):
         """
         No publishing in GCE.
         """

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -51,7 +51,7 @@ class AzureReplicationJob(MashJob):
 
         self.cleanup_images = self.job_config.get('cleanup_images', True)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Replicate image in each source region.
 

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -49,7 +49,7 @@ class EC2ReplicationJob(MashJob):
 
         self.source_region_results = defaultdict(dict)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Replicate image to all target regions in each source region.
         """

--- a/mash/services/replication/gce_job.py
+++ b/mash/services/replication/gce_job.py
@@ -32,7 +32,7 @@ class GCEReplicationJob(MashJob):
         # Skip credential request since there is no replication in GCE
         self.credentials = {'status': 'no replication'}
 
-    def _run_job(self):
+    def run_job(self):
         """
         No replication in GCE.
         """

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -73,7 +73,7 @@ class AzureTestingJob(MashJob):
         if not os.path.exists(self.ssh_private_key_file):
             create_ssh_key_pair(self.ssh_private_key_file)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Tests image with IPA and update status and results.
         """

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -76,7 +76,7 @@ class EC2TestingJob(MashJob):
         if not os.path.exists(self.ssh_private_key_file):
             create_ssh_key_pair(self.ssh_private_key_file)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Tests image with IPA and update status and results.
         """

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -73,7 +73,7 @@ class GCETestingJob(MashJob):
         if not os.path.exists(self.ssh_private_key_file):
             create_ssh_key_pair(self.ssh_private_key_file)
 
-    def _run_job(self):
+    def run_job(self):
         """
         Tests image with IPA and update status and results.
         """

--- a/mash/services/uploader/azure_job.py
+++ b/mash/services/uploader/azure_job.py
@@ -52,7 +52,7 @@ class AzureUploaderJob(MashJob):
                 )
             )
 
-    def _run_job(self):
+    def run_job(self):
         self.status = SUCCESS
         self.send_log('Uploading image.')
 

--- a/mash/services/uploader/ec2_job.py
+++ b/mash/services/uploader/ec2_job.py
@@ -62,7 +62,7 @@ class EC2UploaderJob(MashJob):
         if self.arch == 'aarch64':
             self.arch = 'arm64'
 
-    def _run_job(self):
+    def run_job(self):
         self.status = SUCCESS
         self.send_log('Uploading image.')
 

--- a/mash/services/uploader/gce_job.py
+++ b/mash/services/uploader/gce_job.py
@@ -61,7 +61,7 @@ class GCEUploaderJob(MashJob):
                 'No SLES 11 support in mash for GCE.'
             )
 
-    def _run_job(self):
+    def run_job(self):
         self.status = SUCCESS
         self.send_log('Uploading image.')
 

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -47,7 +47,7 @@ class TestMashJob(object):
         job = MashJob(self.job_config, self.config)
 
         with raises(NotImplementedError):
-            job._run_job()
+            job.run_job()
 
     def test_job_get_job_id(self):
         job = MashJob(self.job_config, self.config)
@@ -71,7 +71,7 @@ class TestMashJob(object):
 
         assert job.log_callback == callback
 
-    @patch.object(MashJob, '_run_job')
+    @patch.object(MashJob, 'run_job')
     def test_process_job(self, mock_run_job):
         job = MashJob(self.job_config, self.config)
         job.process_job()

--- a/test/unit/services/deprecation/azure_job_test.py
+++ b/test/unit/services/deprecation/azure_job_test.py
@@ -16,5 +16,5 @@ class TestAzureDeprecationJob(object):
         assert self.job.credentials['status'] == 'no deprecation'
 
     def test_deprecate(self):
-        self.job._run_job()
+        self.job.run_job()
         assert self.job.status == 'success'

--- a/test/unit/services/deprecation/ec2_job_test.py
+++ b/test/unit/services/deprecation/ec2_job_test.py
@@ -42,7 +42,7 @@ class TestEC2DeprecationJob(object):
         mock_ec2_deprecate_image.return_value = deprecation
 
         self.job.source_regions = {'us-east-2': 'ami-123456'}
-        self.job._run_job()
+        self.job.run_job()
 
         mock_ec2_deprecate_image.assert_called_once_with(
             access_key='123456', deprecation_image_name='old_image_123',
@@ -58,7 +58,7 @@ class TestEC2DeprecationJob(object):
     def test_deprecate_no_old_image(self):
         self.job.source_regions = {'us-east-2': 'ami-123456'}
         self.job.old_cloud_image_name = None
-        self.job._run_job()
+        self.job.run_job()
         assert self.job.status == 'success'
 
     @patch.object(EC2DeprecationJob, 'send_log')
@@ -75,5 +75,5 @@ class TestEC2DeprecationJob(object):
         msg = 'Error deprecating image old_image_123 in us-east-2.' \
             ' No images to deprecate.'
         with raises(MashDeprecationException) as e:
-            self.job._run_job()
+            self.job.run_job()
         assert msg == str(e.value)

--- a/test/unit/services/deprecation/gce_job_test.py
+++ b/test/unit/services/deprecation/gce_job_test.py
@@ -41,7 +41,7 @@ class TestGCEDeprecationJob(object):
         compute_driver = MagicMock()
         compute_engine.return_value = compute_driver
 
-        self.job._run_job()
+        self.job.run_job()
 
         assert compute_driver.ex_deprecate_image.call_count == 1
         assert self.job.status == 'success'
@@ -51,7 +51,7 @@ class TestGCEDeprecationJob(object):
 
     def test_deprecate_no_old_image(self):
         self.job.old_cloud_image_name = None
-        self.job._run_job()
+        self.job.run_job()
         assert self.job.status == 'success'
 
     @patch.object(GCEDeprecationJob, 'send_log')
@@ -67,7 +67,7 @@ class TestGCEDeprecationJob(object):
         compute_driver.ex_deprecate_image.side_effect = Exception('Failed!')
         compute_engine.return_value = compute_driver
 
-        self.job._run_job()
+        self.job.run_job()
 
         mock_send_log.assert_called_once_with(
             'There was an error deprecating image in test-gce: Failed!',

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -89,7 +89,7 @@ class TestAzurePublisherJob(object):
 
         mock_publish_offer.return_value = '/api/operation/url'
 
-        self.job._run_job()
+        self.job.run_job()
 
         mock_send_log.assert_has_calls([
             call('Publishing image for account: acnt1, using cloud partner API.'),
@@ -122,7 +122,7 @@ class TestAzurePublisherJob(object):
         }
         mock_put_doc.side_effect = Exception('Invalid doc!')
 
-        self.job._run_job()
+        self.job.run_job()
 
         mock_send_log.assert_has_calls([
             call('Publishing image for account: acnt1, using cloud partner API.'),

--- a/test/unit/services/publisher/ec2_job_test.py
+++ b/test/unit/services/publisher/ec2_job_test.py
@@ -44,7 +44,7 @@ class TestEC2PublisherJob(object):
         publisher = Mock()
         mock_ec2_publish_image.return_value = publisher
         self.job.cloud_image_name = 'image_name_123'
-        self.job._run_job()
+        self.job.run_job()
 
         mock_ec2_publish_image.assert_called_once_with(
             access_key='123456', allow_copy=False, image_name='image_name_123',
@@ -70,5 +70,5 @@ class TestEC2PublisherJob(object):
         msg = 'An error publishing image image_name_123 in us-east-2.' \
             ' Failed to publish.'
         with raises(MashPublisherException) as e:
-            self.job._run_job()
+            self.job.run_job()
         assert msg == str(e.value)

--- a/test/unit/services/publisher/gce_job_test.py
+++ b/test/unit/services/publisher/gce_job_test.py
@@ -16,4 +16,4 @@ class TestGCEPublisherJob(object):
         self.job = GCEPublisherJob(self.job_config, self.config)
 
     def test_publish(self):
-        self.job._run_job()
+        self.job.run_job()

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -70,7 +70,7 @@ class TestAzureReplicationJob(object):
         mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
 
-        self.job._run_job()
+        self.job.run_job()
 
         mock_send_log.has_calls([
             call('Copying image for account: acnt1, to classic storage container.'),

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -49,7 +49,7 @@ class TestEC2ReplicationJob(object):
         mock_replicate_to_region.return_value = 'ami-54321'
 
         self.job.source_regions = {'us-east-1': 'ami-12345'}
-        self.job._run_job()
+        self.job.run_job()
 
         mock_send_log.assert_called_once_with(
             'Replicating source region: us-east-1 to the following regions: '

--- a/test/unit/services/replication/gce_job_test.py
+++ b/test/unit/services/replication/gce_job_test.py
@@ -15,4 +15,4 @@ class TestGCEReplicationJob(object):
         self.job = GCEReplicationJob(self.job_config, self.config)
 
     def test_replicate(self):
-        self.job._run_job()
+        self.job.run_job()

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -64,7 +64,7 @@ class TestAzureTestingJob(object):
             }
         }
         job.source_regions = {'East US': 'ami-123'}
-        job._run_job()
+        job.run_job()
 
         mock_test_image.assert_called_once_with(
             'azure',
@@ -90,7 +90,7 @@ class TestAzureTestingJob(object):
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
-        job._run_job()
+        job.run_job()
         assert mock_send_log.mock_calls[1] == call(
             'Image tests failed in region: East US.', success=False
         )

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -76,7 +76,7 @@ class TestEC2TestingJob(object):
             }
         }
         job.source_regions = {'us-east-1': 'ami-123'}
-        job._run_job()
+        job.run_job()
 
         client.import_key_pair.assert_called_once_with(
             KeyName='random_name', PublicKeyMaterial='fakekey'
@@ -106,7 +106,7 @@ class TestEC2TestingJob(object):
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
-        job._run_job()
+        job.run_job()
         assert mock_send_log.mock_calls[1] == call(
             'Image tests failed in region: us-east-1.', success=False
         )
@@ -116,4 +116,4 @@ class TestEC2TestingJob(object):
 
         # Failed key cleanup
         client.delete_key_pair.side_effect = Exception('Cannot delete key!')
-        job._run_job()
+        job.run_job()

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -73,7 +73,7 @@ class TestGCETestingJob(object):
             }
         }
         job.source_regions = {'us-west1': 'ami-123'}
-        job._run_job()
+        job.run_job()
 
         mock_test_image.assert_called_once_with(
             'gce',
@@ -99,7 +99,7 @@ class TestGCETestingJob(object):
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
-        job._run_job()
+        job.run_job()
         assert mock_send_log.mock_calls[1] == call(
             'Image tests failed in region: us-west1.', success=False
         )

--- a/test/unit/services/uploader/azure_job_test.py
+++ b/test/unit/services/uploader/azure_job_test.py
@@ -118,7 +118,7 @@ class TestAzureUploaderJob(object):
         system_image_file_type.is_xz.return_value = True
         mock_FileType.return_value = system_image_file_type
 
-        self.job._run_job()
+        self.job.run_job()
 
         assert mock_get_client_from_auth_file.call_args_list == [
             call(StorageManagementClient, auth_path='tempfile'),
@@ -156,4 +156,4 @@ class TestAzureUploaderJob(object):
         page_blob_service.create_blob_from_stream.side_effect = Exception
 
         with raises(MashUploadException):
-            self.job._run_job()
+            self.job.run_job()

--- a/test/unit/services/uploader/ec2_job_test.py
+++ b/test/unit/services/uploader/ec2_job_test.py
@@ -98,7 +98,7 @@ class TestAmazonUploaderJob(object):
         ec2_setup.create_security_group.return_value = 'sg-123456789'
         mock_ec2_setup.return_value = ec2_setup
 
-        self.job._run_job()
+        self.job.run_job()
         mock_get_client.assert_called_once_with(
             'ec2', 'access-key', 'secret-access-key', 'us-east-1'
         )
@@ -141,4 +141,4 @@ class TestAmazonUploaderJob(object):
         ec2_upload.create_image.side_effect = Exception
 
         with raises(MashUploadException):
-            self.job._run_job()
+            self.job.run_job()

--- a/test/unit/services/uploader/gce_job_test.py
+++ b/test/unit/services/uploader/gce_job_test.py
@@ -102,7 +102,7 @@ class TestGCEUploaderJob(object):
         tempfile.name = 'tempfile'
         mock_NamedTemporaryFile.return_value = tempfile
 
-        self.job._run_job()
+        self.job.run_job()
 
         storage_driver.get_container.assert_called_once_with('images')
         assert storage_driver.upload_object_via_stream.call_count == 1


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Make run_job method public.

It is called and extended by child classes.
