### PR TITLE
testing service: retry test in fallback region

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -23,7 +23,7 @@ APScheduler
 python-dateutil>=2.6.0,<3.0.0
 amqpstorm
 ec2imgutils
-img-proof>=4.0.0
+img-proof>=4.2.0
 lxml
 requests
 urllib3<1.25,>=1.20

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ zypper in mash
 - python-dateutil>=2.6.0,<3.0.0
 - amqpstorm
 - ec2imgutils
-- img-proof>=4.0.0
+- img-proof>=4.2.0
 - lxml
 - requests
 

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -397,7 +397,8 @@ gce_job_message['properties']['guest_os_features'] = {
 }
 gce_job_message['properties']['test_fallback_regions'] = {
     'type': 'array',
-    'items': {'$ref': '#/definitions/non_empty_string'}
+    'items': {'$ref': '#/definitions/non_empty_string'},
+    'minItems': 0
 }
 gce_job_message['definitions']['account'] = {
     'type': 'object',

--- a/mash/services/api/schema.py
+++ b/mash/services/api/schema.py
@@ -395,6 +395,10 @@ gce_job_message['properties']['guest_os_features'] = {
     'uniqueItems': True,
     'minItems': 1
 }
+gce_job_message['properties']['test_fallback_regions'] = {
+    'type': 'array',
+    'items': {'$ref': '#/definitions/non_empty_string'}
+}
 gce_job_message['definitions']['account'] = {
     'type': 'object',
     'properties': {

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -52,6 +52,7 @@ class BaseJob(object):
             )
 
         self.tests = kwargs.get('tests', [])
+        self.test_fallback_regions = kwargs.get('test_fallback_regions', [])
         self.conditions = kwargs.get('conditions')
         self.instance_type = kwargs.get('instance_type')
         self.old_cloud_image_name = kwargs.get('old_cloud_image_name')
@@ -207,7 +208,8 @@ class BaseJob(object):
             'testing_job': {
                 'cloud': self.cloud,
                 'tests': self.tests,
-                'test_regions': self.get_testing_regions()
+                'test_regions': self.get_testing_regions(),
+                'test_fallback_regions': self.test_fallback_regions
             }
         }
 

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -53,6 +53,8 @@ class BaseJob(object):
 
         self.tests = kwargs.get('tests', [])
         self.test_fallback_regions = kwargs.get('test_fallback_regions', [])
+        self.test_fallback = 'test_fallback_regions' not in kwargs and not self.test_fallback_regions
+
         self.conditions = kwargs.get('conditions')
         self.instance_type = kwargs.get('instance_type')
         self.old_cloud_image_name = kwargs.get('old_cloud_image_name')
@@ -209,7 +211,6 @@ class BaseJob(object):
                 'cloud': self.cloud,
                 'tests': self.tests,
                 'test_regions': self.get_testing_regions(),
-                'test_fallback_regions': self.test_fallback_regions
             }
         }
 
@@ -223,6 +224,10 @@ class BaseJob(object):
         if self.last_service == 'testing' and \
                 self.cleanup_images in [True, None]:
             testing_message['testing_job']['cleanup_images'] = True
