### PR TITLE
Add models for user, token and ec2.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -13,6 +13,8 @@ azure-mgmt-storage
 azure-storage-blob
 Flask
 flask-restplus
+flask-sqlalchemy
+flask-migrate
 setuptools
 idna<2.7
 boto3

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -10,6 +10,7 @@ smtp_host: localhost
 smtp_port: 25
 smtp_ssl: False
 smtp_user: test@fake.com
+database_uri: sqlite:////var/lib/mash/app.db
 services:
   - obs
   - uploader

--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -165,3 +165,9 @@ class MashJobException(MashException):
     """
     Exception raised if an error occurs in mash job class.
     """
+
+
+class MashDBException(MashException):
+    """
+    Exception raised if an error occurs accessing mash DB.
+    """

--- a/mash/services/api/__init__.py
+++ b/mash/services/api/__init__.py
@@ -15,23 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+# flake8: noqa: E402
 
 import json
 
 from flask import Flask
 from flask_restplus import Api
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 
-from mash.services.api.routes.accounts import api as accounts_api
-from mash.services.api.routes.accounts.azure import api as azure_accounts_api
-from mash.services.api.routes.accounts.gce import api as gce_accounts_api
-from mash.services.api.routes.accounts.ec2 import api as ec2_accounts_api
+from mash.services.api.config import Config
 
-from mash.services.api.routes.jobs import api as jobs_api
-from mash.services.api.routes.jobs.ec2 import api as ec2_jobs_api
-from mash.services.api.routes.jobs.gce import api as gce_jobs_api
-from mash.services.api.routes.jobs.azure import api as azure_jobs_api
-
-app = Flask(__name__, static_url_path='/static')
+app = Flask('MashAPIService', static_url_path='/static')
 api = Api(
     app,
     version='3.4.0',
@@ -41,6 +36,21 @@ api = Api(
     validate=True,
     doc=False
 )
+
+app.config.from_object(Config)
+db = SQLAlchemy(app)
+migrate = Migrate(app, db)
+
+# Imports out of order to prevent circular dependencies
+from mash.services.api.routes.accounts import api as accounts_api
+from mash.services.api.routes.accounts.azure import api as azure_accounts_api
+from mash.services.api.routes.accounts.gce import api as gce_accounts_api
+from mash.services.api.routes.accounts.ec2 import api as ec2_accounts_api
+
+from mash.services.api.routes.jobs import api as jobs_api
+from mash.services.api.routes.jobs.ec2 import api as ec2_jobs_api
+from mash.services.api.routes.jobs.gce import api as gce_jobs_api
+from mash.services.api.routes.jobs.azure import api as azure_jobs_api
 
 api.add_namespace(accounts_api, path='/accounts')
 api.add_namespace(azure_accounts_api, path='/accounts/azure')

--- a/mash/services/api/config.py
+++ b/mash/services/api/config.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.base_config import BaseConfig
+
+
+class Config(object):
+    """
+    Flask API config.
+    """
+    config = BaseConfig()
+    SQLALCHEMY_DATABASE_URI = config.get_database_uri()
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    AMQP_HOST = config.get_amqp_host()
+    AMQP_USER = config.get_amqp_user()
+    AMQP_PASS = config.get_amqp_pass()

--- a/mash/services/api/models.py
+++ b/mash/services/api/models.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from mash.services.api import db
+
+
+class User(db.Model):
+    __tablename__ = 'user'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(
+        db.String(64),
+        index=True,
+        unique=True,
+        nullable=False
+    )
+    email = db.Column(db.String(120), index=True, unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    ec2_accounts = db.relationship(
+        'EC2Account',
+        back_populates='user',
+        lazy='select',
+        cascade='all, delete, delete-orphan'
+    )
+    ec2_groups = db.relationship(
+        'EC2Group',
+        back_populates='user',
+        lazy='select',
+        cascade='all, delete, delete-orphan'
+    )
+    tokens = db.relationship(
+        'Token',
+        back_populates='user',
+        lazy='select',
+        cascade="all, delete, delete-orphan"
+    )
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+    def __repr__(self):
+        return '<User {}>'.format(self.username)
+
+
+class Token(db.Model):
+    __tablename__ = 'token'
+    id = db.Column(db.Integer, primary_key=True)
+    jti = db.Column(db.String(36), index=True, nullable=False)
+    token_type = db.Column(db.String(10), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', back_populates='tokens')
+    expires = db.Column(db.DateTime)
+
+    def __repr__(self):
+        return '<Token {}>'.format(self.jti)
+
+
+class EC2Group(db.Model):
+    __tablename__ = 'ec2_group'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', back_populates='ec2_groups')
+    accounts = db.relationship(
+        'EC2Account',
+        back_populates='group'
+    )
+    __table_args__ = (
+        db.UniqueConstraint('name', 'user_id', name='_name_user_uc'),
+    )
+
+    def __repr__(self):
+        return '<EC2 Group {}>'.format(self.name)
+
+
+class EC2Region(db.Model):
+    __tablename__ = 'ec2_region'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(32), nullable=False)
+    helper_image = db.Column(db.String(32), nullable=False)
+    account_id = db.Column(
+        db.Integer,
+        db.ForeignKey('ec2_account.id'),
+        nullable=False
+    )
+    account = db.relationship('EC2Account', back_populates='additional_regions')
+
+    def __repr__(self):
+        return '<EC2 Region {}>'.format(self.name)
+
+
+class EC2Account(db.Model):
+    __tablename__ = 'ec2_account'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), nullable=False)
+    partition = db.Column(db.String(10), nullable=False)
+    region = db.Column(db.String(32), nullable=False)
+    additional_regions = db.relationship(
+        'EC2Region',
+        back_populates='account',
+        lazy='select',
+        cascade="all, delete, delete-orphan"
+    )
+    group_id = db.Column(db.Integer, db.ForeignKey('ec2_group.id'))
+    group = db.relationship('EC2Group', back_populates='accounts')
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', back_populates='ec2_accounts')
+    __table_args__ = (
+        db.UniqueConstraint('name', 'user_id', name='_name_user_uc'),
+    )
+
+    def __repr__(self):
+        return '<EC2 Account {}>'.format(self.name)

