### PR TITLE
Add image cleanup for gce.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -36,5 +36,6 @@
   "sku": "123",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
-  "publish_offer": true
+  "publish_offer": true,
+  "cleanup_images": true
 }

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -157,7 +157,6 @@ class AzureJob(BaseJob):
         """
         replication_message = {
             'replication_job': {
-                'cleanup_images': self.cleanup_images,
                 'image_description': self.image_description,
                 'cloud': self.cloud,
                 'replication_source_regions':
@@ -165,6 +164,10 @@ class AzureJob(BaseJob):
             }
         }
         replication_message['replication_job'].update(self.base_message)
+
+        if self.cleanup_images is not None:
+            replication_message['replication_job']['cleanup_images'] = \
+                self.cleanup_images
 
         return JsonFormat.json_message(replication_message)
 

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -55,7 +55,7 @@ class BaseJob(object):
         self.conditions = kwargs.get('conditions')
         self.instance_type = kwargs.get('instance_type')
         self.old_cloud_image_name = kwargs.get('old_cloud_image_name')
-        self.cleanup_images = kwargs.get('cleanup_images', True)
+        self.cleanup_images = kwargs.get('cleanup_images')
         self.cloud_architecture = kwargs.get('cloud_architecture', 'x86_64')
         self.cloud_accounts = self._get_accounts_data(
             kwargs.get('cloud_accounts')
@@ -213,6 +213,10 @@ class BaseJob(object):
         if self.instance_type:
             testing_message['testing_job']['instance_type'] = \
                 self.instance_type
+
+        if self.last_service == 'testing' and \
+                self.cleanup_images in [True, None]:
+            testing_message['testing_job']['cleanup_images'] = True
 
         testing_message['testing_job'].update(self.base_message)
 

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -74,7 +74,8 @@ class GCEJob(BaseJob):
                 'account': account,
                 'bucket': bucket,
                 'family': self.family,
-                'testing_account': testing_account
+                'testing_account': testing_account,
+                'is_publishing_account': is_publishing_account
             }
 
     def get_deprecation_message(self):
@@ -142,7 +143,8 @@ class GCEJob(BaseJob):
         for source_region, value in self.target_account_info.items():
             test_regions[source_region] = {
                 'account': value['account'],
-                'testing_account': value['testing_account']
+                'testing_account': value['testing_account'],
+                'is_publishing_account': value['is_publishing_account']
             }
 
         return test_regions

--- a/mash/utils/gce.py
+++ b/mash/utils/gce.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+from mash.utils.mash_utils import create_json_file
+
+
+def cleanup_gce_image(credentials, cloud_image_name):
+    """
+    Delete the image matching cloud_image_name.
+
+    Use the provided credentials dict data for authentication.
+    """
+    ComputeEngine = get_driver(Provider.GCE)
+
+    with create_json_file(credentials) as auth_file:
+        compute_driver = ComputeEngine(
+            credentials['client_email'],
+            auth_file,
+            project=credentials['project_id']
+        )
+        compute_driver.ex_delete_image(cloud_image_name)

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -36,5 +36,6 @@
   "sku": "123",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
-  "publish_offer": true
+  "publish_offer": true,
+  "cleanup_images": true
 }

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from mash.mash_exceptions import MashJobCreatorException
 from mash.services.jobcreator.base_job import BaseJob
+from mash.utils.json_format import JsonFormat
 
 
 class TestJobCreatorBaseJob(object):
@@ -15,13 +16,14 @@ class TestJobCreatorBaseJob(object):
                 'job_id': '123',
                 'cloud': 'aws',
                 'requesting_user': 'test-user',
-                'last_service': 'deprecation',
+                'last_service': 'testing',
                 'utctime': 'now',
                 'image': 'test-image',
                 'cloud_image_name': 'test-cloud-image',
                 'image_description': 'image description',
                 'distro': 'sles',
-                'download_url': 'https://download.here'
+                'download_url': 'https://download.here',
+                'cleanup_images': True
             }
         )
 
@@ -56,3 +58,10 @@ class TestJobCreatorBaseJob(object):
                     'download_url': 'https://download.here'
                 }
             )
+
+    @patch.object(BaseJob, 'get_testing_regions')
+    def test_get_testing_message_cleanup(self, mock_get_testing_regions):
+        mock_get_testing_regions.return_value = {}
+        message = self.job.get_testing_message()
+
+        assert JsonFormat.json_loads(message)['testing_job']['cleanup_images']

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -16,11 +16,13 @@ class TestGCETestingJob(object):
             'test_regions': {
                 'us-west1': {
                     'account': 'test-gce',
-                    'testing_account': 'testingacnt'
+                    'testing_account': 'testingacnt',
+                    'is_publishing_account': False
                 }
             },
             'tests': ['test_stuff'],
             'utctime': 'now',
+            'cleanup_images': True
         }
         self.config = Mock()
         self.config.get_ssh_private_key_file.return_value = \
@@ -33,6 +35,7 @@ class TestGCETestingJob(object):
         with pytest.raises(MashTestingException):
             GCETestingJob(self.job_config, self.config)
 
+    @patch('mash.services.testing.gce_job.cleanup_gce_image')
     @patch('mash.services.testing.gce_job.os')
     @patch('mash.services.testing.gce_job.create_ssh_key_pair')
     @patch('mash.services.testing.gce_job.random')
@@ -41,7 +44,7 @@ class TestGCETestingJob(object):
     @patch.object(GCETestingJob, 'send_log')
     def test_testing_run_gce_test(
         self, mock_send_log, mock_test_image, mock_temp_file, mock_random,
-        mock_create_ssh_key_pair, mock_os
+        mock_create_ssh_key_pair, mock_os, mock_cleanup_image
     ):
         tmp_file = Mock()
         tmp_file.name = '/tmp/acnt.file'
@@ -96,6 +99,7 @@ class TestGCETestingJob(object):
             timeout=None
         )
         mock_send_log.reset_mock()
+        mock_cleanup_image.side_effect = Exception('Unable to cleanup image!')
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')

--- a/test/unit/utils/gce_test.py
+++ b/test/unit/utils/gce_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from unittest.mock import Mock, patch
+from mash.utils.gce import cleanup_gce_image
+
+
+@patch('mash.utils.gce.get_driver')
+def test_get_client(mock_get_driver):
+    compute_engine = Mock()
+    driver = Mock()
+    mock_get_driver.return_value = compute_engine
+    compute_engine.return_value = driver
+
+    creds = {
+        'client_email': 'fake@fake.com',
+        'project_id': '123'
+    }
+
+    cleanup_gce_image(creds, 'image_123')
+
+    driver.ex_delete_image.assert_called_once_with('image_123')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If account is publishing account and testing fails cleanup image. Or if cleanup_images is provided in job doc and testing service is last service cleanup image.

Cleanup default value handling for cleanup_images. Default in base class should be None. For Azure replication default cleanup is True.

### How will these changes be tested?

Unit + integration tests.

Fixes #462 