+
+        if self.test_fallback_regions or self.test_fallback is False:
+            testing_message['testing_job']['test_fallback_regions'] = \
+                self.test_fallback_regions
 
         testing_message['testing_job'].update(self.base_message)
 

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -107,7 +107,7 @@ class GCETestingJob(MashJob):
 
             self.send_log(
                 'Starting test in region: {0}.'.format(
-                   region
+                    region
                 )
             )
             process = create_testing_thread(results, img_proof_kwargs, region)

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -50,6 +50,7 @@ class GCETestingJob(MashJob):
         """
         try:
             self.test_regions = self.job_config['test_regions']
+            self.test_fallback_regions = self.job_config['test_fallback_regions']
             self.tests = self.job_config['tests']
         except KeyError as error:
             raise MashTestingException(
@@ -83,6 +84,7 @@ class GCETestingJob(MashJob):
 
         self.status = SUCCESS
         self.send_log('Running img-proof tests against image.')
+        self.send_log('Test regions: {}'.format(self.test_regions))
 
         for region, info in self.test_regions.items():
             account = get_testing_account(info)
@@ -92,6 +94,7 @@ class GCETestingJob(MashJob):
                 'cloud': self.cloud,
                 'description': self.description,
                 'distro': self.distro,
+                'fallback_regions': self.test_fallback_regions,
                 'image_id': self.source_regions[region],
                 'instance_type': self.instance_type,
                 'img_proof_timeout': self.img_proof_timeout,
@@ -102,6 +105,11 @@ class GCETestingJob(MashJob):
                 'tests': self.tests
             }
 
+            self.send_log(
+                'Starting test in region: {0}.'.format(
+                   region
+                )
+            )
             process = create_testing_thread(results, img_proof_kwargs, region)
             jobs.append(process)
 

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -20,6 +20,7 @@ import logging
 import os
 import threading
 import traceback
+import random
 
 from img_proof.ipa_controller import test_image
 from img_proof.ipa_exceptions import IpaRetryableError
@@ -99,7 +100,8 @@ def img_proof_test(
         )
     except IpaRetryableError as error:
         if fallback_regions:
-            retry_region = fallback_regions.pop(0)
+            retry_region = random.choice(fallback_regions)
+            fallback_regions.remove(retry_region)
         else:
             status = FAILED
             results[name] = {

--- a/mash/utils/gce.py
+++ b/mash/utils/gce.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+import random
 
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
@@ -37,3 +38,28 @@ def cleanup_gce_image(credentials, cloud_image_name):
             project=credentials['project_id']
         )
         compute_driver.ex_delete_image(cloud_image_name)
+
+
+def get_region_list(credentials):
+    """
+    Returns a list of regions (with random zone suffix) in status UP.
+
+    Use the provided credentials dict data for authentication.
+    """
+    ComputeEngine = get_driver(Provider.GCE)
+
+    with create_json_file(credentials) as auth_file:
+        compute_driver = ComputeEngine(
+            credentials['client_email'],
+            auth_file,
+            project=credentials['project_id']
+        )
+        regions = compute_driver.ex_list_regions()
+
+    region_names = []
+    for region in regions:
+        if region.status == 'UP':
+            # we actually need a specifc zone not just the region, pick one
+            region_names.append(random.choice(region.zones).name)
+
+    return region_names

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -23,7 +23,8 @@ class TestJobCreatorBaseJob(object):
                 'image_description': 'image description',
                 'distro': 'sles',
                 'download_url': 'https://download.here',
-                'cleanup_images': True
+                'cleanup_images': True,
+                'test_fallback_regions': []
             }
         )
 

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -21,6 +21,7 @@ class TestGCETestingJob(object):
                 }
             },
             'tests': ['test_stuff'],
+            'test_fallback_regions': [ 'us-west1' ],
             'utctime': 'now',
             'cleanup_images': True
         }

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -21,7 +21,7 @@ class TestGCETestingJob(object):
                 }
             },
             'tests': ['test_stuff'],
-            'test_fallback_regions': [ 'us-west1' ],
+            'test_fallback_regions': ['us-west1'],
             'utctime': 'now',
             'cleanup_images': True
         }

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -4,6 +4,7 @@ from unittest.mock import call, Mock, patch
 
 from mash.services.testing.gce_job import GCETestingJob
 from mash.mash_exceptions import MashTestingException
+from img_proof.ipa_exceptions import IpaRetryableError
 
 
 class TestGCETestingJob(object):
@@ -21,7 +22,6 @@ class TestGCETestingJob(object):
                 }
             },
             'tests': ['test_stuff'],
-            'test_fallback_regions': ['us-west1'],
             'utctime': 'now',
             'cleanup_images': True
         }
@@ -36,6 +36,7 @@ class TestGCETestingJob(object):
         with pytest.raises(MashTestingException):
             GCETestingJob(self.job_config, self.config)
 
+    @patch('mash.services.testing.gce_job.get_region_list')
     @patch('mash.services.testing.gce_job.cleanup_gce_image')
     @patch('mash.services.testing.gce_job.os')
     @patch('mash.services.testing.gce_job.create_ssh_key_pair')
@@ -45,7 +46,7 @@ class TestGCETestingJob(object):
     @patch.object(GCETestingJob, 'send_log')
     def test_testing_run_gce_test(
         self, mock_send_log, mock_test_image, mock_temp_file, mock_random,
-        mock_create_ssh_key_pair, mock_os, mock_cleanup_image
+        mock_create_ssh_key_pair, mock_os, mock_cleanup_image, mock_get_region_list
     ):
         tmp_file = Mock()
         tmp_file.name = '/tmp/acnt.file'
@@ -63,6 +64,10 @@ class TestGCETestingJob(object):
         )
         mock_random.choice.return_value = 'n1-standard-1'
         mock_os.path.exists.return_value = False
+        mock_get_region_list.return_value = ['us-west1']
+
+        if 'test_fallback_regions' in self.job_config:
+            mock_test_image.side_effect = IpaRetryableError('quota exceeded')
 
         job = GCETestingJob(self.job_config, self.config)
         mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
@@ -79,7 +84,7 @@ class TestGCETestingJob(object):
         job.source_regions = {'us-west1': 'ami-123'}
         job.run_job()
 
-        mock_test_image.assert_called_once_with(
+        test_image_calls = [call(
             'gce',
             access_key_id=None,
             cleanup=True,
@@ -97,8 +102,33 @@ class TestGCETestingJob(object):
             ssh_user='root',
             subnet_id=None,
             tests=['test_stuff'],
-            timeout=None
-        )
+            timeout=None)
+        ]
+
+        if 'test_fallback_regions' in self.job_config:
+            for fallback_region in self.job_config['test_fallback_regions']:
+                test_image_calls.append(call(
+                    'gce',
+                    access_key_id=None,
+                    cleanup=True,
+                    description=job.description,
+                    distro='sles',
+                    image_id='ami-123',
+                    instance_type='n1-standard-1',
+                    log_level=30,
+                    region=fallback_region,
+                    secret_access_key=None,
+                    security_group_id=None,
+                    service_account_file='/tmp/acnt.file',
+                    ssh_key_name=None,
+                    ssh_private_key_file='private_ssh_key.file',
+                    ssh_user='root',
+                    subnet_id=None,
+                    tests=['test_stuff'],
+                    timeout=None)
+                )
+
+        mock_test_image.assert_has_calls(test_image_calls)
         mock_send_log.reset_mock()
         mock_cleanup_image.side_effect = Exception('Unable to cleanup image!')
 
@@ -110,3 +140,11 @@ class TestGCETestingJob(object):
         )
         assert 'Tests broken!' in mock_send_log.mock_calls[2][1][0]
         assert mock_send_log.mock_calls[2][2] == {'success': False}
+
+    def test_testing_run_gce_test_no_fallback_region(self):
+        self.job_config['test_fallback_regions'] = []
+        self.test_testing_run_gce_test()
+
+    def test_testing_run_gce_test_explicit_fallback_region(self):
+        self.job_config['test_fallback_regions'] = ['us-central1-c']
+        self.test_testing_run_gce_test()

--- a/test/unit/utils/gce_test.py
+++ b/test/unit/utils/gce_test.py
@@ -44,7 +44,19 @@ def test_get_region_list(mock_get_driver):
     driver = Mock()
     mock_get_driver.return_value = compute_engine
     compute_engine.return_value = driver
-    driver.ex_list_regions.return_value = []
+
+    class MockGCERegion:
+        def __init__(self, name, status, zones):
+            self.name = name
+            self.status = status
+            self.zones = zones
+
+    class MockGCEZone:
+        def __init__(self, name):
+            self.name = name
+
+    driver.ex_list_regions.return_value = \
+        [MockGCERegion('us-west1', 'UP', [MockGCEZone('us-west1-c')])]
 
     creds = {
         'client_email': 'fake@fake.com',

--- a/test/unit/utils/gce_test.py
+++ b/test/unit/utils/gce_test.py
@@ -65,4 +65,4 @@ def test_get_region_list(mock_get_driver):
 
     get_region_list(creds)
 
-    driver.ex_list_regions.assert_called_once()
+    driver.ex_list_regions.assert_called_once_with()

--- a/test/unit/utils/gce_test.py
+++ b/test/unit/utils/gce_test.py
@@ -18,6 +18,7 @@
 
 from unittest.mock import Mock, patch
 from mash.utils.gce import cleanup_gce_image
+from mash.utils.gce import get_region_list
 
 
 @patch('mash.utils.gce.get_driver')
@@ -35,3 +36,21 @@ def test_get_client(mock_get_driver):
     cleanup_gce_image(creds, 'image_123')
 
     driver.ex_delete_image.assert_called_once_with('image_123')
+
+
+@patch('mash.utils.gce.get_driver')
+def test_get_region_list(mock_get_driver):
+    compute_engine = Mock()
+    driver = Mock()
+    mock_get_driver.return_value = compute_engine
+    compute_engine.return_value = driver
+    driver.ex_list_regions.return_value = []
+
+    creds = {
+        'client_email': 'fake@fake.com',
+        'project_id': '123'
+    }
+
+    get_region_list(creds)
+
+    driver.ex_list_regions.assert_called_once()


### PR DESCRIPTION
If img_proof throws IpaRetryableError, and there is at least one fallback region configured, retry the test in a different region (issue  #483).

This adds an optional parameter `fallback_regions` to the GCE job message.