--- a/mash/services/api/routes/utils.py
+++ b/mash/services/api/routes/utils.py
@@ -20,44 +20,29 @@ import sys
 
 from amqpstorm import Connection
 
-from mash.services.base_config import BaseConfig
+from mash.services.api import app
 
 module = sys.modules[__name__]
 
 connection = None
 channel = None
-config = None
-
-amqp_host = None
-amqp_user = None
-amqp_pass = None
 
 
 def connect():
     module.connection = Connection(
-        amqp_host,
-        amqp_user,
-        amqp_pass,
+        app.config['AMQP_HOST'],
+        app.config['AMQP_USER'],
+        app.config['AMQP_PASS'],
         kwargs={'heartbeat': 600}
     )
     module.channel = connection.channel()
     channel.confirm_deliveries()
 
 
-def get_config():
-    module.config = BaseConfig()
-    module.amqp_host = config.get_amqp_host()
-    module.amqp_user = config.get_amqp_user()
-    module.amqp_pass = config.get_amqp_pass()
-
-
 def publish(exchange, routing_key, message):
     """
     Publish message to the provided exchange with the routing key.
     """
-    if not config:
-        get_config()
-
     if not channel or channel.is_closed:
         connect()
 

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -276,3 +276,14 @@ class BaseConfig(object):
         )
 
         return notification_subject or Defaults.get_notification_subject()
+
+    def get_database_uri(self):
+        """
+        Return the database uri.
+         :rtype: string
+        """
+        database_uri = self._get_attribute(
+            attribute='database_uri'
+        )
+
+        return database_uri

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -6,6 +6,7 @@ amqp_user: guest
 amqp_pass: guest
 smtp_user: user@test.com
 smtp_pass: super.secret
+database_uri: sqlite:////var/lib/mash/app.db
 services:
   - obs
   - uploader

--- a/test/unit/services/api/api_test.py
+++ b/test/unit/services/api/api_test.py
@@ -3,7 +3,13 @@ import pytest
 
 from unittest.mock import MagicMock, patch
 
-from mash.services.api import wsgi
+with patch('mash.services.base_config.BaseConfig') as mock_config:
+    config = MagicMock()
+    config.get_amqp_host.return_value = 'localhost'
+    config.get_amqp_user.return_value = 'guest'
+    config.get_amqp_pass.return_value = 'guest'
+    mock_config.return_value = config
+    from mash.services.api import wsgi
 
 
 @pytest.fixture(scope='module')
