### PR TITLE
Check ec2 image status in waiter

### DIFF
--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -91,7 +91,10 @@ class EC2ReplicationJob(MashJob):
             if reg_info['image_id']:
                 try:
                     self._wait_on_image(
-                        credential, reg_info['image_id'], target_region
+                        credential['access_key_id'],
+                        credential['secret_access_key'],
+                        reg_info['image_id'],
+                        target_region
                     )
                 except Exception as error:
                     self.status = FAILED
@@ -135,14 +138,16 @@ class EC2ReplicationJob(MashJob):
         return new_image['ImageId']
 
     @staticmethod
-    def _wait_on_image(credential, image_id, region):
+    def _wait_on_image(access_key_id, secret_access_key, image_id, region):
         """
         Wait on image to finish replicating in the given region.
         """
         while True:
             client = get_client(
-                'ec2', credential['access_key_id'],
-                credential['secret_access_key'], region
+                'ec2',
+                access_key_id,
+                secret_access_key,
+                region
             )
 
             try:

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -83,7 +83,7 @@ class EC2ReplicationJob(MashJob):
                         credential
 
         # Wait for images to replicate, this will take time.
-        time.sleep(900)
+        time.sleep(300)
 
         for target_region, reg_info in self.source_region_results.items():
             credential = reg_info['account']

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from mash.mash_exceptions import MashReplicationException
 from mash.services.mash_job import MashJob
 from mash.services.status_levels import FAILED, SUCCESS
-from mash.utils.ec2 import get_client
+from mash.utils.ec2 import get_client, describe_images
 
 
 class EC2ReplicationJob(MashJob):
@@ -151,10 +151,7 @@ class EC2ReplicationJob(MashJob):
             )
 
             try:
-                images = client.describe_images(
-                    Owners=['self'],
-                    ImageIds=[image_id]
-                )['Images']
+                images = describe_images(client, [image_id])
                 state = images[0]['State']
             except (IndexError, KeyError, ClientError):
                 raise MashReplicationException(
@@ -179,7 +176,7 @@ class EC2ReplicationJob(MashJob):
         """
         Determine if image exists given image name.
         """
-        images = client.describe_images(Owners=['self'])['Images']
+        images = describe_images(client)
         for image in images:
             if cloud_image_name == image.get('Name'):
                 return True

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -134,7 +134,8 @@ class EC2ReplicationJob(MashJob):
 
         return new_image['ImageId']
 
-    def _wait_on_image(self, credential, image_id, region):
+    @staticmethod
+    def _wait_on_image(credential, image_id, region):
         """
         Wait on image to finish replicating in the given region.
         """
@@ -168,7 +169,8 @@ class EC2ReplicationJob(MashJob):
             elif state == 'pending':
                 time.sleep(60)
 
-    def image_exists(self, client, cloud_image_name):
+    @staticmethod
+    def image_exists(client, cloud_image_name):
         """
         Determine if image exists given image name.
         """

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -35,3 +35,18 @@ def get_client(service_name, access_key_id, secret_access_key, region_name):
 def get_vpc_id_from_subnet(ec2_client, subnet_id):
     response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
     return response['Subnets'][0]['VpcId']
+
+
+def describe_images(client, image_ids=None):
+    """
+    Return a list of custom images using provided client.
+
+    If image_ids list is provided use it to filter the results.
+    """
+    kwargs = {'Owners': ['self']}
+
+    if image_ids:
+        kwargs['ImageIds'] = image_ids
+
+    images = client.describe_images(**kwargs)['Images']
+    return images

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -1,5 +1,5 @@
 from pytest import raises
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 from mash.mash_exceptions import MashReplicationException
 from mash.services.status_levels import FAILED
@@ -47,14 +47,18 @@ class TestEC2ReplicationJob(object):
         mock_wait_on_image, mock_time
     ):
         mock_replicate_to_region.return_value = 'ami-54321'
+        mock_wait_on_image.side_effect = Exception('Broken!')
 
         self.job.source_regions = {'us-east-1': 'ami-12345'}
         self.job.run_job()
 
