### PR TITLE
Add .db sqlite extension to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Session.vim
 
 ### pycharm ###
 .idea/
+
+### sqlite ###
+*.db


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Add sqlite .db extension to gitignore.