### PR TITLE
Migrate job specific methods

### DIFF
--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -33,6 +33,9 @@ class CredentialsService(MashService):
     Implements CredentialsService based on web token technology
     """
     def post_init(self):
+        self.listener_queue = 'listener'
+        self.job_document_key = 'job_document'
+
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 
         self.encryption_keys_file = self.config.get_encryption_keys_file()
@@ -61,6 +64,9 @@ class CredentialsService(MashService):
         )
         self.bind_queue(
             self.service_exchange, self.delete_account_key, self.listener_queue
+        )
+        self.bind_queue(
+            self.service_exchange, self.job_document_key, self.service_queue
         )
         self._bind_credential_request_keys()
 

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -34,8 +34,9 @@ class CredentialsService(MashService):
     """
     def post_init(self):
         self.listener_queue = 'listener'
-        self.job_document_key = 'job_document'
         self.service_queue = 'service'
+        self.job_document_key = 'job_document'
+        self.listener_msg_key = 'listener_msg'
 
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -28,6 +28,7 @@ from mash.services.mash_service import MashService
 from mash.services.credentials import get_account_info
 from mash.services.credentials.account_datastore import AccountDatastore
 from mash.utils.json_format import JsonFormat
+from mash.utils.mash_utils import remove_file
 
 
 class CredentialsService(MashService):
@@ -177,7 +178,7 @@ class CredentialsService(MashService):
             )
 
             del self.jobs[job_id]
-            self.remove_file(job['job_file'])
+            remove_file(job['job_file'])
         else:
             self._send_control_response(
                 'Job deletion failed, job is not queued.',
@@ -398,15 +399,6 @@ class CredentialsService(MashService):
             self.log.warning(
                 'Unable to delete account: {0}'.format(error)
             )
-
-    def remove_file(self, config_file):
-        """
-        Remove file from disk if it exists.
-        """
-        try:
-            os.remove(config_file)
-        except Exception:
-            pass
 
     def persist_job_config(self, config):
         """

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -23,6 +23,7 @@ import os
 from datetime import datetime, timedelta
 
 # project
+from mash.services.base_defaults import Defaults
 from mash.services.mash_service import MashService
 from mash.services.credentials import get_account_info
 from mash.services.credentials.account_datastore import AccountDatastore
@@ -58,6 +59,12 @@ class CredentialsService(MashService):
         )
 
         self.jobs = {}
+
+        # setup service job directory
+        self.job_directory = Defaults.get_job_directory(self.service_exchange)
+        os.makedirs(
+            self.job_directory, exist_ok=True
+        )
 
         self.add_account_key = 'add_account'
         self.delete_account_key = 'delete_account'

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -421,6 +421,19 @@ class CredentialsService(MashService):
 
         return config['job_file']
 
+    def restart_jobs(self, callback):
+        """
+        Restart jobs from config files.
+
+        Recover from service failure with existing jobs.
+        """
+        for job_file in os.listdir(self.job_directory):
+            with open(os.path.join(self.job_directory, job_file), 'r') \
+                    as conf_file:
+                job_config = json.load(conf_file)
+
+            callback(job_config)
+
     def start(self):
         """
         Start credentials service.

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -18,6 +18,7 @@
 
 import jwt
 import json
+import os
 
 from datetime import datetime, timedelta
 
@@ -390,6 +391,15 @@ class CredentialsService(MashService):
             self.log.warning(
                 'Unable to delete account: {0}'.format(error)
             )
+
+    def remove_file(self, config_file):
+        """
+        Remove file from disk if it exists.
+        """
+        try:
+            os.remove(config_file)
+        except Exception:
+            pass
 
     def start(self):
         """

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -28,7 +28,7 @@ from mash.services.mash_service import MashService
 from mash.services.credentials import get_account_info
 from mash.services.credentials.account_datastore import AccountDatastore
 from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import remove_file
+from mash.utils.mash_utils import remove_file, persist_json
 
 
 class CredentialsService(MashService):
@@ -106,8 +106,11 @@ class CredentialsService(MashService):
 
                 job_document['cloud_accounts'] += testing_accounts
 
-                job_document['job_file'] = self.persist_job_config(
-                    job_document
+                job_document['job_file'] = '{0}job-{1}.json'.format(
+                    self.job_directory, job_id
+                )
+                persist_json(
+                    job_document['job_file'], job_document
                 )
 
             self._send_control_response(
@@ -399,19 +402,6 @@ class CredentialsService(MashService):
             self.log.warning(
                 'Unable to delete account: {0}'.format(error)
             )
-
-    def persist_job_config(self, config):
-        """
-        Persist the job config file to disk for recoverability.
-        """
-        config['job_file'] = '{0}job-{1}.json'.format(
-            self.job_directory, config['id']
-        )
-
-        with open(config['job_file'], 'w') as config_file:
-            config_file.write(JsonFormat.json_message(config))
-
-        return config['job_file']
 
     def restart_jobs(self, callback):
         """

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -35,6 +35,7 @@ class CredentialsService(MashService):
     def post_init(self):
         self.listener_queue = 'listener'
         self.job_document_key = 'job_document'
+        self.service_queue = 'service'
 
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 
@@ -393,9 +394,13 @@ class CredentialsService(MashService):
         """
         Start credentials service.
         """
-        self.consume_queue(self._handle_job_documents)
         self.consume_queue(
-            self._handle_account_request, queue_name=self.listener_queue
+            self._handle_job_documents,
+            queue_name=self.service_queue
+        )
+        self.consume_queue(
+            self._handle_account_request,
+            queue_name=self.listener_queue
         )
         self.consume_queue(
             self._handle_credential_request,

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -28,7 +28,7 @@ from mash.services.mash_service import MashService
 from mash.services.credentials import get_account_info
 from mash.services.credentials.account_datastore import AccountDatastore
 from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import remove_file, persist_json
+from mash.utils.mash_utils import remove_file, persist_json, restart_jobs
 
 
 class CredentialsService(MashService):
@@ -81,7 +81,7 @@ class CredentialsService(MashService):
         )
         self._bind_credential_request_keys()
 
-        self.restart_jobs(self._add_job)
+        restart_jobs(self.job_directory, self._add_job)
         self.start()
 
     def _add_job(self, job_document):
@@ -402,19 +402,6 @@ class CredentialsService(MashService):
             self.log.warning(
                 'Unable to delete account: {0}'.format(error)
             )
-
-    def restart_jobs(self, callback):
-        """
-        Restart jobs from config files.
-
-        Recover from service failure with existing jobs.
-        """
-        for job_file in os.listdir(self.job_directory):
-            with open(os.path.join(self.job_directory, job_file), 'r') \
-                    as conf_file:
-                job_config = json.load(conf_file)
-
-            callback(job_config)
 
     def start(self):
         """

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -408,6 +408,19 @@ class CredentialsService(MashService):
         except Exception:
             pass
 
+    def persist_job_config(self, config):
+        """
+        Persist the job config file to disk for recoverability.
+        """
+        config['job_file'] = '{0}job-{1}.json'.format(
+            self.job_directory, config['id']
+        )
+
+        with open(config['job_file'], 'w') as config_file:
+            config_file.write(JsonFormat.json_message(config))
+
+        return config['job_file']
+
     def start(self):
         """
         Start credentials service.

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -36,6 +36,7 @@ class JobCreatorService(MashService):
         """
         self.listener_queue = 'listener'
         self.job_document_key = 'job_document'
+        self.service_queue = 'service'
 
         self.set_logfile(self.config.get_log_file(self.service_exchange))
         self.cloud_data = self.config.get_cloud_data()
@@ -247,9 +248,13 @@ class JobCreatorService(MashService):
         """
         Start job creator service.
         """
-        self.consume_queue(self._handle_service_message)
         self.consume_queue(
-            self._handle_listener_message, queue_name=self.listener_queue
+            self._handle_service_message,
+            queue_name=self.service_queue
+        )
+        self.consume_queue(
+            self._handle_listener_message,
+            queue_name=self.listener_queue
         )
         try:
             self.channel.start_consuming()

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -34,6 +34,9 @@ class JobCreatorService(MashService):
         """
         Initialize job creator service class.
         """
+        self.listener_queue = 'listener'
+        self.job_document_key = 'job_document'
+
         self.set_logfile(self.config.get_log_file(self.service_exchange))
         self.cloud_data = self.config.get_cloud_data()
         self.services = self.config.get_service_names()
@@ -46,6 +49,9 @@ class JobCreatorService(MashService):
         )
         self.bind_queue(
             self.service_exchange, self.delete_account_key, self.listener_queue
+        )
+        self.bind_queue(
+            self.service_exchange, self.job_document_key, self.service_queue
         )
 
         self.jobs = {}

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -35,8 +35,9 @@ class JobCreatorService(MashService):
         Initialize job creator service class.
         """
         self.listener_queue = 'listener'
-        self.job_document_key = 'job_document'
         self.service_queue = 'service'
+        self.job_document_key = 'job_document'
+        self.listener_msg_key = 'listener_msg'
 
         self.set_logfile(self.config.get_log_file(self.service_exchange))
         self.cloud_data = self.config.get_cloud_data()

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -56,8 +56,6 @@ class MashService(object):
         self.service_exchange = service_exchange
         self.custom_args = custom_args
         self.service_queue = 'service'
-        self.listener_queue = 'listener'
-        self.job_document_key = 'job_document'
         self.listener_msg_key = 'listener_msg'
 
         self.config = get_configuration(self.service_exchange)
@@ -82,12 +80,6 @@ class MashService(object):
         )
 
         self._open_connection()
