### PR TITLE
Move credentials methods to pipeline service.

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -35,6 +35,12 @@ class CredentialsService(MashService):
     def post_init(self):
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 
+        self.encryption_keys_file = self.config.get_encryption_keys_file()
+        self.jwt_secret = self.config.get_jwt_secret()
+        self.jwt_algorithm = self.config.get_jwt_algorithm()
+        self.credentials_queue = 'credentials'
+        self.credentials_response_key = 'response'
+
         self.services = self.config.get_service_names(
             credentials_required=True
         )
@@ -375,8 +381,9 @@ class CredentialsService(MashService):
         self.consume_queue(
             self._handle_account_request, queue_name=self.listener_queue
         )
-        self.consume_credentials_queue(
-            self._handle_credential_request, queue_name='request'
+        self.consume_queue(
+            self._handle_credential_request,
+            queue_name='request'
         )
 
         try:

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -17,14 +17,11 @@
 #
 
 import json
-import jwt
 import logging
 import os
 import smtplib
 
-from amqpstorm import AMQPError, Connection
-from cryptography.fernet import Fernet, MultiFernet
-from datetime import datetime, timedelta
+from amqpstorm import Connection
 from email.message import EmailMessage
 
 # project
@@ -64,9 +61,6 @@ class MashService(object):
         self.listener_msg_key = 'listener_msg'
 
         self.config = get_configuration(self.service_exchange)
-        self.encryption_keys_file = self.config.get_encryption_keys_file()
-        self.jwt_secret = self.config.get_jwt_secret()
-        self.jwt_algorithm = self.config.get_jwt_algorithm()
 
         # amqp settings
         self.amqp_host = self.config.get_amqp_host()
@@ -93,13 +87,6 @@ class MashService(object):
         )
         self.bind_queue(
             self.service_exchange, self.listener_msg_key, self.listener_queue
-        )
-
-        # Credentials
-        self.credentials_queue = 'credentials'
-        self.credentials_response_key = 'response'
-        self.credentials_request_key = 'request.{0}'.format(
-            self.service_exchange
         )
 
         logging.basicConfig()
@@ -197,15 +184,6 @@ class MashService(object):
             mandatory=True
         )
 
-    def bind_credentials_queue(self):
-        """
-        Bind the response key to the credentials queue.
-        """
-        self.bind_queue(
-            self.service_exchange, self.credentials_response_key,
-            self.credentials_queue
-        )
-
     def bind_queue(self, exchange, routing_key, name):
         """
         Bind queue on exchange to the provided routing key.
@@ -231,19 +209,6 @@ class MashService(object):
         if self.connection and self.connection.is_open:
             self.connection.close()
 
-    def consume_credentials_queue(self, callback, queue_name=None):
-        """
-        Setup credentials attributes from configuration.
-
-        Then consume credentials response queue to receive credentials
-        tokens for jobs.
-        """
-        if not queue_name:
-            queue_name = self.credentials_queue
-
-        queue = self._get_queue_name(self.service_exchange, queue_name)
-        self.channel.basic.consume(callback=callback, queue=queue)
-
     def consume_queue(self, callback, queue_name=None):
         """
         Declare and consume queue.
@@ -258,81 +223,6 @@ class MashService(object):
         self.channel.basic.consume(
             callback=callback, queue=queue
         )
