### PR TITLE
Remove very large instance from GCE.

### DIFF
--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -36,7 +36,6 @@ instance_types = [
     'n1-highmem-2',
     'n1-highcpu-2',
     'f1-micro',
-    'n1-ultramem-40'
 ]
 
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Remove very large instance from testing rotation for GCE. It frequently causes resource limit errors.

### Additional Information

Fixes #485 