-        self.bind_queue(
-            self.service_exchange, self.job_document_key, self.service_queue
-        )
-        self.bind_queue(
-            self.service_exchange, self.listener_msg_key, self.listener_queue
-        )
 
         logging.basicConfig()
         self.log = logging.getLogger(

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -27,7 +27,6 @@ from email.message import EmailMessage
 # project
 from mash.log.filter import BaseServiceFilter
 from mash.log.handler import RabbitMQHandler
-from mash.services.base_defaults import Defaults
 from mash.services import get_configuration
 from mash.services.status_levels import SUCCESS
 from mash.mash_exceptions import (
@@ -70,12 +69,6 @@ class MashService(object):
         self.smtp_user = self.config.get_smtp_user()
         self.smtp_pass = self.config.get_smtp_pass()
         self.notification_subject = self.config.get_notification_subject()
-
-        # setup service data directory
-        self.job_directory = Defaults.get_job_directory(self.service_exchange)
-        os.makedirs(
-            self.job_directory, exist_ok=True
-        )
 
         self._open_connection()
 

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -55,7 +55,6 @@ class MashService(object):
 
         self.service_exchange = service_exchange
         self.custom_args = custom_args
-        self.service_queue = 'service'
         self.listener_msg_key = 'listener_msg'
 
         self.config = get_configuration(self.service_exchange)
@@ -201,15 +200,10 @@ class MashService(object):
         if self.connection and self.connection.is_open:
             self.connection.close()
 
-    def consume_queue(self, callback, queue_name=None):
+    def consume_queue(self, callback, queue_name):
         """
         Declare and consume queue.
-
-        If queue_name not provided use service_queue name attr.
         """
-        if not queue_name:
-            queue_name = self.service_queue
-
         queue = self._get_queue_name(self.service_exchange, queue_name)
         self._declare_queue(queue)
         self.channel.basic.consume(

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -16,7 +16,6 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import json
 import logging
 import os
 import smtplib
@@ -200,19 +199,6 @@ class MashService(object):
         self.channel.basic.consume(
             callback=callback, queue=queue
         )
-
-    def restart_jobs(self, callback):
-        """
-        Restart jobs from config files.
-
-        Recover from service failure with existing jobs.
-        """
-        for job_file in os.listdir(self.job_directory):
-            with open(os.path.join(self.job_directory, job_file), 'r') \
-                    as conf_file:
-                job_config = json.load(conf_file)
-
-            callback(job_config)
 
     def set_logfile(self, logfile):
         """

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -33,7 +33,6 @@ from mash.mash_exceptions import (
     MashRabbitConnectionException,
     MashLogSetupException
 )
-from mash.utils.json_format import JsonFormat
 
 
 class MashService(object):
@@ -201,19 +200,6 @@ class MashService(object):
         self.channel.basic.consume(
             callback=callback, queue=queue
         )
-
-    def persist_job_config(self, config):
-        """
-        Persist the job config file to disk for recoverability.
-        """
-        config['job_file'] = '{0}job-{1}.json'.format(
-            self.job_directory, config['id']
-        )
-
-        with open(config['job_file'], 'w') as config_file:
-            config_file.write(JsonFormat.json_message(config))
-
-        return config['job_file']
 
     def restart_jobs(self, callback):
         """

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -55,7 +55,6 @@ class MashService(object):
 
         self.service_exchange = service_exchange
         self.custom_args = custom_args
-        self.listener_msg_key = 'listener_msg'
 
         self.config = get_configuration(self.service_exchange)
 
@@ -231,12 +230,6 @@ class MashService(object):
             config_file.write(JsonFormat.json_message(config))
 
         return config['job_file']
-
-    def publish_job_result(self, exchange, message):
-        """
-        Publish the result message to the listener queue on given exchange.
-        """
-        self._publish(exchange, self.listener_msg_key, message)
 
     def remove_file(self, config_file):
         """

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -209,15 +209,6 @@ class MashService(object):
             callback=callback, queue=queue
         )
 
-    def log_job_message(self, msg, metadata, success=True):
-        """
-        Callback for job instance to log given message.
-        """
-        if success:
-            self.log.info(msg, extra=metadata)
-        else:
-            self.log.error(msg, extra=metadata)
-
     def persist_job_config(self, config):
         """
         Persist the job config file to disk for recoverability.

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -222,15 +222,6 @@ class MashService(object):
 
         return config['job_file']
 
-    def remove_file(self, config_file):
-        """
-        Remove file from disk if it exists.
-        """
-        try:
-            os.remove(config_file)
-        except Exception:
-            pass
-
     def restart_jobs(self, callback):
         """
         Restart jobs from config files.

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -32,6 +32,8 @@ class OBSImageBuildResultService(MashService):
     service
     """
     def post_init(self):
+        self.job_document_key = 'job_document'
+
         # setup service log file
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 
@@ -39,6 +41,10 @@ class OBSImageBuildResultService(MashService):
         self.download_directory = self.config.get_download_directory()
 
         self.jobs = {}
+
+        self.bind_queue(
+            self.service_exchange, self.job_document_key, self.service_queue
+        )
 
         # read and launch open jobs
         self.restart_jobs(self._start_job)

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -20,6 +20,7 @@ import os
 import dateutil.parser
 
 # project
+from mash.services.base_defaults import Defaults
 from mash.services.mash_service import MashService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
@@ -43,6 +44,12 @@ class OBSImageBuildResultService(MashService):
         self.download_directory = self.config.get_download_directory()
 
         self.jobs = {}
+
+        # setup service job directory
+        self.job_directory = Defaults.get_job_directory(self.service_exchange)
+        os.makedirs(
+            self.job_directory, exist_ok=True
+        )
 
         self.bind_queue(
             self.service_exchange, self.job_document_key, self.service_queue

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -26,6 +26,7 @@ from mash.services.mash_service import MashService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
 from mash.services.status_levels import DELETE
+from mash.utils.mash_utils import persist_json
 
 
 class OBSImageBuildResultService(MashService):
@@ -177,7 +178,12 @@ class OBSImageBuildResultService(MashService):
         }
         """
         data = data['obs_job']
-        data['job_file'] = self.persist_job_config(data)
+        data['job_file'] = '{0}job-{1}.json'.format(
+            self.job_directory, data['id']
+        )
+        persist_json(
+            data['job_file'], data
+        )
         return self._start_job(data)
 
     def _delete_job(self, job_id):
@@ -260,19 +266,6 @@ class OBSImageBuildResultService(MashService):
             'ok': True,
             'message': 'Job started'
         }
-
-    def persist_job_config(self, config):
-        """
-        Persist the job config file to disk for recoverability.
-        """
-        config['job_file'] = '{0}job-{1}.json'.format(
-            self.job_directory, config['id']
-        )
-
-        with open(config['job_file'], 'w') as config_file:
-            config_file.write(JsonFormat.json_message(config))
-
-        return config['job_file']
 
     def restart_jobs(self, callback):
         """

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 import atexit
+import json
 import os
 import dateutil.parser
 
@@ -272,3 +273,16 @@ class OBSImageBuildResultService(MashService):
             config_file.write(JsonFormat.json_message(config))
 
         return config['job_file']
+
+    def restart_jobs(self, callback):
+        """
+        Restart jobs from config files.
+
+        Recover from service failure with existing jobs.
+        """
+        for job_file in os.listdir(self.job_directory):
+            with open(os.path.join(self.job_directory, job_file), 'r') \
+                    as conf_file:
+                job_config = json.load(conf_file)
+
+            callback(job_config)

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -16,7 +16,6 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 import atexit
-import json
 import os
 import dateutil.parser
 
@@ -26,7 +25,7 @@ from mash.services.mash_service import MashService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
 from mash.services.status_levels import DELETE
-from mash.utils.mash_utils import persist_json
+from mash.utils.mash_utils import persist_json, restart_jobs
 
 
 class OBSImageBuildResultService(MashService):
@@ -58,7 +57,7 @@ class OBSImageBuildResultService(MashService):
         )
 
         # read and launch open jobs
-        self.restart_jobs(self._start_job)
+        restart_jobs(self.job_directory, self._start_job)
 
         # consume on service queue
         atexit.register(lambda: os._exit(0))
@@ -266,16 +265,3 @@ class OBSImageBuildResultService(MashService):
             'ok': True,
             'message': 'Job started'
         }
-
-    def restart_jobs(self, callback):
-        """
-        Restart jobs from config files.
-
-        Recover from service failure with existing jobs.
-        """
-        for job_file in os.listdir(self.job_directory):
-            with open(os.path.join(self.job_directory, job_file), 'r') \
-                    as conf_file:
-                job_config = json.load(conf_file)
-
-            callback(job_config)

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -259,3 +259,16 @@ class OBSImageBuildResultService(MashService):
             'ok': True,
             'message': 'Job started'
         }
