### PR TITLE
Migrate API to app factory model.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,5 +9,5 @@ replace = Version:        {new_version}
 
 [bumpversion:file:mash/version.py]
 
-[bumpversion:file:mash/services/api/__init__.py]
+[bumpversion:file:mash/services/api/extensions.py]
 

--- a/mash/services/api/app.py
+++ b/mash/services/api/app.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import logging
+
+from flask import Flask
+from flask.logging import default_handler
+
+from mash.services.api.extensions import api, db, jwt, migrate
+
+from mash.log.filter import BaseServiceFilter
+from mash.utils.mash_utils import setup_logfile, setup_rabbitmq_log_handler
+
+from mash.services.api.utils.tokens import is_token_revoked
+
+from mash.services.api.routes.api_spec import spec_api
+
+from mash.services.api.routes.accounts import api as accounts_api
+from mash.services.api.routes.accounts.azure import api as azure_accounts_api
+from mash.services.api.routes.accounts.gce import api as gce_accounts_api
+from mash.services.api.routes.accounts.ec2 import api as ec2_accounts_api
+
+from mash.services.api.routes.jobs import api as jobs_api
+from mash.services.api.routes.jobs.ec2 import api as ec2_jobs_api
+from mash.services.api.routes.jobs.gce import api as gce_jobs_api
+from mash.services.api.routes.jobs.azure import api as azure_jobs_api
+
+
+@jwt.token_in_blacklist_loader
+def check_if_token_in_blacklist(decoded_token):
+    return is_token_revoked(decoded_token)
+
+
+def create_app(config_object):
+    """
+    Factory for creating api using provided configuration object.
+    """
+    app = Flask('APIService', static_url_path='/static')
+    app.config.from_object(config_object)
+    register_extensions(app)
+    register_namespaces()
+    configure_logger(app)
+    return app
+
+
+def configure_logger(app):
+    """Configure loggers."""
+    app.logger.removeHandler(default_handler)
+
+    logging.basicConfig()
+    app.logger.addFilter(BaseServiceFilter())
+    app.logger.setLevel(logging.DEBUG)
+    app.logger.propagate = False
+
+    rabbit_handler = setup_rabbitmq_log_handler(
+        app.config['AMQP_HOST'],
+        app.config['AMQP_USER'],
+        app.config['AMQP_PASS']
+    )
+    app.logger.addHandler(rabbit_handler)
+
+    logfile_handler = setup_logfile(app.config['LOG_FILE'])
+    app.logger.addHandler(logfile_handler)
+
+
+def register_namespaces():
+    """Register Flask restplus namespaces."""
+    api.add_namespace(spec_api, path='/api/spec')
+
+    api.add_namespace(accounts_api, path='/accounts')
+    api.add_namespace(azure_accounts_api, path='/accounts/azure')
+    api.add_namespace(gce_accounts_api, path='/accounts/gce')
+    api.add_namespace(ec2_accounts_api, path='/accounts/ec2')
+
+    api.add_namespace(jobs_api, path='/jobs')
+    api.add_namespace(ec2_jobs_api, path='/jobs/ec2')
+    api.add_namespace(gce_jobs_api, path='/jobs/gce')
+    api.add_namespace(azure_jobs_api, path='/jobs/azure')
+
+
+def register_extensions(app):
+    """Register Flask extensions."""
+    db.init_app(app)
+    migrate.init_app(app, db)
+    jwt.init_app(app)
+    api.init_app(app)
+
+    # Required for flask-restplus to play nicely with flask-jwt-extended
+    jwt._set_error_handler_callbacks(api)

--- a/mash/services/api/config.py
+++ b/mash/services/api/config.py
@@ -23,13 +23,47 @@ class Config(object):
     """
     Flask API config.
     """
-    config = BaseConfig()
-    SQLALCHEMY_DATABASE_URI = config.get_database_uri()
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-    AMQP_HOST = config.get_amqp_host()
-    AMQP_USER = config.get_amqp_user()
-    AMQP_PASS = config.get_amqp_pass()
+    def __init__(self, config_file=None, testing=False):
+        self.config = BaseConfig(config_file)
+        self.TESTING = testing
 
