### PR TITLE
configurable subnet in EC2

### DIFF
--- a/mash/services/api/schema/accounts/ec2.py
+++ b/mash/services/api/schema/accounts/ec2.py
@@ -48,6 +48,7 @@ ec2_account = {
         'group': string_with_example('group1'),
         'partition': partition,
         'region': string_with_example('us-east-1'),
+        'subnet': string_with_example('subnet-12345678'),
         'cloud': {'enum': ['ec2']},
         'requesting_user': string_with_example('user1'),
     },

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -65,6 +65,9 @@ class EC2Job(BaseJob):
             target_region = self.cloud_accounts[account].get('region') or \
                 info.get('region')
 
+            subnet = self.cloud_accounts[account].get('subnet') or \
+                info.get('subnet')
+
             # Add additional regions for account
             additional_regions = info.get('additional_regions')
 
@@ -87,7 +90,8 @@ class EC2Job(BaseJob):
             self.target_account_info[target_region] = {
                 'account': account,
                 'target_regions': target_regions,
-                'helper_image': helper_image
+                'helper_image': helper_image,
+                'subnet': subnet
             }
 
     def _get_regions_for_partition(self, partition):
@@ -192,7 +196,8 @@ class EC2Job(BaseJob):
 
         for source_region, value in self.target_account_info.items():
             test_regions[source_region] = {
-                'account': value['account']
+                'account': value['account'],
+                'subnet': value['subnet']
             }
 
         return test_regions
@@ -208,7 +213,8 @@ class EC2Job(BaseJob):
                 'account': value['account'],
                 'helper_image': value['helper_image'],
                 'billing_codes': self.billing_codes,
-                'use_root_swap': self.use_root_swap
+                'use_root_swap': self.use_root_swap,
+                'subnet': value['subnet']
             }
 
         return target_regions

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -104,6 +104,10 @@ class EC2TestingJob(MashJob):
                 'ssh_user': self.ssh_user,
                 'tests': self.tests
             }
+            subnet_id = info.get('subnet')
+            if subnet_id:
+                img_proof_kwargs['subnet_id'] = subnet_id
+                img_proof_kwargs['security_group_id'] = info.get('security_groups')
 
             process = create_testing_thread(results, img_proof_kwargs, region)
             jobs.append(process)

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -102,12 +102,9 @@ class EC2TestingJob(MashJob):
                 'secret_access_key': creds['secret_access_key'],
                 'ssh_private_key_file': self.ssh_private_key_file,
                 'ssh_user': self.ssh_user,
+                'subnet_id': info.get('subnet'),
                 'tests': self.tests
             }
-            subnet_id = info.get('subnet')
-            if subnet_id:
-                img_proof_kwargs['subnet_id'] = subnet_id
-                img_proof_kwargs['security_group_id'] = info.get('security_groups')
 
             process = create_testing_thread(results, img_proof_kwargs, region)
             jobs.append(process)

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -38,12 +38,13 @@ from ec2imgutils.ec2setup import EC2Setup
 def img_proof_test(
     results, cloud=None, access_key_id=None, description=None, distro=None,
     image_id=None, instance_type=None, img_proof_timeout=None, region=None,
-    secret_access_key=None, security_group_id=None,
-    service_account_credentials=None, ssh_private_key_file=None, ssh_user=None,
-    subnet_id=None, tests=None, fallback_regions=None
+    secret_access_key=None, service_account_credentials=None,
+    ssh_private_key_file=None, ssh_user=None, subnet_id=None, tests=None,
+    fallback_regions=None
 ):
     saved_args = locals()
     name = threading.current_thread().getName()
+    security_group_id = None
     service_account_file = None
     key_name = None
     result = {}

--- a/mash/services/uploader/ec2_job.py
+++ b/mash/services/uploader/ec2_job.py
@@ -147,21 +147,17 @@ class EC2UploaderJob(MashJob):
                     False
                 )
 
