### PR TITLE
Move user pass validation out of schema.

### DIFF
--- a/mash/services/api/routes/user.py
+++ b/mash/services/api/routes/user.py
@@ -26,6 +26,7 @@ from flask_jwt_extended import (
     get_jwt_identity
 )
 
+from mash.mash_exceptions import MashDBException
 from mash.services.api.schema import (
     add_account,
     default_response,
@@ -66,7 +67,17 @@ class Account(Resource):
         Create a new MASH account.
         """
         data = json.loads(request.data.decode())
-        user = add_user(data['username'], data['email'], data['password'])
+
+        try:
+            user = add_user(data['username'], data['email'], data['password'])
+        except MashDBException as error:
+            return make_response(
+                jsonify({
+                    "errors": {"password": str(error)},
+                    "message": "Input payload validation failed"
+                }),
+                400
+            )
 
         if user:
             return make_response(

--- a/mash/services/api/utils/users.py
+++ b/mash/services/api/utils/users.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import IntegrityError
 
 from mash.services.api.extensions import db
 from mash.services.api.models import User
+from mash.mash_exceptions import MashDBException
 
 
 def add_user(username, email, password):
@@ -28,6 +29,11 @@ def add_user(username, email, password):
 
     If the user or email exists return None.
     """
+    if len(password) < 8:
+        raise MashDBException(
+            'Password too short. Minimum length is 8 characters.'
+        )
+
     user = User(
         username=username,
         email=email

--- a/test/unit/services/api/utils/user_utils_test.py
+++ b/test/unit/services/api/utils/user_utils_test.py
@@ -1,8 +1,16 @@
+from pytest import raises
 from unittest.mock import patch, Mock
 
 from sqlalchemy.exc import IntegrityError
 
-from mash.services.api.utils.users import add_user, verify_login, get_user_by_username, get_user_email, delete_user
+from mash.mash_exceptions import MashDBException
+from mash.services.api.utils.users import (
+    add_user,
+    verify_login,
+    get_user_by_username,
+    get_user_email,
+    delete_user
+)
 
 
 @patch('mash.services.api.utils.users.db')
@@ -19,6 +27,9 @@ def test_add_user(mock_db):
 
     assert user is None
     mock_db.session.rollback.assert_called_once_with()
+
+    with raises(MashDBException):
+        add_user('user1', 'user1@fake.com', 'pass')
 
 
 @patch('mash.services.api.utils.users.get_user_by_username')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The schema responds with the plain text password in the error message. Instead respond with a general validation error.