-    CLOUD_DATA = config.get_cloud_data()
-    CREDENTIALS_URL = config.get_credentials_url()
+    @property
+    def AMQP_HOST(self):
+        return self.config.get_amqp_host()
+
+    @property
+    def AMQP_USER(self):
+        return self.config.get_amqp_user()
+
+    @property
+    def AMQP_PASS(self):
+        return self.config.get_amqp_pass()
+
+    @property
+    def LOG_FILE(self):
+        return self.config.get_log_file('api')
+
+    @property
+    def CREDENTIALS_URL(self):
+        return self.config.get_credentials_url()
+
+    @property
+    def CLOUD_DATA(self):
+        return self.config.get_cloud_data()
+
+    @property
+    def JWT_BLACKLIST_ENABLED(self):
+        return True
+
+    @property
+    def JWT_SECRET_KEY(self):
+        return self.config.get_jwt_secret()
+
+    @property
+    def SQLALCHEMY_TRACK_MODIFICATIONS(self):
+        return False
+
+    @property
+    def SQLALCHEMY_DATABASE_URI(self):
+        return self.config.get_database_uri()

--- a/mash/services/api/extensions.py
+++ b/mash/services/api/extensions.py
@@ -15,3 +15,31 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+
+from flask_restplus import Api
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+from flask_jwt_extended import JWTManager
+
+authorizations = {
+    'apiKey': {
+        'type': 'apiKey',
+        'in': 'header',
+        'name': 'Authorization',
+        'example': 'Bearer {token}'
+    }
+}
+
+api = Api(
+    version='3.4.0',
+    contact='public-cloud-dev@susecloud.net',
+    title='MASH API',
+    description='MASH provides a set of endpoints for Image Release '
+                'automation into Public Cloud Frameworks.',
+    validate=True,
+    doc=False,
+    authorizations=authorizations
+)
+db = SQLAlchemy()
+migrate = Migrate()
+jwt = JWTManager()

--- a/mash/services/api/model_utils.py
+++ b/mash/services/api/model_utils.py
@@ -18,10 +18,11 @@
 
 import copy
 
+from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
 from mash.mash_exceptions import MashDBException, MashJobException