-                subnet = info.get('subnet')
-                if subnet:
-                    vpc_id = get_vpc_id_from_subnet(ec2_client, subnet)
+                subnet_id = info.get('subnet')
+                if subnet_id:
+                    vpc_id = get_vpc_id_from_subnet(ec2_client, subnet_id)
                     security_group_id = ec2_setup.create_security_group(vpc_id=vpc_id)
-
-                    self.ec2_upload_parameters['vpc_subnet_id'] = subnet
-                    self.ec2_upload_parameters['security_group_ids'] = \
-                        security_group_id
                 else:
-                    vpc_subnet_id = ec2_setup.create_vpc_subnet()
+                    subnet_id = ec2_setup.create_vpc_subnet()
                     security_group_id = ec2_setup.create_security_group()
 
-                    self.ec2_upload_parameters['vpc_subnet_id'] = vpc_subnet_id
-                    self.ec2_upload_parameters['security_group_ids'] = \
-                        security_group_id
+                self.ec2_upload_parameters['vpc_subnet_id'] = subnet_id
+                self.ec2_upload_parameters['security_group_ids'] = \
+                    security_group_id
 
                 ec2_upload = EC2ImageUploader(
                     **self.ec2_upload_parameters

--- a/mash/services/uploader/ec2_job.py
+++ b/mash/services/uploader/ec2_job.py
@@ -25,6 +25,7 @@ from ec2imgutils.ec2setup import EC2Setup
 from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
 from mash.utils.ec2 import get_client
+from mash.utils.ec2 import get_vpc_id_from_subnet
 from mash.utils.mash_utils import format_string_with_date, generate_name
 from mash.services.status_levels import SUCCESS
 
@@ -136,8 +137,8 @@ class EC2UploaderJob(MashJob):
                     ssh_key_pair.private_key_file.name
 
                 # Create a temporary vpc, subnet and security group for the
-                # helper image. This provides a security group with an open
-                # ssh port.
+                # helper image, unless a subnet was specificed.
+                # This provides a security group with an open ssh port.
                 ec2_setup = EC2Setup(
                     credentials['access_key_id'],
                     region,
@@ -145,12 +146,22 @@ class EC2UploaderJob(MashJob):
                     None,
                     False
                 )
-                vpc_subnet_id = ec2_setup.create_vpc_subnet()
-                security_group_id = ec2_setup.create_security_group()
 
-                self.ec2_upload_parameters['vpc_subnet_id'] = vpc_subnet_id
-                self.ec2_upload_parameters['security_group_ids'] = \
-                    security_group_id
+                subnet = info.get('subnet')
+                if subnet:
+                    vpc_id = get_vpc_id_from_subnet(ec2_client, subnet)
+                    security_group_id = ec2_setup.create_security_group(vpc_id=vpc_id)
+
+                    self.ec2_upload_parameters['vpc_subnet_id'] = subnet
+                    self.ec2_upload_parameters['security_group_ids'] = \
+                        security_group_id
+                else:
+                    vpc_subnet_id = ec2_setup.create_vpc_subnet()
+                    security_group_id = ec2_setup.create_security_group()
+
+                    self.ec2_upload_parameters['vpc_subnet_id'] = vpc_subnet_id
+                    self.ec2_upload_parameters['security_group_ids'] = \
+                        security_group_id
 
                 ec2_upload = EC2ImageUploader(
                     **self.ec2_upload_parameters

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -29,3 +29,8 @@ def get_client(service_name, access_key_id, secret_access_key, region_name):
         aws_secret_access_key=secret_access_key,
         region_name=region_name,
     )
+
+
+def get_vpc_id_from_subnet(ec2_client, subnet_id):
+    response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
+    return response['Subnets'][0]['VpcId']

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -35,18 +35,20 @@ class TestEC2TestingJob(object):
     @patch('mash.services.testing.img_proof_helper.generate_name')
     @patch('mash.services.testing.img_proof_helper.get_client')
     @patch('mash.services.testing.img_proof_helper.get_key_from_file')
+    @patch('mash.services.testing.img_proof_helper.get_vpc_id_from_subnet')
     @patch('mash.services.testing.img_proof_helper.test_image')
     @patch.object(EC2TestingJob, 'send_log')
     def test_testing_run_test(
-        self, mock_send_log, mock_test_image, mock_get_key_from_file,
-        mock_get_client, mock_generate_name, mock_ec2_setup, mock_random,
-        mock_create_ssh_key_pair, mock_os
+        self, mock_send_log, mock_test_image, mock_get_vpc_id_from_subnet,
+        mock_get_key_from_file, mock_get_client, mock_generate_name,
+        mock_ec2_setup, mock_random, mock_create_ssh_key_pair, mock_os
     ):
         client = Mock()
         mock_get_client.return_value = client
         mock_generate_name.return_value = 'random_name'
         mock_get_key_from_file.return_value = 'fakekey'
         mock_random.choice.return_value = 't2.micro'
+        mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
 
         ec2_setup = Mock()
         ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
@@ -117,3 +119,7 @@ class TestEC2TestingJob(object):
         # Failed key cleanup
         client.delete_key_pair.side_effect = Exception('Cannot delete key!')
         job.run_job()
+
+    def test_testing_run_test_subnet(self):
+        self.job_config['test_regions']['us-east-1']['subnet'] = 'subnet-123456789'
+        self.test_testing_run_test()

--- a/test/unit/services/uploader/ec2_job_test.py
+++ b/test/unit/services/uploader/ec2_job_test.py
@@ -33,7 +33,8 @@ class TestAmazonUploaderJob(object):
                     'account': 'test',
                     'helper_image': 'ami-bc5b48d0',
                     'billing_codes': None,
-                    'use_root_swap': False
+                    'use_root_swap': False,
+                    'subnet': 'subnet-123456789'
                 }
             },
             'cloud_image_name': 'name',
