### PR TITLE
Move next/prev methods to pipeline service.

### DIFF
--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -64,8 +64,6 @@ class MashService(object):
         self.listener_msg_key = 'listener_msg'
 
         self.config = get_configuration(self.service_exchange)
-        self.next_service = self._get_next_service()
-        self.prev_service = self._get_previous_service()
         self.encryption_keys_file = self.config.get_encryption_keys_file()
         self.jwt_secret = self.config.get_jwt_secret()
         self.jwt_algorithm = self.config.get_jwt_algorithm()
@@ -151,33 +149,6 @@ class MashService(object):
         Declare the queue and set as durable.
         """
         return self.channel.queue.declare(queue=queue, durable=True)
-
-    def _get_next_service(self):
-        """Return the next service based on the current exchange."""
-        services = self.config.get_service_names()
-
-        try:
-            next_service = services[services.index(self.service_exchange) + 1]
-        except (IndexError, ValueError):
-            next_service = None
-
-        return next_service
-
-    def _get_previous_service(self):
-        """
-        Return the previous service based on the current exchange.
-        """
-        services = self.config.get_service_names()
-
-        try:
-            index = services.index(self.service_exchange) - 1
-        except ValueError:
-            return None
-
-        if index < 0:
-            return None
-
-        return services[index]
 
     def _get_queue_name(self, exchange, name):
         """

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -61,7 +61,7 @@ class OBSImageBuildResultService(MashService):
 
     def _send_job_result_for_uploader(self, job_id, trigger_info):
         self.publish_job_result(
-            self.next_service, JsonFormat.json_message(trigger_info)
+            'uploader', JsonFormat.json_message(trigger_info)
         )
         if not self.jobs[job_id].job_nonstop:
             self._delete_job(job_id)
@@ -117,7 +117,7 @@ class OBSImageBuildResultService(MashService):
                 }
             }
             self.publish_job_result(
-                self.next_service, JsonFormat.json_message(message)
+                'uploader', JsonFormat.json_message(message)
             )
         else:
             result = {

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -40,6 +40,9 @@ class PipelineService(MashService):
         """Initialize base service class and job scheduler."""
         self.jobs = {}
 
+        self.next_service = self._get_next_service()
+        self.prev_service = self._get_previous_service()
+
         if not self.custom_args:
             self.custom_args = {}
 
@@ -146,6 +149,33 @@ class PipelineService(MashService):
                 'Job deletion failed, job is not queued.',
                 extra={'job_id': job_id}
             )
+
+    def _get_next_service(self):
+        """Return the next service based on the current exchange."""
+        services = self.config.get_service_names()
+
+        try:
+            next_service = services[services.index(self.service_exchange) + 1]
+        except (IndexError, ValueError):
+            next_service = None
+
+        return next_service
+
+    def _get_previous_service(self):
+        """
+        Return the previous service based on the current exchange.
+        """
+        services = self.config.get_service_names()
+
+        try:
+            index = services.index(self.service_exchange) - 1
+        except ValueError:
+            return None
+
+        if index < 0:
+            return None
+
+        return services[index]
 
     def _get_status_message(self, job):
         """

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -311,33 +311,6 @@ class TestBaseService(object):
             'credentials', 'request.obs', token
         )
 
-    def test_get_next_service_error(self):
-        # Test service with no next service
-        self.service.service_exchange = 'pint'
-        next_service = self.service._get_next_service()
-        assert next_service is None
-
-        # Test service not in pipeline
-        self.service.service_exchange = 'credentials'
-        next_service = self.service._get_next_service()
-        assert next_service is None
-
-    def test_get_prev_service(self):
-        # Test service with prev service
-        self.service.service_exchange = 'testing'
-        prev_service = self.service._get_previous_service()
-        assert prev_service == 'uploader'
-
-        # Test service not in pipeline
-        self.service.service_exchange = 'credentials'
-        prev_service = self.service._get_previous_service()
-        assert prev_service is None
-
-        # Test service as beginning of pipeline
-        self.service.service_exchange = 'obs'
-        prev_service = self.service._get_previous_service()
-        assert prev_service is None
-
     @patch.object(MashService, '_publish')
     def test_publish_credentials_delete(self, mock_publish):
         self.service.publish_credentials_delete('1')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Move next/prev methods to pipeline service. Only pipeline classes should use them.

### How will these changes be tested?

Unit and integration testing.