-from mash.services.api import app, db
+from mash.services.api.extensions import db
 from mash.services.api.models import (
     EC2Account,
     EC2Group,
@@ -197,7 +198,7 @@ def create_ec2_account(
 
     try:
         handle_request(
-            app.config['CREDENTIALS_URL'],
+            current_app.config['CREDENTIALS_URL'],
             'credentials',
             'post',
             job_data=data
@@ -263,7 +264,7 @@ def delete_ec2_account(name, username):
             db.session.delete(ec2_account)
             db.session.commit()
             handle_request(
-                app.config['CREDENTIALS_URL'],
+                current_app.config['CREDENTIALS_URL'],
                 'credentials',
                 'delete',
                 job_data=data
@@ -282,7 +283,7 @@ def get_ec2_regions_by_partition(partition):
     Get EC2 regions from config file based on partition.
     """
     regions = copy.deepcopy(
-        app.config['CLOUD_DATA']['ec2']['regions'][partition]
+        current_app.config['CLOUD_DATA']['ec2']['regions'][partition]
     )
     return regions
 
@@ -292,7 +293,7 @@ def get_ec2_helper_images():
     Get helper image data for EC2 from config file.
     """
     helper_images = copy.deepcopy(
-        app.config['CLOUD_DATA']['ec2']['helper_images']
+        current_app.config['CLOUD_DATA']['ec2']['helper_images']
     )
     return helper_images
 

--- a/mash/services/api/models.py
+++ b/mash/services/api/models.py
@@ -18,7 +18,7 @@
 
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from mash.services.api import db
+from mash.services.api.extensions import db
 
 
 class User(db.Model):

--- a/mash/services/api/routes/amqp_utils.py
+++ b/mash/services/api/routes/amqp_utils.py
@@ -19,8 +19,7 @@
 import sys
 
 from amqpstorm import Connection
-
-from mash.services.api import app
+from flask import current_app
 
 module = sys.modules[__name__]
 
@@ -30,9 +29,9 @@ channel = None
 
 def connect():
     module.connection = Connection(
-        app.config['AMQP_HOST'],
-        app.config['AMQP_USER'],
-        app.config['AMQP_PASS'],
+        current_app.config['AMQP_HOST'],
+        current_app.config['AMQP_USER'],
+        current_app.config['AMQP_PASS'],
         kwargs={'heartbeat': 600}
     )
     module.channel = connection.channel()

--- a/mash/services/api/routes/api_spec.py
+++ b/mash/services/api/routes/api_spec.py
@@ -15,3 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+
+import json
+
+from flask_restplus import Namespace, Resource
+
+from mash.services.api.extensions import api
+
+spec_api = Namespace(
+    'API Spec document',
+    description='API Specification'
+)
+
+
+@spec_api.route('/', doc=False)
+class APIDoc(Resource):
+    def post(self):
+        return json.dumps(api.__schema__)
+
+    def get(self):
+        return json.dumps(api.__schema__)

--- a/mash/services/api/utils/tokens.py
+++ b/mash/services/api/utils/tokens.py
@@ -15,3 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from mash.services.api.models import Token
+
+
+def is_token_revoked(decoded_token):
+    """
+    Checks if the given token exists.
+    """
+    jti = decoded_token['jti']
+
+    try:
+        Token.query.filter_by(jti=jti).one()
+    except NoResultFound:
+        return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,6 @@ addopts = --ignore=.tmp/ --ignore=.git/ --ignore=.tox/ -p no:warnings
 testpaths = test/unit/
 
 [flake8]
-exclude = .tox*/*
+exclude = .tox*/* migrations
 # we allow long lines
 ignore = E501

--- a/test/unit/services/api/api_test.py
+++ b/test/unit/services/api/api_test.py
@@ -1,37 +1,6 @@
 import json
-import pytest
 
 from unittest.mock import MagicMock, patch
-
-with patch('mash.services.base_config.BaseConfig') as mock_config:
-    config = MagicMock()
-    config.get_amqp_host.return_value = 'localhost'
-    config.get_amqp_user.return_value = 'guest'
-    config.get_amqp_pass.return_value = 'guest'
-    config.get_credentials_url.return_value = 'http://localhost:8080/'
-    config.get_cloud_data.return_value = {
-        'ec2': {
-            'regions': {
-                'aws': ['us-east-99']
-            },
-            'helper_images': {
-                'us-east-99': 'ami-789'
-            }
-        }
-    }
-    mock_config.return_value = config
-    from mash.services.api import wsgi
-
-
-@pytest.fixture(scope='module')
-def test_client():
-    testing_client = wsgi.application.test_client()
-
-    ctx = wsgi.application.app_context()
-    ctx.push()
-
-    yield testing_client
-    ctx.pop()
 
 
 @patch('mash.services.api.routes.amqp_utils.Connection')
@@ -413,6 +382,10 @@ def test_api_docs(test_client):
     api_desc = b'MASH provides a set of endpoints for Image Release ' \
                b'automation into Public Cloud Frameworks.'
 
-    response = test_client.get('/api/spec')
+    response = test_client.get('/api/spec/')
+    assert response.status_code == 200
+    assert api_desc in response.data
+
+    response = test_client.post('/api/spec/')
     assert response.status_code == 200
     assert api_desc in response.data

--- a/test/unit/services/api/conftest.py
+++ b/test/unit/services/api/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from mash.services.api.app import create_app
+from mash.services.api.config import Config
+
+
+@pytest.fixture(scope='module')
+def test_client():
+    flask_config = Config(
+        config_file='../data/mash_config.yaml',
+        testing=True
+    )
+    application = create_app(flask_config)
+    testing_client = application.test_client()
+
+    ctx = application.app_context()
+    ctx.push()
+
+    yield testing_client
+    ctx.pop()

--- a/test/unit/services/api/utils/token_utils_test.py
+++ b/test/unit/services/api/utils/token_utils_test.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch, Mock
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from mash.services.api.app import check_if_token_in_blacklist
+from mash.services.api.utils.tokens import is_token_revoked
+
+
+@patch('mash.services.api.utils.tokens.Token')
+def test_is_token_revoked(mock_token):
+    decoded_token = {'jti': '123'}
+
+    queryset = Mock()
+    queryset.one.side_effect = NoResultFound()
+    mock_token.query.filter_by.return_value = queryset
+
+    assert is_token_revoked(decoded_token)
+
+
+@patch('mash.services.api.app.is_token_revoked')
+def test_check_if_token_in_blacklist(mock_is_token_revoked):
+    decoded_token = Mock()
+    check_if_token_in_blacklist(decoded_token)
+    mock_is_token_revoked.assert_called_once_with(decoded_token)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This prevents issues with circular imports and allows for modular plugin of config objects.
