### PR TITLE
Get new session for each boto3 client.

### DIFF
--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -23,7 +23,8 @@ def get_client(service_name, access_key_id, secret_access_key, region_name):
     """
     Return client session given credentials and region_name.
     """
-    return boto3.client(
+    session = boto3.session.Session()
+    return session.client(
         service_name=service_name,
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key,

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -24,12 +24,14 @@ from mash.utils.ec2 import get_vpc_id_from_subnet
 @patch('mash.utils.ec2.boto3')
 def test_get_client(mock_boto3):
     client = Mock()
+    session = Mock()
+    session.client.return_value = client
+    mock_boto3.session.Session.return_value = session
 
-    mock_boto3.client.return_value = client
     result = get_client('ec2', '123456', 'abc123', 'us-east-1')
 
     assert client == result
-    mock_boto3.client.assert_called_once_with(
+    session.client.assert_called_once_with(
         service_name='ec2',
         aws_access_key_id='123456',
         aws_secret_access_key='abc123',


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Get new session for each boto3 client. Prevent threading issues from using default session.