+
+    def persist_job_config(self, config):
+        """
+        Persist the job config file to disk for recoverability.
+        """
+        config['job_file'] = '{0}job-{1}.json'.format(
+            self.job_directory, config['id']
+        )
+
+        with open(config['job_file'], 'w') as config_file:
+            config_file.write(JsonFormat.json_message(config))
+
+        return config['job_file']

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -33,6 +33,7 @@ class OBSImageBuildResultService(MashService):
     """
     def post_init(self):
         self.job_document_key = 'job_document'
+        self.listener_msg_key = 'listener_msg'
         self.service_queue = 'service'
 
         # setup service log file
@@ -70,8 +71,10 @@ class OBSImageBuildResultService(MashService):
         self.log.info(status_message, extra={'job_id': job_id})
 
     def _send_job_result_for_uploader(self, job_id, trigger_info):
-        self.publish_job_result(
-            'uploader', JsonFormat.json_message(trigger_info)
+        self._publish(
+            'uploader',
+            self.listener_msg_key,
+            JsonFormat.json_message(trigger_info)
         )
         if not self.jobs[job_id].job_nonstop:
             self._delete_job(job_id)
@@ -126,8 +129,10 @@ class OBSImageBuildResultService(MashService):
                     'status': DELETE
                 }
             }
-            self.publish_job_result(
-                'uploader', JsonFormat.json_message(message)
+            self._publish(
+                'uploader',
+                self.listener_msg_key,
+                JsonFormat.json_message(message)
             )
         else:
             result = {

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -33,6 +33,7 @@ class OBSImageBuildResultService(MashService):
     """
     def post_init(self):
         self.job_document_key = 'job_document'