-        mock_send_log.assert_called_once_with(
-            'Replicating source region: us-east-1 to the following regions: '
-            'us-east-2.'
-        )
+        mock_send_log.assert_has_calls([
+            call(
+                'Replicating source region: us-east-1 to the following '
+                'regions: us-east-2.'
+            ),
+            call('Replication to us-east-2 region failed: Broken!')
+        ])
 
         mock_replicate_to_region.assert_called_once_with(
             self.job.credentials['test-aws'], 'ami-12345',
@@ -63,6 +67,7 @@ class TestEC2ReplicationJob(object):
         mock_wait_on_image.assert_called_once_with(
             self.job.credentials['test-aws'], 'ami-54321', 'us-east-2'
         )
+        assert self.job.status == FAILED
 
     @patch.object(EC2ReplicationJob, 'image_exists')
     @patch('mash.services.replication.ec2_job.get_client')
@@ -133,8 +138,9 @@ class TestEC2ReplicationJob(object):
     @patch('mash.services.replication.ec2_job.get_client')
     def test_replicate_wait_on_image(self, mock_get_client):
         client = Mock()
-        waiter = Mock()
-        client.get_waiter.return_value = waiter
+        client.describe_images.return_value = {
+            'Images': [{'State': 'available'}]
+        }
         mock_get_client.return_value = client
 
         self.job._wait_on_image(
@@ -144,31 +150,34 @@ class TestEC2ReplicationJob(object):
         mock_get_client.assert_called_once_with(
             'ec2', '123456', '654321', 'us-east-2'
         )
-        client.get_waiter.assert_called_once_with('image_available')
-        waiter.wait.assert_called_once_with(
-            ImageIds=['ami-54321'],
-            Filters=[{'Name': 'state', 'Values': ['available']}]
+        client.describe_images.assert_called_once_with(
+            Owners=['self'],
+            ImageIds=['ami-54321']
         )
 
+    @patch('mash.services.replication.ec2_job.time')
     @patch.object(EC2ReplicationJob, 'send_log')
     @patch('mash.services.replication.ec2_job.get_client')
     def test_replicate_wait_on_image_exception(
-        self, mock_get_client, mock_send_log
+        self, mock_get_client, mock_send_log, mock_sleep
     ):
         client = Mock()
-        client.get_waiter.side_effect = Exception('Error copying image!')
+        client.describe_images.side_effect = [
+            KeyError('Images'),
+            {'Images': [{'State': 'pending'}]},
+            {'Images': [{'State': 'failed'}]}
+        ]
         mock_get_client.return_value = client
 
-        self.job._wait_on_image(
-            self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
-        )
+        with raises(MashReplicationException):
+            self.job._wait_on_image(
+                self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
+            )
 
-        mock_send_log.assert_called_once_with(
-            'There was an error replicating image to us-east-2. '
-            'Error copying image!',
-            False
-        )
-        assert self.job.status == FAILED
+        with raises(MashReplicationException):
+            self.job._wait_on_image(
+                self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
+            )
 
     def test_replicate_image_exists(self):
         images = {'Images': []}

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -65,7 +65,10 @@ class TestEC2ReplicationJob(object):
             'us-east-1', 'us-east-2'
         )
         mock_wait_on_image.assert_called_once_with(
-            self.job.credentials['test-aws'], 'ami-54321', 'us-east-2'
+            self.job.credentials['test-aws']['access_key_id'],
+            self.job.credentials['test-aws']['secret_access_key'],
+            'ami-54321',
+            'us-east-2'
         )
         assert self.job.status == FAILED
 
@@ -144,7 +147,10 @@ class TestEC2ReplicationJob(object):
         mock_get_client.return_value = client
 
         self.job._wait_on_image(
-            self.job.credentials['test-aws'], 'ami-54321', 'us-east-2'
+            self.job.credentials['test-aws']['access_key_id'],
+            self.job.credentials['test-aws']['secret_access_key'],
+            'ami-54321',
+            'us-east-2'
         )
 
         mock_get_client.assert_called_once_with(
@@ -171,12 +177,18 @@ class TestEC2ReplicationJob(object):
 
         with raises(MashReplicationException):
             self.job._wait_on_image(
-                self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
+                self.job.credentials['test-aws']['access_key_id'],
+                self.job.credentials['test-aws']['secret_access_key'],
+                'ami-54321',
+                'us-east-2'
             )
 
         with raises(MashReplicationException):
             self.job._wait_on_image(
-                self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
+                self.job.credentials['test-aws']['access_key_id'],
+                self.job.credentials['test-aws']['secret_access_key'],
+                'ami-54321',
+                'us-east-2'
             )
 
     def test_replicate_image_exists(self):


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Check image status in waiter. Instead of using waiter from boto3. Continue until the image is
marked as failed or available.

Fixes #503 