### PR TITLE
Allow base job dir to be configurable.

### DIFF
--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -93,6 +93,16 @@ class BaseConfig(object):
         log_dir = self._get_attribute(attribute='log_dir')
         return log_dir or Defaults.get_log_directory()
 
+    def get_job_directory(self, service_name):
+        """
+        Return job directory path based on service name attribute.
+
+        :rtype: string
+        """
+        base_job_dir = self._get_attribute(attribute='base_job_dir')
+        base_job_dir = base_job_dir or Defaults.get_base_job_directory()
+        return os.path.join(base_job_dir, Defaults.get_job_directory(service_name))
+
     def get_log_file(self, service):
         """
         Return log file name based on log_dir attribute.

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -30,8 +30,12 @@ class Defaults(object):
         return '/var/lib/mash/encryption_keys'
 
     @classmethod
+    def get_base_job_directory(self):
+        return '/var/lib/mash/'
+
+    @classmethod
     def get_job_directory(self, service_name):
-        return '/var/lib/mash/{0}_jobs/'.format(service_name)
+        return '{0}_jobs/'.format(service_name)
 
     @classmethod
     def get_jwt_algorithm(self):

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -1,5 +1,7 @@
 jwt_secret: abc123
-encryption_keys_file: /etc/mash/encryption_keys
+log_dir: /tmp/log/
+base_job_dir: /tmp/jobs/
+encryption_keys_file: ../data/encryption_keys
 ssh_private_key_file: /var/lib/mash/ssh_key
 amqp_host: localhost
 amqp_user: guest
@@ -17,10 +19,7 @@ services:
   - deprecation
 non_cred_services:
   - obs
-logger:
-  log_dir: /var/log/othermash/
 obs:
-  logfile: /tmp/foo.log
   download_directory: /images
 cloud:
   ec2:

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -111,8 +111,14 @@ class TestBaseConfig(object):
         subject = self.empty_config.get_notification_subject()
         assert subject == '[MASH] Job Status Update'
 
+    def test_get_job_dir(self):
+        assert self.config.get_job_directory('testing') == \
+            '/tmp/jobs/testing_jobs/'
+        assert self.empty_config.get_job_directory('testing') == \
+            '/var/lib/mash/testing_jobs/'
+
     def test_get_log_dir(self):
-        assert self.config.get_log_directory() == '/var/log/mash/'
+        assert self.config.get_log_directory() == '/tmp/log/'
         assert self.empty_config.get_log_directory() == '/var/log/mash/'
 
     @patch.object(BaseConfig, 'get_log_directory')

--- a/test/unit/services/base/defaults_test.py
+++ b/test/unit/services/base/defaults_test.py
@@ -7,8 +7,8 @@ def test_get_config():
 
 
 def test_get_job_directory():
-    job_directory = Defaults.get_job_directory('testing')
-    assert job_directory == '/var/lib/mash/testing_jobs/'
+    job_directory = Defaults.get_base_job_directory()
+    assert job_directory == '/var/lib/mash/'
 
 
 def test_get_log_directory():

--- a/test/unit/services/credentials/config_test.py
+++ b/test/unit/services/credentials/config_test.py
@@ -12,7 +12,7 @@ class TestCredentialsConfig(object):
 
     def test_get_log_file(self):
         assert self.config.get_log_file('credentials') == \
-            '/var/log/mash/credentials_service.log'
+            '/tmp/log/credentials_service.log'
 
     def test_get_credentials_dir(self):
         assert self.config.get_credentials_dir() == \

--- a/test/unit/services/obs/config_test.py
+++ b/test/unit/services/obs/config_test.py
@@ -18,7 +18,7 @@ class TestOBSConfig(object):
 
     def test_get_log_file(self):
         assert self.config.get_log_file('obs') == \
-            '/var/log/mash/obs_service.log'
+            '/tmp/log/obs_service.log'
         assert self.config_defaults.get_log_file('obs') == \
             '/var/log/mash/obs_service.log'
 

--- a/test/unit/services/publisher/config_test.py
+++ b/test/unit/services/publisher/config_test.py
@@ -12,4 +12,4 @@ class TestPublisherConfig(object):
 
     def test_publisher_get_log_file(self):
         assert self.config.get_log_file('publisher') == \
-            '/var/log/mash/publisher_service.log'
+            '/tmp/log/publisher_service.log'

--- a/test/unit/services/replication/config_test.py
+++ b/test/unit/services/replication/config_test.py
@@ -12,4 +12,4 @@ class TestReplicationConfig(object):
 
     def test_get_log_file(self):
         assert self.config.get_log_file('replication') == \
-            '/var/log/mash/replication_service.log'
+            '/tmp/log/replication_service.log'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

base_job_dir will be concatenated to '/{service_name}_jobs' to build job dir. This allows the base dir to configurable.