+        self.service_queue = 'service'
 
         # setup service log file
         self.set_logfile(self.config.get_log_file(self.service_exchange))
@@ -51,7 +52,10 @@ class OBSImageBuildResultService(MashService):
 
         # consume on service queue
         atexit.register(lambda: os._exit(0))
-        self.consume_queue(self._process_message)
+        self.consume_queue(
+            self._process_message,
+            queue_name=self.service_queue
+        )
 
         try:
             self.channel.start_consuming()

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -602,6 +602,19 @@ class PipelineService(MashService):
         except Exception:
             pass
 
+    def persist_job_config(self, config):
+        """
+        Persist the job config file to disk for recoverability.
+        """
+        config['job_file'] = '{0}job-{1}.json'.format(
+            self.job_directory, config['id']
+        )
+
+        with open(config['job_file'], 'w') as config_file:
+            config_file.write(JsonFormat.json_message(config))
+
+        return config['job_file']
+
     def start(self):
         """
         Start pipeline service.

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -36,7 +36,7 @@ from mash.services.job_factory import JobFactory
 from mash.services.mash_service import MashService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import remove_file
+from mash.utils.mash_utils import remove_file, persist_json
 
 
 class PipelineService(MashService):
@@ -126,8 +126,11 @@ class PipelineService(MashService):
                 job.log_callback = self.log_job_message
 
                 if 'job_file' not in job_config:
-                    job_config['job_file'] = self.persist_job_config(
-                        job_config
+                    job_config['job_file'] = '{0}job-{1}.json'.format(
+                        self.job_directory, job_id
+                    )
+                    persist_json(
+                        job_config['job_file'], job_config
                     )
                     job.job_file = job_config['job_file']
 
@@ -593,19 +596,6 @@ class PipelineService(MashService):
             self.log.info(msg, extra=metadata)
         else:
             self.log.error(msg, extra=metadata)
-
-    def persist_job_config(self, config):
-        """
-        Persist the job config file to disk for recoverability.
-        """
-        config['job_file'] = '{0}job-{1}.json'.format(
-            self.job_directory, config['id']
-        )
-
-        with open(config['job_file'], 'w') as config_file:
-            config_file.write(JsonFormat.json_message(config))
-
-        return config['job_file']
 
     def restart_jobs(self, callback):
         """

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -18,6 +18,7 @@
 
 import json
 import jwt
+import os
 
 from amqpstorm import AMQPError
 
@@ -584,6 +585,15 @@ class PipelineService(MashService):
             self.log.info(msg, extra=metadata)
         else:
             self.log.error(msg, extra=metadata)
+
+    def remove_file(self, config_file):
+        """
+        Remove file from disk if it exists.
+        """
+        try:
+            os.remove(config_file)
+        except Exception:
+            pass
 
     def start(self):
         """

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -615,6 +615,19 @@ class PipelineService(MashService):
 
         return config['job_file']
 
+    def restart_jobs(self, callback):
+        """
+        Restart jobs from config files.
+
+        Recover from service failure with existing jobs.
+        """
+        for job_file in os.listdir(self.job_directory):
+            with open(os.path.join(self.job_directory, job_file), 'r') \
+                    as conf_file:
+                job_config = json.load(conf_file)
+
+            callback(job_config)
+
     def start(self):
         """
         Start pipeline service.

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -36,7 +36,7 @@ from mash.services.job_factory import JobFactory
 from mash.services.mash_service import MashService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import remove_file, persist_json
+from mash.utils.mash_utils import remove_file, persist_json, restart_jobs
 
 
 class PipelineService(MashService):
@@ -100,7 +100,7 @@ class PipelineService(MashService):
             events.EVENT_JOB_EXECUTED | events.EVENT_JOB_ERROR
         )
 
-        self.restart_jobs(self._add_job)
+        restart_jobs(self.job_directory, self._add_job)
         self.start()
 
     def _add_job(self, job_config):
@@ -596,19 +596,6 @@ class PipelineService(MashService):
             self.log.info(msg, extra=metadata)
         else:
             self.log.error(msg, extra=metadata)
