### PR TITLE
Remove is_publishing_account flag.

### DIFF
--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -167,8 +167,7 @@ add_account_gce = {
         'cloud': {'enum': ['gce']},
         'testing_account': {'$ref': '#/definitions/non_empty_string'},
         'region': {'$ref': '#/definitions/non_empty_string'},
-        'requesting_user': {'$ref': '#/definitions/non_empty_string'},
-        'is_publishing_account': {'type': 'boolean'}
+        'requesting_user': {'$ref': '#/definitions/non_empty_string'}
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -57,25 +57,17 @@ class GCEJob(BaseJob):
             ) or info.get('bucket')
 
             testing_account = info.get('testing_account')
-            is_publishing_account = info.get('is_publishing_account')
 
-            if is_publishing_account and not self.family:
+            if testing_account and not self.family:
                 raise MashJobCreatorException(
                     'Jobs using a GCE publishing account require a family.'
-                )
-
-            if is_publishing_account and not testing_account:
-                raise MashJobCreatorException(
-                    'Jobs using a GCE publishing account require'
-                    ' the use of a testing account.'
                 )
 
             self.target_account_info[region] = {
                 'account': account,
                 'bucket': bucket,
                 'family': self.family,
-                'testing_account': testing_account,
-                'is_publishing_account': is_publishing_account
+                'testing_account': testing_account
             }
 
     def get_deprecation_message(self):
@@ -143,8 +135,7 @@ class GCEJob(BaseJob):
         for source_region, value in self.target_account_info.items():
             test_regions[source_region] = {
                 'account': value['account'],
-                'testing_account': value['testing_account'],
-                'is_publishing_account': value['is_publishing_account']
+                'testing_account': value['testing_account']
             }
 
         return test_regions

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -116,7 +116,7 @@ class GCETestingJob(MashJob):
 
             if self.cleanup_images or \
                     status != SUCCESS and \
-                    self.test_regions[region]['is_publishing_account']:
+                    self.test_regions[region].get('testing_account'):
                 self.cleanup_image(region)
 
     def cleanup_image(self, region):

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -10,7 +10,7 @@ def test_gce_job_publish_acnt():
             'name': 'actn1',
             'bucket': 'test',
             'region': 'us-west1-a',
-            'is_publishing_account': True
+            'testing_account': 'acnt2'
         }
     }
 
@@ -28,24 +28,6 @@ def test_gce_job_publish_acnt():
                 'image_description': 'image description',
                 'distro': 'sles',
                 'download_url': 'https://download.here'
-            }
-        )
-
-    with pytest.raises(MashJobCreatorException):
-        GCEJob(
-            account_info, {}, {
-                'job_id': '123',
-                'cloud': 'gce',
-                'requesting_user': 'test-user',
-                'last_service': 'deprecation',
-                'utctime': 'now',
-                'image': 'test-image',
-                'cloud_image_name': 'test-cloud-image',
-                'cloud_accounts': [{'name': 'acnt1'}],
-                'image_description': 'image description',
-                'distro': 'sles',
-                'download_url': 'https://download.here',
-                'family': 'sles'
             }
         )
 

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -16,8 +16,7 @@ class TestGCETestingJob(object):
             'test_regions': {
                 'us-west1': {
                     'account': 'test-gce',
-                    'testing_account': 'testingacnt',
-                    'is_publishing_account': False
+                    'testing_account': 'testingacnt'
                 }
             },
             'tests': ['test_stuff'],


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Remove is_publishing_account flag. If a GCE account has a testing account it is a publishing account. There's no need for an extra flag to handle this logic.

### How will these changes be tested?

Unit testing.