### PR TITLE
Move log setup methods to utils functions.

### DIFF
--- a/mash/services/credentials/app.py
+++ b/mash/services/credentials/app.py
@@ -23,15 +23,10 @@ import os
 from flask import Flask
 from flask.logging import default_handler
 
+from mash.utils.mash_utils import setup_logfile, setup_rabbitmq_log_handler
 from mash.log.filter import BaseServiceFilter
-from mash.services.credentials.datastore import (
-    CredentialsDatastore
-)
-from mash.services.credentials.utils import (
-    restart_jobs,
-    setup_logfile,
-    setup_rabbitmq_log_handler
-)
+from mash.services.credentials.datastore import CredentialsDatastore
+from mash.services.credentials.utils import restart_jobs
 from mash.services.credentials.routes import credentials
 from mash.services.credentials.routes import jobs
 

--- a/mash/services/credentials/utils.py
+++ b/mash/services/credentials/utils.py
@@ -16,51 +16,9 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import logging
 import os
 
-from mash.log.handler import RabbitMQHandler
-from mash.mash_exceptions import MashLogSetupException
 from mash.utils.mash_utils import load_json, persist_json, remove_file
-
-
-def setup_logfile(logfile):
-    """
-    Create log dir and log file if either does not already exist.
-    """
-    try:
-        log_dir = os.path.dirname(logfile)
-        if not os.path.isdir(log_dir):
-            os.makedirs(log_dir)
-    except Exception as e:
-        raise MashLogSetupException(
-            'Log setup failed: {0}'.format(e)
-        )
-
-    logfile_handler = logging.FileHandler(
-        filename=logfile, encoding='utf-8'
-    )
-
-    return logfile_handler
-
-
-def get_logging_formatter():
-    return logging.Formatter(
-        '%(newline)s%(levelname)s %(asctime)s %(name)s%(newline)s'
-        '    %(job)s %(message)s'
-    )
-
-
-def setup_rabbitmq_log_handler(host, username, password):
-    rabbit_handler = RabbitMQHandler(
-        host=host,
-        username=username,
-        password=password,
-        routing_key='mash.logger'
-    )
-    rabbit_handler.setFormatter(get_logging_formatter())
-
-    return rabbit_handler
 
 
 def add_job_to_queue(job_doc, jobs):

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -21,7 +21,7 @@ import json
 from mash.services.mash_service import MashService
 from mash.services.jobcreator import create_job
 from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import handle_request
+from mash.utils.mash_utils import handle_request, setup_logfile
 
 
 class JobCreatorService(MashService):
@@ -38,7 +38,10 @@ class JobCreatorService(MashService):
         self.service_queue = 'service'
         self.job_document_key = 'job_document'
 
-        self.set_logfile(self.config.get_log_file(self.service_exchange))
+        logfile_handler = setup_logfile(
+            self.config.get_log_file(self.service_exchange)
+        )
+        self.log.addHandler(logfile_handler)
         self.services = self.config.get_service_names()
         self.credentials_url = self.config.get_credentials_url()
 

--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -36,7 +36,8 @@ from mash.utils.mash_utils import (
     remove_file,
     persist_json,
     restart_jobs,
-    handle_request
+    handle_request,
+    setup_logfile
 )
 
 
@@ -74,7 +75,10 @@ class ListenerService(MashService):
         if self.custom_args.get('status_msg_args'):
             self.status_msg_args += self.custom_args['status_msg_args']
 
