### PR TITLE
Add is_publishing_account option to gce jobs.

### DIFF
--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -167,7 +167,8 @@ add_account_gce = {
         'cloud': {'enum': ['gce']},
         'testing_account': {'$ref': '#/definitions/non_empty_string'},
         'region': {'$ref': '#/definitions/non_empty_string'},
-        'requesting_user': {'$ref': '#/definitions/non_empty_string'}
+        'requesting_user': {'$ref': '#/definitions/non_empty_string'},
+        'is_publishing_account': {'type': 'boolean'}
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -64,6 +64,12 @@ class GCEJob(BaseJob):
                     'Jobs using a GCE publishing account require a family.'
                 )
 
+            if is_publishing_account and not testing_account:
+                raise MashJobCreatorException(
+                    'Jobs using a GCE publishing account require'
+                    ' the use of a testing account.'
+                )
+
             self.target_account_info[region] = {
                 'account': account,
                 'bucket': bucket,

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from mash.mash_exceptions import MashJobCreatorException
 from mash.services.jobcreator.base_job import BaseJob
 from mash.utils.json_format import JsonFormat
 
@@ -55,9 +56,13 @@ class GCEJob(BaseJob):
                 'bucket'
             ) or info.get('bucket')
 
-            testing_account = self.cloud_accounts[account].get(
-                'testing_account'
-            ) or info.get('testing_account')
+            testing_account = info.get('testing_account')
+            is_publishing_account = info.get('is_publishing_account')
+
+            if is_publishing_account and not self.family:
+                raise MashJobCreatorException(
+                    'Jobs using a GCE publishing account require a family.'
+                )
 
             self.target_account_info[region] = {
                 'account': account,

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -30,3 +30,40 @@ def test_gce_job_publish_acnt():
                 'download_url': 'https://download.here'
             }
         )
+
+    with pytest.raises(MashJobCreatorException):
+        GCEJob(
+            account_info, {}, {
+                'job_id': '123',
+                'cloud': 'gce',
+                'requesting_user': 'test-user',
+                'last_service': 'deprecation',
+                'utctime': 'now',
+                'image': 'test-image',
+                'cloud_image_name': 'test-cloud-image',
+                'cloud_accounts': [{'name': 'acnt1'}],
+                'image_description': 'image description',
+                'distro': 'sles',
+                'download_url': 'https://download.here',
+                'family': 'sles'
+            }
+        )
+
+    # Should not raise exception
+    account_info['acnt1']['testing_account'] = 'test'
+    GCEJob(
+        account_info, {}, {
+            'job_id': '123',
+            'cloud': 'gce',
+            'requesting_user': 'test-user',
+            'last_service': 'deprecation',
+            'utctime': 'now',
+            'image': 'test-image',
+            'cloud_image_name': 'test-cloud-image',
+            'cloud_accounts': [{'name': 'acnt1'}],
+            'image_description': 'image description',
+            'distro': 'sles',
+            'download_url': 'https://download.here',
+            'family': 'sles'
+        }
+    )

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from mash.mash_exceptions import MashJobCreatorException
+from mash.services.jobcreator.gce_job import GCEJob
+
+
+def test_gce_job_publish_acnt():
+    account_info = {
+        'acnt1': {
+            'name': 'actn1',
+            'bucket': 'test',
+            'region': 'us-west1-a',
+            'is_publishing_account': True
+        }
+    }
+
+    with pytest.raises(MashJobCreatorException):
+        GCEJob(
+            account_info, {}, {
+                'job_id': '123',
+                'cloud': 'gce',
+                'requesting_user': 'test-user',
+                'last_service': 'deprecation',
+                'utctime': 'now',
+                'image': 'test-image',
+                'cloud_image_name': 'test-cloud-image',
+                'cloud_accounts': [{'name': 'acnt1'}],
+                'image_description': 'image description',
+                'distro': 'sles',
+                'download_url': 'https://download.here'
+            }
+        )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Add is_publishing_account option to gce jobs. If publishing account is used for a job without a family raise exception.

### How will these changes be tested?

Unit and integration testing.

Fixes #456 