-
-    def restart_jobs(self, callback):
-        """
-        Restart jobs from config files.
-
-        Recover from service failure with existing jobs.
-        """
-        for job_file in os.listdir(self.job_directory):
-            with open(os.path.join(self.job_directory, job_file), 'r') \
-                    as conf_file:
-                job_config = json.load(conf_file)
-
-            callback(job_config)
 
     def start(self):
         """

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -36,6 +36,7 @@ from mash.services.job_factory import JobFactory
 from mash.services.mash_service import MashService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.utils.json_format import JsonFormat
+from mash.utils.mash_utils import remove_file
 
 
 class PipelineService(MashService):
@@ -178,7 +179,7 @@ class PipelineService(MashService):
                 self.publish_credentials_delete(job_id)
 
             del self.jobs[job_id]
-            self.remove_file(job.job_file)
+            remove_file(job.job_file)
         else:
             self.log.warning(
                 'Job deletion failed, job is not queued.',
@@ -592,15 +593,6 @@ class PipelineService(MashService):
             self.log.info(msg, extra=metadata)
         else:
             self.log.error(msg, extra=metadata)
-
-    def remove_file(self, config_file):
-        """
-        Remove file from disk if it exists.
-        """
-        try:
-            os.remove(config_file)
-        except Exception:
-            pass
 
     def persist_job_config(self, config):
         """

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -42,6 +42,9 @@ class PipelineService(MashService):
     """
     def post_init(self):
         """Initialize base service class and job scheduler."""
+        self.listener_queue = 'listener'
+        self.job_document_key = 'job_document'
+
         self.jobs = {}
 
         self.next_service = self._get_next_service()
@@ -71,6 +74,13 @@ class PipelineService(MashService):
             self.status_msg_args += self.custom_args['status_msg_args']
 
         self.set_logfile(self.config.get_log_file(self.service_exchange))
+
+        self.bind_queue(
+            self.service_exchange, self.job_document_key, self.service_queue
+        )
+        self.bind_queue(
+            self.service_exchange, self.listener_msg_key, self.listener_queue
+        )
         self.bind_credentials_queue()
 
         self.scheduler = BackgroundScheduler(timezone=utc)

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta
 
 from pytz import utc
 
+from mash.services.base_defaults import Defaults
 from mash.services.job_factory import JobFactory
 from mash.services.mash_service import MashService
 from mash.services.status_levels import EXCEPTION, SUCCESS
@@ -49,6 +50,12 @@ class PipelineService(MashService):
         self.listener_msg_key = 'listener_msg'
 
         self.jobs = {}
+
+        # setup service job directory
+        self.job_directory = Defaults.get_job_directory(self.service_exchange)
+        os.makedirs(
+            self.job_directory, exist_ok=True
+        )
 
         self.next_service = self._get_next_service()
         self.prev_service = self._get_previous_service()

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -43,8 +43,9 @@ class PipelineService(MashService):
     def post_init(self):
         """Initialize base service class and job scheduler."""
         self.listener_queue = 'listener'
-        self.job_document_key = 'job_document'
         self.service_queue = 'service'
+        self.job_document_key = 'job_document'
+        self.listener_msg_key = 'listener_msg'
 
         self.jobs = {}
 
@@ -568,6 +569,12 @@ class PipelineService(MashService):
             'credentials', self.credentials_request_key,
             self.get_credential_request(job_id)
         )
+
+    def publish_job_result(self, exchange, message):
+        """
+        Publish the result message to the listener queue on given exchange.
+        """
+        self._publish(exchange, self.listener_msg_key, message)
 
     def start(self):
         """

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -44,6 +44,7 @@ class PipelineService(MashService):
         """Initialize base service class and job scheduler."""
         self.listener_queue = 'listener'
         self.job_document_key = 'job_document'
+        self.service_queue = 'service'
 
         self.jobs = {}
 
@@ -573,9 +574,13 @@ class PipelineService(MashService):
         Start pipeline service.
         """
         self.scheduler.start()
-        self.consume_queue(self._handle_service_message)
         self.consume_queue(
-            self._handle_listener_message, queue_name=self.listener_queue
+            self._handle_service_message,
+            queue_name=self.service_queue
+        )
+        self.consume_queue(
+            self._handle_listener_message,
+            queue_name=self.listener_queue
         )
         self.consume_credentials_queue(self._handle_credentials_response)
 

--- a/mash/services/pipeline_service.py
+++ b/mash/services/pipeline_service.py
@@ -576,6 +576,15 @@ class PipelineService(MashService):
         """
         self._publish(exchange, self.listener_msg_key, message)
 
+    def log_job_message(self, msg, metadata, success=True):
+        """
+        Callback for job instance to log given message.
+        """
+        if success:
+            self.log.info(msg, extra=metadata)
+        else:
+            self.log.error(msg, extra=metadata)
+
     def start(self):
         """
         Start pipeline service.

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -102,3 +102,13 @@ def format_string_with_date(value, timestamp=None, date_format='%Y%m%d'):
         pass
 
     return value
+
+
+def remove_file(file_path):
+    """
+    Remove file from disk if it exists.
+    """
+    try:
+        os.remove(file_path)
+    except FileNotFoundError:
+        pass

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -17,6 +17,7 @@
 #
 
 import datetime
+import json
 import os
 import random
 
@@ -120,3 +121,29 @@ def persist_json(file_path, data):
     """
     with open(file_path, 'w') as json_file:
         json_file.write(JsonFormat.json_message(data))
+
+
+def load_json(file_path):
+    """
+    Load json from file and return dictionary.
+    """
+    with open(file_path, 'r') as json_file:
+        data = json.load(json_file)
+
+    return data
+
+
+def restart_job(job_file, callback):
+    """
+    Restart job from config file using callback.
+    """
+    job_config = load_json(job_file)
+    callback(job_config)
+
+
+def restart_jobs(job_dir, callback):
+    """
+    Restart all jobs in job_dir using callback.
+    """
+    for job_file in os.listdir(job_dir):
+        restart_job(os.path.join(job_dir, job_file), callback)

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -112,3 +112,11 @@ def remove_file(file_path):
         os.remove(file_path)
     except FileNotFoundError:
         pass
+
+
+def persist_json(file_path, data):
+    """
+    Persist the json data to a file on disk.
+    """
+    with open(file_path, 'w') as json_file:
+        json_file.write(JsonFormat.json_message(data))

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -124,12 +124,6 @@ class TestBaseService(object):
                 })
             )
 
-    @patch('mash.services.mash_service.os.remove')
-    def test_remove_file(self, mock_remove):
-        mock_remove.side_effect = Exception('File not found.')
-        self.service.remove_file('job-test.json')
-        mock_remove.assert_called_once_with('job-test.json')
-
     @patch('mash.services.mash_service.json.load')
     @patch('mash.services.mash_service.os.listdir')
     def test_restart_jobs(self, mock_os_listdir, mock_json_load):

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -1,5 +1,3 @@
-import io
-
 from unittest.mock import patch
 from unittest.mock import call
 from unittest.mock import MagicMock, Mock
@@ -11,8 +9,6 @@ from mash.mash_exceptions import (
     MashRabbitConnectionException,
     MashLogSetupException
 )
-
-open_name = "builtins.open"
 
 
 class TestBaseService(object):
@@ -97,23 +93,6 @@ class TestBaseService(object):
         self.service.close_connection()
         self.connection.close.assert_called_once_with()
         self.channel.close.assert_called_once_with()
