### PR TITLE
Fix version creep in spec.

### DIFF
--- a/package/mash.spec
+++ b/package/mash.spec
@@ -34,14 +34,14 @@ BuildRequires:  python3-azure-mgmt-resource
 BuildRequires:  python3-azure-mgmt-storage
 BuildRequires:  python3-azure-storage-blob
 BuildRequires:  python3-boto3
-BuildRequires:  python3-cryptography >= 3.2.0
+BuildRequires:  python3-cryptography >= 2.2.0
 BuildRequires:  python3-jsonschema
 BuildRequires:  python3-PyYAML
 BuildRequires:  python3-PyJWT
-BuildRequires:  python3-amqpstorm >= 3.2.0
+BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
-BuildRequires:  python3-python-dateutil < 3.2.0
+BuildRequires:  python3-python-dateutil < 3.0.0
 BuildRequires:  python3-ec2imgutils
 BuildRequires:  python3-img-proof>=4.0.0
 BuildRequires:  python3-img-proof-tests>=4.0.0
@@ -57,14 +57,14 @@ Requires:       python3-azure-mgmt-resource
 Requires:       python3-azure-mgmt-storage
 Requires:       python3-azure-storage-blob
 Requires:       python3-boto3
-Requires:       python3-cryptography >= 3.2.0
+Requires:       python3-cryptography >= 2.2.0
 Requires:       python3-jsonschema
 Requires:       python3-PyYAML
 Requires:       python3-PyJWT
-Requires:       python3-amqpstorm >= 3.2.0
+Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
-Requires:       python3-python-dateutil < 3.2.0
+Requires:       python3-python-dateutil < 3.0.0
 Requires:       python3-ec2imgutils
 Requires:       python3-img-proof>=4.0.0
 Requires:       python3-img-proof-tests>=4.0.0


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Bumpversion started shifting version requirements for other packages. Reset to proper values.