### PR TITLE
 Remove any instance types that are not everywhere.

### DIFF
--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -81,7 +81,12 @@ class AzureTestingJob(MashJob):
         jobs = []
 
         self.status = SUCCESS
-        self.send_log('Running img-proof tests against image.')
+        self.send_log(
+            'Running img-proof tests against image with '
+            'type: {inst_type}.'.format(
+                inst_type=self.instance_type
+            )
+        )
 
         for region, info in self.test_regions.items():
             account = get_testing_account(info)

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -80,7 +80,12 @@ class EC2TestingJob(MashJob):
         jobs = []
 
         self.status = SUCCESS
-        self.send_log('Running img-proof tests against image.')
+        self.send_log(
+            'Running img-proof tests against image with '
+            'type: {inst_type}.'.format(
+                inst_type=self.instance_type
+            )
+        )
 
         for region, info in self.test_regions.items():
             account = get_testing_account(info)

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -30,14 +30,10 @@ from mash.services.testing.utils import (
 from mash.utils.mash_utils import create_ssh_key_pair
 
 instance_types = [
-    'c5d.large',
-    'd2.xlarge',
+    'c5.large',
     'i3.8xlarge',
-    'i3.metal',
+    'i3.large',
     'm5.large',
-    'm5d.large',
-    'r5.24xlarge',
-    't2.micro',
     't3.small'
 ]
 

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -84,7 +84,12 @@ class GCETestingJob(MashJob):
         jobs = []
 
         self.status = SUCCESS
-        self.send_log('Running img-proof tests against image.')
+        self.send_log(
+            'Running img-proof tests against image with '
+            'type: {inst_type}.'.format(
+                inst_type=self.instance_type
+            )
+        )
 
         for region, info in self.test_regions.items():
             account = get_testing_account(info)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Only types that are in all regions should be in default list.
- Add instance type to log message.

### How will these changes be tested?

Unit testing.

### Additional information

The removed types are based on a set intersection for all regions including gov-cloud based on the pricing list. The following are the only types that exist in every region:

c5.18xlarge
c5.2xlarge
c5.4xlarge
c5.9xlarge
c5.large
c5.xlarge
i3.16xlarge
i3.2xlarge
i3.4xlarge
i3.8xlarge
i3.large
i3.xlarge
m5.12xlarge
m5.16xlarge
m5.24xlarge
m5.2xlarge
m5.4xlarge
m5.8xlarge
m5.large
m5.xlarge
t3.2xlarge
t3.large
t3.medium
t3.micro
t3.nano
t3.small
t3.xlarge