-
-    @patch('mash.services.mash_service.json.load')
-    @patch('mash.services.mash_service.os.listdir')
-    def test_restart_jobs(self, mock_os_listdir, mock_json_load):
-        self.service.job_directory = 'tmp-dir'
-        mock_os_listdir.return_value = ['job-123.json']
-        mock_json_load.return_value = {'id': '1'}
-
-        with patch(open_name, create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            mock_callback = Mock()
-            self.service.restart_jobs(mock_callback)
-
-            file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.read.call_count == 1
-
-        mock_callback.assert_called_once_with({'id': '1'})
 
     def test_unbind_queue(self):
         self.service.unbind_queue(

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -94,15 +94,6 @@ class TestBaseService(object):
         with raises(MashLogSetupException):
             self.service.set_logfile('/some/log')
 
-    @patch('mash.services.mash_service.Connection')
-    def test_publish_job_result(self, mock_connection):
-        mock_connection.return_value = self.connection
-        self.service.publish_job_result('exchange', 'message')
-        self.channel.basic.publish.assert_called_once_with(
-            body='message', exchange='exchange', mandatory=True,
-            properties=self.msg_properties, routing_key='listener_msg'
-        )
-
     def test_consume_queue(self):
         callback = Mock()
         self.service.consume_queue(callback, queue_name='service')

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -11,7 +11,6 @@ from mash.mash_exceptions import (
     MashRabbitConnectionException,
     MashLogSetupException
 )
-from mash.utils.json_format import JsonFormat
 
 open_name = "builtins.open"
 
@@ -98,22 +97,6 @@ class TestBaseService(object):
         self.service.close_connection()
         self.connection.close.assert_called_once_with()
         self.channel.close.assert_called_once_with()
-
-    def test_persist_job_config(self):
-        self.service.job_directory = 'tmp-dir/'
-
-        with patch(open_name, create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.service.persist_job_config({'id': '1'})
-            file_handle = mock_open.return_value.__enter__.return_value
-            # Dict is mutable, mock compares the final value of Dict
-            # not the initial value that was passed in.
-            file_handle.write.assert_called_with(
-                JsonFormat.json_message({
-                    "id": "1",
-                    "job_file": "tmp-dir/job-1.json"
-                })
-            )
 
     @patch('mash.services.mash_service.json.load')
     @patch('mash.services.mash_service.os.listdir')

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, Mock
 from pytest import raises
 
 from mash.services.mash_service import MashService
-from mash.services.base_defaults import Defaults
 
 from mash.mash_exceptions import (
     MashRabbitConnectionException,
@@ -19,14 +18,10 @@ open_name = "builtins.open"
 
 class TestBaseService(object):
     @patch('mash.services.mash_service.get_configuration')
-    @patch('mash.services.mash_service.os.makedirs')
-    @patch.object(Defaults, 'get_job_directory')
     @patch('mash.services.mash_service.Connection')
     def setup(
-        self, mock_connection, mock_get_job_directory, mock_makedirs,
-        mock_get_configuration
+        self, mock_connection, mock_get_configuration
     ):
-        mock_get_job_directory.return_value = '/var/lib/mash/obs_jobs/'
         self.connection = Mock()
         self.channel = Mock()
         self.msg_properties = {
@@ -52,10 +47,6 @@ class TestBaseService(object):
         self.service = MashService('obs')
 
         mock_get_configuration.assert_called_once_with('obs')
-        mock_get_job_directory.assert_called_once_with('obs')
-        mock_makedirs.assert_called_once_with(
-            '/var/lib/mash/obs_jobs/', exist_ok=True
-        )
         self.service.log = Mock()
         mock_connection.side_effect = Exception
         with raises(MashRabbitConnectionException):

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -108,23 +108,6 @@ class TestBaseService(object):
         self.connection.close.assert_called_once_with()
         self.channel.close.assert_called_once_with()
 
-    def test_log_job_message(self):
-        self.service.log_job_message('Test message', {'job_id': '1'})
-
-        self.service.log.info.assert_called_once_with(
-            'Test message',
-            extra={'job_id': '1'}
-        )
-
-        self.service.log_job_message(
-            'Test error message', {'job_id': '1'}, success=False
-        )
-
-        self.service.log.error.assert_called_once_with(
-            'Test error message',
-            extra={'job_id': '1'}
-        )
-
     def test_persist_job_config(self):
         self.service.job_directory = 'tmp-dir/'
 

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -105,7 +105,7 @@ class TestBaseService(object):
 
     def test_consume_queue(self):
         callback = Mock()
-        self.service.consume_queue(callback)
+        self.service.consume_queue(callback, queue_name='service')
         self.channel.basic.consume.assert_called_once_with(
             callback=callback, queue='obs.service'
         )

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -185,7 +185,7 @@ class TestCredentialsService(object):
             )
         )
 
-    @patch.object(CredentialsService, 'remove_file')
+    @patch('mash.services.credentials.service.remove_file')
     @patch.object(CredentialsService, '_send_control_response')
     def test_credentials_delete_job(
         self, mock_send_control_response, mock_remove_file
@@ -545,12 +545,6 @@ class TestCredentialsService(object):
         self.service.log.warning.assert_called_once_with(
             'Unable to delete account: Forbidden!'
         )
-
-    @patch('mash.services.credentials.service.os.remove')
-    def test_remove_file(self, mock_remove):
-        mock_remove.side_effect = Exception('File not found.')
-        self.service.remove_file('job-test.json')
-        mock_remove.assert_called_once_with('job-test.json')
 
     def test_persist_job_config(self):
         self.service.job_directory = 'tmp-dir/'

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -568,6 +568,23 @@ class TestCredentialsService(object):
                 })
             )
 
+    @patch('mash.services.credentials.service.json.load')
+    @patch('mash.services.credentials.service.os.listdir')
+    def test_restart_jobs(self, mock_os_listdir, mock_json_load):
+        self.service.job_directory = 'tmp-dir'
+        mock_os_listdir.return_value = ['job-123.json']
+        mock_json_load.return_value = {'id': '1'}
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            mock_callback = Mock()
+            self.service.restart_jobs(mock_callback)
+
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.call_count == 1
+
+        mock_callback.assert_called_once_with({'id': '1'})
+
     @patch.object(CredentialsService, 'consume_queue')
     @patch.object(CredentialsService, 'close_connection')
     def test_credentials_start(

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -535,6 +535,12 @@ class TestCredentialsService(object):
             'Unable to delete account: Forbidden!'
         )
 
+    @patch('mash.services.credentials.service.os.remove')
+    def test_remove_file(self, mock_remove):
+        mock_remove.side_effect = Exception('File not found.')
+        self.service.remove_file('job-test.json')
+        mock_remove.assert_called_once_with('job-test.json')
+
     @patch.object(CredentialsService, 'consume_queue')
     @patch.object(CredentialsService, 'close_connection')
     def test_credentials_start(

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -749,7 +749,10 @@ class TestJobCreatorService(object):
         self.channel.start_consuming.assert_called_once_with()
 
         mock_consume_queue.assert_has_calls([
-            call(self.jobcreator._handle_service_message),
+            call(
+                self.jobcreator._handle_service_message,
+                queue_name='service'
+            ),
             call(
                 self.jobcreator._handle_listener_message,
                 queue_name='listener'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -34,6 +34,7 @@ class TestJobCreatorService(object):
         self.jobcreator.delete_account_key = 'delete_account'
         self.jobcreator.service_exchange = 'jobcreator'
         self.jobcreator.listener_queue = 'listener'
+        self.jobcreator.service_queue = 'service'
         self.jobcreator.job_document_key = 'job_document'
         self.jobcreator.services = [
             'obs', 'uploader', 'testing', 'replication',

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -44,7 +44,9 @@ class TestOBSImageBuildResultService(object):
         self.obs_result.channel.is_open = True
         self.obs_result.close_connection = Mock()
         self.obs_result.service_exchange = 'obs'
+        self.obs_result.service_queue = 'service'
         self.obs_result.next_service = 'uploader'
+        self.obs_result.job_document_key = 'job_document'
 
         self.obs_result.post_init()
 

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -186,10 +186,11 @@ class TestOBSImageBuildResultService(object):
             )
         ]
 
-    @patch.object(OBSImageBuildResultService, 'persist_job_config')
+    @patch('mash.services.obs.service.persist_json')
     @patch.object(OBSImageBuildResultService, '_start_job')
     @patch_open
-    def test_add_job(self, mock_open, mock_start_job, mock_persist_job_config):
+    def test_add_job(self, mock_open, mock_start_job, mock_persist_json):
+        self.obs_result.job_directory = 'tmp/'
         job_data = {
             "obs_job": {
                 "id": "123",
@@ -205,7 +206,10 @@ class TestOBSImageBuildResultService(object):
             }
         }
         self.obs_result._add_job(job_data)
-        mock_persist_job_config.assert_called_once_with(job_data['obs_job'])
+        mock_persist_json.assert_called_once_with(
+            'tmp/job-123.json',
+            job_data['obs_job']
+        )
         mock_start_job.assert_called_once_with(job_data['obs_job'])
 
     @patch('os.remove')
@@ -296,22 +300,6 @@ class TestOBSImageBuildResultService(object):
         job_worker.start_watchdog.assert_called_once_with(
             isotime='2017-10-11T17:50:26+00:00', nonstop=False
         )
-
-    def test_persist_job_config(self):
-        self.obs_result.job_directory = 'tmp-dir/'
-
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.obs_result.persist_job_config({'id': '1'})
-            file_handle = mock_open.return_value.__enter__.return_value
-            # Dict is mutable, mock compares the final value of Dict
-            # not the initial value that was passed in.
-            file_handle.write.assert_called_with(
-                JsonFormat.json_message({
-                    "id": "1",
-                    "job_file": "tmp-dir/job-1.json"
-                })
-            )
 
     @patch('mash.services.obs.service.json.load')
     @patch('mash.services.obs.service.os.listdir')

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -312,3 +312,20 @@ class TestOBSImageBuildResultService(object):
                     "job_file": "tmp-dir/job-1.json"
                 })
             )
+
+    @patch('mash.services.obs.service.json.load')
+    @patch('mash.services.obs.service.os.listdir')
+    def test_restart_jobs(self, mock_os_listdir, mock_json_load):
+        self.obs_result.job_directory = 'tmp-dir'
+        mock_os_listdir.return_value = ['job-123.json']
+        mock_json_load.return_value = {'id': '1'}
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            mock_callback = Mock()
+            self.obs_result.restart_jobs(mock_callback)
+
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.call_count == 1
+
+        mock_callback.assert_called_once_with({'id': '1'})

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -54,7 +54,7 @@ class TestOBSImageBuildResultService(object):
         mock_restart_jobs.assert_called_once_with(self.obs_result._start_job)
 
         self.obs_result.consume_queue.assert_called_once_with(
-            mock_process_message
+            mock_process_message, queue_name='service'
         )
         self.obs_result.channel.start_consuming.assert_called_once_with()
 

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -79,13 +79,15 @@ class TestPipelineService(object):
         self.service.listener_msg_args = ['cloud_image_name']
         self.service.status_msg_args = ['cloud_image_name']
 
+    @patch.object(PipelineService, 'bind_queue')
     @patch.object(PipelineService, 'bind_credentials_queue')
     @patch.object(PipelineService, 'restart_jobs')
     @patch.object(PipelineService, 'set_logfile')
     @patch.object(PipelineService, 'start')
     def test_service_post_init(
         self, mock_start,
-        mock_set_logfile, mock_restart_jobs, mock_bind_creds
+        mock_set_logfile, mock_restart_jobs, mock_bind_creds,
+        mock_bind_queue
     ):
         self.service.config = self.config
         self.config.get_log_file.return_value = \
@@ -102,16 +104,22 @@ class TestPipelineService(object):
         )
 
         mock_bind_creds.assert_called_once_with()
