### PR TITLE
Fix credentials path.

### DIFF
--- a/mash/services/api/utils/accounts/ec2.py
+++ b/mash/services/api/utils/accounts/ec2.py
@@ -119,7 +119,7 @@ def create_ec2_account(
     try:
         handle_request(
             current_app.config['CREDENTIALS_URL'],
-            'credentials',
+            'credentials/',
             'post',
             job_data=data
         )
@@ -185,7 +185,7 @@ def delete_ec2_account(name, username):
             db.session.commit()
             handle_request(
                 current_app.config['CREDENTIALS_URL'],
-                'credentials',
+                'credentials/',
                 'delete',
                 job_data=data
             )

--- a/test/unit/services/api/utils/accounts/ec2_account_utils_test.py
+++ b/test/unit/services/api/utils/accounts/ec2_account_utils_test.py
@@ -124,7 +124,7 @@ def test_create_ec2_account(
 
     mock_handle_request.assert_called_once_with(
         'http://localhost:5000/',
-        'credentials',
+        'credentials/',
         'post',
         job_data=data
     )
@@ -216,7 +216,7 @@ def test_delete_ec2_account(
     mock_db.session.commit.assert_called_once_with()
     mock_handle_request.assert_called_once_with(
         'http://localhost:5000/',
-        'credentials',
+        'credentials/',
         'delete',
         job_data=data
     )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Adding slash to the path prevents an unneeded redirect call.