-
-    def decode_credentials(self, message):
-        """
-        Decode jwt credential response message.
-        """
-        decrypted_credentials = {}
-        try:
-            payload = jwt.decode(
-                message['jwt_token'], self.jwt_secret,
-                algorithm=self.jwt_algorithm, issuer='credentials',
-                audience=self.service_exchange
-            )
-            job_id = payload['id']
-            for account, credentials in payload['credentials'].items():
-                decrypted_credentials[account] = self.decrypt_credentials(
-                    credentials
-                )
-        except KeyError as error:
-            self.log.error(
-                'Invalid credentials response recieved: {0}'
-                ' key must be in credentials message.'.format(error)
-            )
-        except Exception as error:
-            self.log.error(
-                'Invalid credentials response token: {0}'.format(error)
-            )
-        else:
-            return job_id, decrypted_credentials
-
-        # If exception occurs decoding credentials return None.
-        return None, None
-
-    def decrypt_credentials(self, credentials):
-        """
-        Decrypt credentials string and load json to dictionary.
-        """
-        encryption_keys = self.get_encryption_keys_from_file(
-            self.encryption_keys_file
-        )
-        fernet_key = MultiFernet(encryption_keys)
-
-        try:
-            # Ensure string is encoded as bytes before decrypting.
-            credentials = credentials.encode()
-        except Exception:
-            pass
-
-        return json.loads(fernet_key.decrypt(credentials).decode())
-
-    def get_credential_request(self, job_id):
-        """
-        Return jwt encoded credentials request message.
-        """
-        request = {
-            'exp': datetime.utcnow() + timedelta(minutes=5),  # Expiration time
-            'iat': datetime.utcnow(),  # Issued at time
-            'sub': 'credentials_request',  # Subject
-            'iss': self.service_exchange,  # Issuer
-            'aud': 'credentials',  # audience
-            'id': job_id,
-        }
-        token = jwt.encode(
-            request, self.jwt_secret, algorithm=self.jwt_algorithm
-        )
-        message = json.dumps({'jwt_token': token.decode()})
-        return message
-
-    def get_encryption_keys_from_file(self, encryption_keys_file):
-        """
-        Returns a list of Fernet keys based on the provided keys file.
-        """
-        with open(encryption_keys_file, 'r') as keys_file:
-            keys = keys_file.readlines()
-
-        return [Fernet(key.strip()) for key in keys if key]
 
     def log_job_message(self, msg, metadata, success=True):
         """
@@ -355,32 +245,6 @@ class MashService(object):
             config_file.write(JsonFormat.json_message(config))
 
         return config['job_file']
-
-    def publish_credentials_delete(self, job_id):
-        """
-        Publish delete message to credentials service.
-        """
-        delete_message = JsonFormat.json_message(
-            {"credentials_job_delete": job_id}
-        )
-
-        try:
-            self._publish(
-                'credentials', self.job_document_key, delete_message
-            )
-        except AMQPError:
-            self.log.warning(
-                'Message not received: {0}'.format(delete_message)
-            )
-
-    def publish_credentials_request(self, job_id):
-        """
-        Publish credentials request message to the credentials exchange.
-        """
-        self._publish(
-            'credentials', self.credentials_request_key,
-            self.get_credential_request(job_id)
-        )
 
     def publish_job_result(self, exchange, message):
         """

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -493,32 +493,27 @@ class TestCredentialsService(object):
             'user2', 'test-aws', 'ec2'
         )
 
-    @patch.object(CredentialsService, 'consume_credentials_queue')
     @patch.object(CredentialsService, 'consume_queue')
     @patch.object(CredentialsService, 'close_connection')
     def test_credentials_start(
-        self, mock_close_connection, mock_consume_queue,
-        mock_consume_creds_queue
+        self, mock_close_connection, mock_consume_queue
     ):
         self.service.start()
 
         self.service.channel.start_consuming.assert_called_once_with()
         mock_consume_queue.has_calls([
             call(self.service._handle_job_documents),
-            call(self.service._handle_account_request, queue_name='listener')
+            call(self.service._handle_account_request, queue_name='listener'),
+            call(self.service._handle_credential_request, queue_name='request')
         ])
-        mock_consume_creds_queue.assert_called_once_with(
-            self.service._handle_credential_request, queue_name='request'
-        )
         mock_close_connection.assert_called_once_with()
 
     @patch.object(AccountDatastore, 'shutdown')
-    @patch.object(CredentialsService, 'consume_credentials_queue')
     @patch.object(CredentialsService, 'consume_queue')
     @patch.object(CredentialsService, 'close_connection')
     def test_credentials_start_exception(
         self, mock_close_connection, mock_consume_queue,
-        mock_consume_creds_queue, mock_datastore_shutdown
+        mock_datastore_shutdown
     ):
         self.service.channel.start_consuming.side_effect = KeyboardInterrupt()
         self.service.start()


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Move credentials methods to pipeline service. Credentials methods are not used by all base services.

### How will these changes be tested?

Unit and integration tests.