+        mock_bind_queue.has_calls([
+            call('replication', 'job_document', 'service'),
+            call('replication', 'listener_msg', 'listener')
+        ])
         mock_restart_jobs.assert_called_once_with(self.service._add_job)
         mock_start.assert_called_once_with()
 
+    @patch.object(PipelineService, 'bind_queue')
     @patch.object(PipelineService, 'bind_credentials_queue')
     @patch.object(PipelineService, 'restart_jobs')
     @patch.object(PipelineService, 'set_logfile')
     @patch.object(PipelineService, 'start')
     def test_service_post_init_custom_args(
         self, mock_start,
-        mock_set_logfile, mock_restart_jobs, mock_bind_creds
+        mock_set_logfile, mock_restart_jobs, mock_bind_creds,
+        mock_bind_queue
     ):
         self.service.config = self.config
         self.service.custom_args = {

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -794,6 +794,23 @@ class TestPipelineService(object):
             properties=self.msg_properties, routing_key='listener_msg'
         )
 
+    def test_log_job_message(self):
+        self.service.log_job_message('Test message', {'job_id': '1'})
+
+        self.service.log.info.assert_called_once_with(
+            'Test message',
+            extra={'job_id': '1'}
+        )
+
+        self.service.log_job_message(
+            'Test error message', {'job_id': '1'}, success=False
+        )
+
+        self.service.log.error.assert_called_once_with(
+            'Test error message',
+            extra={'job_id': '1'}
+        )
+
     def test_service_start_job(self):
         job = Mock()
         self.service.jobs['1'] = job

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -811,6 +811,12 @@ class TestPipelineService(object):
             extra={'job_id': '1'}
         )
 