@@ -17,19 +23,12 @@ def test_client():
     ctx.pop()
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_account_ec2(mock_connection, mock_config, test_client):
+def test_api_add_account_ec2(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     request = {
         'account_name': 'test',
@@ -63,19 +62,12 @@ def test_api_add_account_ec2(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_account_gce(mock_connection, mock_config, test_client):
+def test_api_add_account_gce(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     request = {
         'account_name': 'test',
@@ -117,19 +109,12 @@ def test_api_add_account_gce(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_account_azure(mock_connection, mock_config, test_client):
+def test_api_add_account_azure(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     request = {
         'account_name': 'test',
@@ -176,19 +161,12 @@ def test_api_add_account_azure(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_delete_account_ec2(mock_connection, mock_config, test_client):
+def test_api_delete_account_ec2(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     data = {
         'requesting_user': 'user1'
@@ -215,19 +193,12 @@ def test_api_delete_account_ec2(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_delete_account_gce(mock_connection, mock_config, test_client):
+def test_api_delete_account_gce(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     data = {
         'requesting_user': 'user1'
@@ -254,19 +225,12 @@ def test_api_delete_account_gce(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_delete_account_azure(mock_connection, mock_config, test_client):
+def test_api_delete_account_azure(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     data = {
         'requesting_user': 'user1'
@@ -293,20 +257,13 @@ def test_api_delete_account_azure(mock_connection, mock_config, test_client):
     assert response.data == b'{"name":"test"}\n'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.jobs.uuid')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_job_ec2(mock_connection, mock_uuid, mock_config, test_client):
+def test_api_add_job_ec2(mock_connection, mock_uuid, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     uuid = '12345678-1234-1234-1234-123456789012'
     mock_uuid.uuid4.return_value = uuid
@@ -339,20 +296,13 @@ def test_api_add_job_ec2(mock_connection, mock_uuid, mock_config, test_client):
         b'{"job_id": "12345678-1234-1234-1234-123456789012"}'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.jobs.uuid')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_job_gce(mock_connection, mock_uuid, mock_config, test_client):
+def test_api_add_job_gce(mock_connection, mock_uuid, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     uuid = '12345678-1234-1234-1234-123456789012'
     mock_uuid.uuid4.return_value = uuid
@@ -385,20 +335,13 @@ def test_api_add_job_gce(mock_connection, mock_uuid, mock_config, test_client):
         b'{"job_id": "12345678-1234-1234-1234-123456789012"}'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.jobs.uuid')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_add_job_azure(mock_connection, mock_uuid, mock_config, test_client):
+def test_api_add_job_azure(mock_connection, mock_uuid, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     uuid = '12345678-1234-1234-1234-123456789012'
     mock_uuid.uuid4.return_value = uuid
@@ -431,19 +374,12 @@ def test_api_add_job_azure(mock_connection, mock_uuid, mock_config, test_client)
         b'{"job_id": "12345678-1234-1234-1234-123456789012"}'
 
 
-@patch('mash.services.api.routes.utils.BaseConfig')
 @patch('mash.services.api.routes.utils.Connection')
-def test_api_delete_job(mock_connection, mock_config, test_client):
+def test_api_delete_job(mock_connection, test_client):
     channel = MagicMock()
     connection = MagicMock()
     connection.channel.return_value = channel
     mock_connection.return_value = connection
-
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    mock_config.return_value = config
 
     response = test_client.delete(
         '/jobs/12345678-1234-1234-1234-123456789012'

--- a/test/unit/services/api/model_test.py
+++ b/test/unit/services/api/model_test.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+with patch('mash.services.base_config.BaseConfig') as mock_config:
+    config = MagicMock()
+    config.get_amqp_host.return_value = 'localhost'
+    config.get_amqp_user.return_value = 'guest'
+    config.get_amqp_pass.return_value = 'guest'
+    mock_config.return_value = config
+    from mash.services.api.models import (
+        User,
+        Token,
+        EC2Account,
+        EC2Group,
+        EC2Region
+    )
+
+
+def test_user_model():
+    user = User(
+        username='user1',
+        email='user1@fake.com'
+    )
+    user.set_password('password')
+    assert user.check_password('password')
+    assert user.__repr__() == '<User user1>'
+
+
+def test_token_model():
+    token = Token(
+        jti='12345',
+        token_type='access',
+        user_id='1',
+        expires=None
+    )
+    assert token.__repr__() == '<Token 12345>'
+
+
+def test_ec2_account_model():
+    account = EC2Account(
+        name='acnt1',
+        partition='aws',
+        region='us-east-1',
+        user_id='1'
+    )
+    assert account.__repr__() == '<EC2 Account acnt1>'
+
+
+def test_ec2_group_model():
+    group = EC2Group(
+        name='group1',
+        user_id='1'
+    )
+    assert group.__repr__() == '<EC2 Group group1>'
+
+
+def test_ec2_region_model():
+    region = EC2Region(
+        name='us-east-99',
+        helper_image='ami-1234567890',
+        account_id='1'
+    )
+    assert region.__repr__() == '<EC2 Region us-east-99>'

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -120,3 +120,6 @@ class TestBaseConfig(object):
         mock_get_log_dir.return_value = '/var/log/mash/'
         assert self.empty_config.get_job_log_file('1234') == \
             '/var/log/mash/jobs/1234.log'
+
+    def test_get_database_uri(self):
+        assert self.config.get_database_uri() == 'sqlite:////var/lib/mash/app.db'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- The user model is for mash users.
- Token model is to store jwt tokens server side. THis allows
  users to revoke tokens.
- EC2 models are for ec2 cloud accounts.