### PR TITLE
Add search/replace strings for spec version.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,6 +4,8 @@ commit = True
 tag = False
 
 [bumpversion:file:package/mash.spec]
+search = Version:        {current_version}
+replace = Version:        {new_version}
 
 [bumpversion:file:mash/version.py]
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This prevents bumpversion from bumping version of other requirements that happen to match current MASH version.