### PR TITLE
Make distro option an enum.

### DIFF
--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -246,7 +246,7 @@ base_job_message = {
         },
         'download_url': {'$ref': '#/definitions/non_empty_string'},
         'image_description': {'$ref': '#/definitions/non_empty_string'},
-        'distro': {'$ref': '#/definitions/non_empty_string'},
+        'distro': {'enum': ['opensuse_leap', 'sles']},
         'instance_type': {'$ref': '#/definitions/non_empty_string'},
         'tests': {
             'type': 'array',


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

IPA validates distro for expected values so MASH will fail early if distro does not match enum (opensuse_leap or sles).
