### PR TITLE
Fix get job directory bug.

### DIFF
--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -27,7 +27,6 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from pytz import utc
 
-from mash.services.base_defaults import Defaults
 from mash.services.job_factory import JobFactory
 from mash.services.mash_service import MashService
 from mash.services.status_levels import EXCEPTION, SUCCESS
@@ -54,7 +53,9 @@ class ListenerService(MashService):
         self.jobs = {}
 
         # setup service job directory
-        self.job_directory = Defaults.get_job_directory(self.service_exchange)
+        self.job_directory = self.config.get_job_directory(
+            self.service_exchange
+        )
         os.makedirs(
             self.job_directory, exist_ok=True
         )

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -20,7 +20,6 @@ import os
 import dateutil.parser
 
 # project
-from mash.services.base_defaults import Defaults
 from mash.services.mash_service import MashService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
@@ -50,7 +49,9 @@ class OBSImageBuildResultService(MashService):
         self.jobs = {}
 
         # setup service job directory
-        self.job_directory = Defaults.get_job_directory(self.service_exchange)
+        self.job_directory = self.config.get_job_directory(
+            self.service_exchange
+        )
         os.makedirs(
             self.job_directory, exist_ok=True
         )

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -24,6 +24,7 @@ class TestListenerService(object):
             'obs', 'uploader', 'testing', 'replication', 'publisher',
             'deprecation'
         ]
+        self.config.get_job_directory.return_value = '/var/lib/mash/replication_jobs/'
 
         self.channel = Mock()
         self.channel.basic_ack.return_value = None
@@ -82,7 +83,6 @@ class TestListenerService(object):
         self.service.status_msg_args = ['cloud_image_name']
 
     @patch('mash.services.listener_service.os.makedirs')
-    @patch.object(Defaults, 'get_job_directory')
     @patch.object(ListenerService, 'bind_queue')
     @patch('mash.services.listener_service.restart_jobs')
     @patch('mash.services.listener_service.setup_logfile')
@@ -90,16 +90,15 @@ class TestListenerService(object):
     def test_service_post_init(
         self, mock_start,
         mock_setup_logfile, mock_restart_jobs,
-        mock_bind_queue, mock_get_job_directory, mock_makedirs
+        mock_bind_queue, mock_makedirs
     ):
-        mock_get_job_directory.return_value = '/var/lib/mash/replication_jobs/'
         self.service.config = self.config
         self.config.get_log_file.return_value = \
             '/var/log/mash/service_service.log'
 
         self.service.post_init()
 
-        mock_get_job_directory.assert_called_once_with('replication')
+        self.config.get_job_directory.assert_called_once_with('replication')
         mock_makedirs.assert_called_once_with(
             '/var/lib/mash/replication_jobs/', exist_ok=True
         )

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -7,7 +7,6 @@ from test.unit.test_helper import (
     patch_open
 )
 
-from mash.services.base_defaults import Defaults
 from mash.services.obs.service import OBSImageBuildResultService
 from mash.services.mash_service import MashService
 from mash.utils.json_format import JsonFormat
@@ -16,7 +15,6 @@ from mash.utils.json_format import JsonFormat
 class TestOBSImageBuildResultService(object):
 
     @patch('mash.services.obs.service.os.makedirs')
-    @patch.object(Defaults, 'get_job_directory')
     @patch('mash.services.obs.service.setup_logfile')
     @patch.object(OBSImageBuildResultService, '_process_message')
     @patch.object(OBSImageBuildResultService, '_send_job_result_for_uploader')
@@ -29,11 +27,11 @@ class TestOBSImageBuildResultService(object):
         self, mock_register, mock_log, mock_listdir, mock_MashService,
         mock_restart_jobs, mock_send_job_result_for_uploader,
         mock_process_message,
-        mock_setup_logfile, mock_get_job_directory, mock_makedirs
+        mock_setup_logfile, mock_makedirs
     ):
-        mock_get_job_directory.return_value = '/var/lib/mash/obs_jobs/'
         config = Mock()
         config.get_log_file.return_value = 'logfile'
+        config.get_job_directory.return_value = '/var/lib/mash/obs_jobs/'
         self.log = Mock()
         mock_listdir.return_value = ['job']
         mock_MashService.return_value = None
@@ -55,7 +53,7 @@ class TestOBSImageBuildResultService(object):
 
         self.obs_result.post_init()
 
-        mock_get_job_directory.assert_called_once_with('obs')
+        config.get_job_directory.assert_called_once_with('obs')
         mock_makedirs.assert_called_once_with(
             '/var/lib/mash/obs_jobs/', exist_ok=True
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Services use the get_job_directory method from configuration
module instead of the defaults method. The get_job_directory
method prepends the base job dir path.