+    @patch('mash.services.pipeline_service.os.remove')
+    def test_remove_file(self, mock_remove):
+        mock_remove.side_effect = Exception('File not found.')
+        self.service.remove_file('job-test.json')
+        mock_remove.assert_called_once_with('job-test.json')
+
     def test_service_start_job(self):
         job = Mock()
         self.service.jobs['1'] = job

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -513,7 +513,10 @@ class TestPipelineService(object):
 
         self.channel.start_consuming.assert_called_once_with()
         mock_consume_queue.assert_has_calls([
-            call(self.service._handle_service_message),
+            call(
+                self.service._handle_service_message,
+                queue_name='service'
+            ),
             call(
                 self.service._handle_listener_message,
                 queue_name='listener'

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -845,6 +845,23 @@ class TestPipelineService(object):
                 })
             )
 
+    @patch('mash.services.pipeline_service.json.load')
+    @patch('mash.services.pipeline_service.os.listdir')
+    def test_restart_jobs(self, mock_os_listdir, mock_json_load):
+        self.service.job_directory = 'tmp-dir'
+        mock_os_listdir.return_value = ['job-123.json']
+        mock_json_load.return_value = {'id': '1'}
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            mock_callback = Mock()
+            self.service.restart_jobs(mock_callback)
+
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.call_count == 1
+
+        mock_callback.assert_called_once_with({'id': '1'})
+
     def test_service_start_job(self):
         job = Mock()
         self.service.jobs['1'] = job

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -829,6 +829,22 @@ class TestPipelineService(object):
         self.service.remove_file('job-test.json')
         mock_remove.assert_called_once_with('job-test.json')
 
+    def test_persist_job_config(self):
+        self.service.job_directory = 'tmp-dir/'
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            self.service.persist_job_config({'id': '1'})
+            file_handle = mock_open.return_value.__enter__.return_value
+            # Dict is mutable, mock compares the final value of Dict
+            # not the initial value that was passed in.
+            file_handle.write.assert_called_with(
+                JsonFormat.json_message({
+                    "id": "1",
+                    "job_file": "tmp-dir/job-1.json"
+                })
+            )
+
     def test_service_start_job(self):
         job = Mock()
         self.service.jobs['1'] = job

--- a/test/unit/services/pipeline/service_test.py
+++ b/test/unit/services/pipeline/service_test.py
@@ -222,7 +222,7 @@ class TestPipelineService(object):
         )
 
     @patch.object(PipelineService, 'publish_credentials_delete')
-    @patch.object(PipelineService, 'remove_file')
+    @patch('mash.services.pipeline_service.remove_file')
     @patch.object(PipelineService, 'unbind_queue')
     def test_service_delete_job(
         self, mock_unbind_queue, mock_remove_file, mock_publish_creds_delete
@@ -822,12 +822,6 @@ class TestPipelineService(object):
             'Test error message',
             extra={'job_id': '1'}
         )
-
-    @patch('mash.services.pipeline_service.os.remove')
-    def test_remove_file(self, mock_remove):
-        mock_remove.side_effect = Exception('File not found.')
-        self.service.remove_file('job-test.json')
-        mock_remove.assert_called_once_with('job-test.json')
 
     def test_persist_job_config(self):
         self.service.job_directory = 'tmp-dir/'

--- a/test/unit/utils/mash_utils_test.py
+++ b/test/unit/utils/mash_utils_test.py
@@ -28,7 +28,10 @@ from mash.utils.mash_utils import (
     create_ssh_key_pair,
     format_string_with_date,
     remove_file,
-    persist_json
+    persist_json,
+    load_json,
+    restart_job,
+    restart_jobs
 )
 
 
@@ -108,3 +111,43 @@ def test_persist_json():
 
         file_handle = mock_open.return_value.__enter__.return_value
         file_handle.write.assert_called_with('{\n    "id": "1"\n}')
+
+
+@patch('mash.utils.mash_utils.json.load')
+def test_load_json(mock_load_json):
+    mock_load_json.return_value = {'id': '123'}
+
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+
+        data = load_json('tmp/job-123.json')
+
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.read.call_count == 1
+
+    assert data['id'] == '123'
+
+
+@patch('mash.utils.mash_utils.load_json')
+def test_restart_job(mock_json_load):
+    mock_json_load.return_value = {'id': '123'}
+    callback = MagicMock()
+
+    restart_job('tmp/job-123.json', callback)
+    mock_json_load.assert_called_once_with(
+        'tmp/job-123.json'
+    )
+    callback.assert_called_once_with({'id': '123'})
+
+
+@patch('mash.utils.mash_utils.restart_job')
+@patch('mash.utils.mash_utils.os.listdir')
+def test_restart_jobs(mock_os_listdir, mock_restart_job):
+    mock_os_listdir.return_value = ['job-123.json']
+    callback = MagicMock()
+
+    restart_jobs('tmp/', callback)
+    mock_restart_job.assert_called_once_with(
+        'tmp/job-123.json',
+        callback
+    )

--- a/test/unit/utils/mash_utils_test.py
+++ b/test/unit/utils/mash_utils_test.py
@@ -27,7 +27,8 @@ from mash.utils.mash_utils import (
     get_key_from_file,
     create_ssh_key_pair,
     format_string_with_date,
-    remove_file
+    remove_file,
+    persist_json
 )
 
 
@@ -97,3 +98,13 @@ def test_remove_file(mock_remove):
     mock_remove.side_effect = FileNotFoundError('File not found.')
     remove_file('job-test.json')
     mock_remove.assert_called_once_with('job-test.json')
+
+
+def test_persist_json():
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+
+        persist_json('tmp-dir/job-1.json', {'id': '1'})
+
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.write.assert_called_with('{\n    "id": "1"\n}')

--- a/test/unit/utils/mash_utils_test.py
+++ b/test/unit/utils/mash_utils_test.py
@@ -26,7 +26,8 @@ from mash.utils.mash_utils import (
     generate_name,
     get_key_from_file,
     create_ssh_key_pair,
-    format_string_with_date
+    format_string_with_date,
+    remove_file
 )
 
 
@@ -89,3 +90,10 @@ def test_create_ssh_key_pair(mock_rsa):
 def test_format_string_with_date_error():
     value = 'Name with a {timestamp}'
     format_string_with_date(value)
+
+
+@patch('mash.utils.mash_utils.os.remove')
+def test_remove_file(mock_remove):
+    mock_remove.side_effect = FileNotFoundError('File not found.')
+    remove_file('job-test.json')
+    mock_remove.assert_called_once_with('job-test.json')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Migrate all methods specific to handling jobs from base mash service class to the pipeline, obs and credentials service classes. Also, move any related attrs.

### How will these changes be tested?

Unit tests and local integration testing.