-        self.set_logfile(self.config.get_log_file(self.service_exchange))
+        logfile_handler = setup_logfile(
+            self.config.get_log_file(self.service_exchange)
+        )
+        self.log.addHandler(logfile_handler)
 
         self.bind_queue(
             self.service_exchange, self.job_document_key, self.service_queue

--- a/mash/services/logger/service.py
+++ b/mash/services/logger/service.py
@@ -20,6 +20,7 @@ import json
 
 from mash.mash_exceptions import MashLoggerException
 from mash.services.mash_service import MashService
+from mash.utils.mash_utils import setup_logfile
 
 
 class LoggerService(MashService):
@@ -36,7 +37,10 @@ class LoggerService(MashService):
         Bind to logger exchange and consume with callback
         method to process log.
         """
-        self.set_logfile(self.config.get_log_file(self.service_exchange))
+        logfile_handler = setup_logfile(
+            self.config.get_log_file(self.service_exchange)
+        )
+        self.log.addHandler(logfile_handler)
 
         self.bind_queue(self.service_exchange, 'mash.logger', 'logging')
         self.start()

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -25,7 +25,7 @@ from mash.services.mash_service import MashService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
 from mash.services.status_levels import DELETE
-from mash.utils.mash_utils import persist_json, restart_jobs
+from mash.utils.mash_utils import persist_json, restart_jobs, setup_logfile
 
 
 class OBSImageBuildResultService(MashService):
@@ -39,7 +39,10 @@ class OBSImageBuildResultService(MashService):
         self.service_queue = 'service'
 
         # setup service log file
-        self.set_logfile(self.config.get_log_file(self.service_exchange))
+        logfile_handler = setup_logfile(
+            self.config.get_log_file(self.service_exchange)
+        )
+        self.log.addHandler(logfile_handler)
 
         # setup service data directories
         self.download_directory = self.config.get_download_directory()

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -1,14 +1,10 @@
 from unittest.mock import patch
-from unittest.mock import call
 from unittest.mock import MagicMock, Mock
 from pytest import raises
 
 from mash.services.mash_service import MashService
 
-from mash.mash_exceptions import (
-    MashRabbitConnectionException,
-    MashLogSetupException
-)
+from mash.mash_exceptions import MashRabbitConnectionException
 
 
 class TestBaseService(object):
@@ -50,35 +46,6 @@ class TestBaseService(object):
 
     def test_post_init(self):
         self.service.post_init()
-
-    @patch('mash.services.mash_service.os')
-    @patch('logging.FileHandler')
-    def test_set_logfile(self, mock_logging_FileHandler, mock_os):
-        logfile_handler = Mock()
-        mock_logging_FileHandler.return_value = logfile_handler
-
-        mock_os.path.dirname.return_value = '/some'
-        mock_os.path.isdir.return_value = False
-
-        self.service.set_logfile('/some/log')
-
-        mock_os.path.dirname.assert_called_with('/some/log')
-        mock_os.path.isdir.assert_called_with('/some')
-        mock_os.makedirs.assert_called_with('/some')
-
-        mock_logging_FileHandler.assert_called_once_with(
-            encoding='utf-8', filename='/some/log'
-        )
-        self.service.log.addHandler.assert_has_calls(
-            [call(logfile_handler)]
-        )
-
-    @patch('mash.services.mash_service.os')
-    @patch('logging.FileHandler')
-    def test_set_logfile_raises(self, mock_logging_FileHandler, mock_os):
-        mock_logging_FileHandler.side_effect = Exception
-        with raises(MashLogSetupException):
-            self.service.set_logfile('/some/log')
 
     def test_consume_queue(self):
         callback = Mock()

--- a/test/unit/services/credentials/utils_test.py
+++ b/test/unit/services/credentials/utils_test.py
@@ -1,11 +1,6 @@
-from pytest import raises
+from unittest.mock import patch
 
-from unittest.mock import Mock, patch
-
-from mash.mash_exceptions import MashLogSetupException
 from mash.services.credentials.utils import (
-    setup_logfile,
-    setup_rabbitmq_log_handler,
     add_job_to_queue,
     get_job_file,
     restart_jobs,
@@ -13,42 +8,6 @@ from mash.services.credentials.utils import (
     remove_job,
     remove_job_from_queue
 )
-
-
-@patch('mash.services.credentials.utils.logging')
-@patch('mash.services.credentials.utils.os')
-def test_setup_logfile(mock_os, mock_logging):
-    mock_os.path.isdir.return_value = False
-    mock_os.path.dirname.return_value = '/file/dir'
-
-    setup_logfile('/file/dir/fake.path')
-    mock_os.makedirs.assert_called_once_with('/file/dir')
-    mock_logging.FileHandler.assert_called_once_with(
-        filename='/file/dir/fake.path', encoding='utf-8'
-    )
-
-    mock_os.makedirs.side_effect = Exception('Cannot create dir')
-    with raises(MashLogSetupException):
-        setup_logfile('fake.path')
-
-
-@patch('mash.services.credentials.utils.logging')
-@patch('mash.services.credentials.utils.RabbitMQHandler')
-def test_setup_rabbitmq_log_handler(mock_rabbit, mock_logging):
-    handler = Mock()
-    formatter = Mock()
-    mock_rabbit.return_value = handler
-    mock_logging.Formatter.return_value = formatter
-
-    setup_rabbitmq_log_handler('localhost', 'user1', 'pass')
-
-    mock_rabbit.assert_called_once_with(
-        host='localhost',
-        username='user1',
-        password='pass',
-        routing_key='mash.logger'
-    )
-    handler.setFormatter.assert_called_once_with(formatter)
 
 
 def test_add_job_to_queue():

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -38,12 +38,12 @@ class TestJobCreatorService(object):
             'publisher', 'deprecation'
         ]
 
-    @patch.object(JobCreatorService, 'set_logfile')
+    @patch('mash.services.jobcreator.service.setup_logfile')
     @patch.object(JobCreatorService, 'start')
     @patch.object(JobCreatorService, 'bind_queue')
     def test_jobcreator_post_init(
         self, mock_bind_queue,
-        mock_start, mock_set_logfile
+        mock_start, mock_setup_logfile
     ):
         self.jobcreator.config = self.config
         self.config.get_log_file.return_value = \
@@ -52,7 +52,7 @@ class TestJobCreatorService(object):
         self.jobcreator.post_init()
 
         self.config.get_log_file.assert_called_once_with('jobcreator')
-        mock_set_logfile.assert_called_once_with(
+        mock_setup_logfile.assert_called_once_with(
             '/var/log/mash/job_creator_service.log'
         )
 

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -89,11 +89,11 @@ class TestListenerService(object):
     @patch.object(Defaults, 'get_job_directory')
     @patch.object(ListenerService, 'bind_queue')
     @patch('mash.services.listener_service.restart_jobs')
-    @patch.object(ListenerService, 'set_logfile')
+    @patch('mash.services.listener_service.setup_logfile')
     @patch.object(ListenerService, 'start')
     def test_service_post_init(
         self, mock_start,
-        mock_set_logfile, mock_restart_jobs,
+        mock_setup_logfile, mock_restart_jobs,
         mock_bind_queue, mock_get_job_directory, mock_makedirs
     ):
         mock_get_job_directory.return_value = '/var/lib/mash/replication_jobs/'
@@ -109,7 +109,7 @@ class TestListenerService(object):
         )
 
         self.config.get_log_file.assert_called_once_with('replication')
-        mock_set_logfile.assert_called_once_with(
+        mock_setup_logfile.assert_called_once_with(
             '/var/log/mash/service_service.log'
         )
 
@@ -127,11 +127,11 @@ class TestListenerService(object):
     @patch.object(Defaults, 'get_job_directory')
     @patch.object(ListenerService, 'bind_queue')
     @patch('mash.services.listener_service.restart_jobs')
-    @patch.object(ListenerService, 'set_logfile')
+    @patch('mash.services.listener_service.setup_logfile')
     @patch.object(ListenerService, 'start')
     def test_service_post_init_custom_args(
         self, mock_start,
-        mock_set_logfile, mock_restart_jobs,
+        mock_setup_logfile, mock_restart_jobs,
         mock_bind_queue, mock_get_job_directory, mock_makedirs
     ):
         mock_makedirs.return_value = True

--- a/test/unit/services/logger/service_test.py
+++ b/test/unit/services/logger/service_test.py
@@ -41,15 +41,16 @@ class TestLoggerService(object):
         )
 
         self.logger = LoggerService()
+        self.logger.log = MagicMock()
         self.logger.service_exchange = 'logger'
         self.logger.channel = self.channel
 
-    @patch.object(LoggerService, 'set_logfile')
+    @patch('mash.services.logger.service.setup_logfile')
     @patch.object(LoggerService, 'start')
     @patch.object(LoggerService, 'bind_queue')
     @patch.object(LoggerService, '_process_log')
     def test_logger_post_init(
-        self, mock_process_log, mock_bind_queue, mock_start, mock_set_logfile
+        self, mock_process_log, mock_bind_queue, mock_start, mock_setup_logfile
     ):
         config = Mock()
         config.get_log_file.return_value = '/var/log/mash/logger_service.log'
@@ -59,7 +60,7 @@ class TestLoggerService(object):
         self.logger.post_init()
 
         config.get_log_file.assert_called_once_with('logger')
-        mock_set_logfile.assert_called_once_with(
+        mock_setup_logfile.assert_called_once_with(
             '/var/log/mash/logger_service.log'
         )
         mock_bind_queue.assert_called_once_with(

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -17,7 +17,7 @@ class TestOBSImageBuildResultService(object):
 
     @patch('mash.services.obs.service.os.makedirs')
     @patch.object(Defaults, 'get_job_directory')
-    @patch.object(OBSImageBuildResultService, 'set_logfile')
+    @patch('mash.services.obs.service.setup_logfile')
     @patch.object(OBSImageBuildResultService, '_process_message')
     @patch.object(OBSImageBuildResultService, '_send_job_result_for_uploader')
     @patch('mash.services.obs.service.restart_jobs')
@@ -29,7 +29,7 @@ class TestOBSImageBuildResultService(object):
         self, mock_register, mock_log, mock_listdir, mock_MashService,
         mock_restart_jobs, mock_send_job_result_for_uploader,
         mock_process_message,
-        mock_set_logfile, mock_get_job_directory, mock_makedirs
+        mock_setup_logfile, mock_get_job_directory, mock_makedirs
     ):
         mock_get_job_directory.return_value = '/var/lib/mash/obs_jobs/'
         config = Mock()
@@ -60,7 +60,7 @@ class TestOBSImageBuildResultService(object):
             '/var/lib/mash/obs_jobs/', exist_ok=True
         )
 
-        mock_set_logfile.assert_called_once_with('logfile')
+        mock_setup_logfile.assert_called_once_with('logfile')
         mock_restart_jobs.assert_called_once_with(
             '/var/lib/mash/obs_jobs/',
             self.obs_result._start_job


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Move setup rabbitmq handler and log file handler to mash utils module. These can be shared with API based services.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