@@ -62,6 +63,7 @@ class TestAmazonUploaderJob(object):
         with raises(MashUploadException):
             EC2UploaderJob(job_doc, self.config)
 
+    @patch('mash.services.uploader.ec2_job.get_vpc_id_from_subnet')
     @patch('mash.services.uploader.ec2_job.EC2Setup')
     @patch('mash.services.uploader.ec2_job.get_client')
     @patch('mash.services.uploader.ec2_job.generate_name')
@@ -70,7 +72,8 @@ class TestAmazonUploaderJob(object):
     @patch_open
     def test_upload(
         self, mock_open, mock_EC2ImageUploader, mock_NamedTemporaryFile,
-        mock_generate_name, mock_get_client, mock_ec2_setup
+        mock_generate_name, mock_get_client, mock_ec2_setup,
+        mock_get_vpc_id_from_subnet
     ):
         open_context = context_manager()
         mock_open.return_value = open_context.context_manager_mock
@@ -98,6 +101,8 @@ class TestAmazonUploaderJob(object):
         ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
         ec2_setup.create_security_group.return_value = 'sg-123456789'
         mock_ec2_setup.return_value = ec2_setup
+
+        mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
 
         self.job.run_job()
         mock_get_client.assert_called_once_with(

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -18,6 +18,7 @@
 
 from unittest.mock import Mock, patch
 from mash.utils.ec2 import get_client
+from mash.utils.ec2 import get_vpc_id_from_subnet
 
 
 @patch('mash.utils.ec2.boto3')
@@ -34,3 +35,10 @@ def test_get_client(mock_boto3):
         aws_secret_access_key='abc123',
         region_name='us-east-1',
     )
+
+
+def test_get_vpc_id_from_subnet():
+    client = Mock()
+    client.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123456789'}]}
+    assert get_vpc_id_from_subnet(client, 'subnet-123456789') == 'vpc-123456789'
+    client.describe_subnets.assert_called_once_with(SubnetIds=['subnet-123456789'])


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This allows the user to set a subnet in the EC2 account configuration that will be used for uploading and testing instead of a temporary one. This can be used to avoid hitting a VPC count limit (issue  #482).

### How will these changes be tested?

Changes have been tested manually.

### How will this change be deployed? Any special considerations?

For supporting this feature properly, mash-client requires support for configuring the subnet. This is not implement yet.