### PR TITLE
New service raw image uploader

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -16,6 +16,7 @@ services:
   - obs
   - uploader
   - testing
+  - raw_image_uploader
   - replication
   - publisher
   - deprecation

--- a/config/mash_raw_image_uploader.service
+++ b/config/mash_raw_image_uploader.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Mash Raw Image Uploader service
+After=syslog.target network.target rabbitmq-server.service
+Before=systemd-user-sessions.service
+Requires=rabbitmq-server.service
+
+[Service]
+User=mash
+Group=mash
+Type=simple
+ExecStart=/usr/bin/mash-raw-image-uploader-service
+StandardOutput=journal
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/mash/services/__init__.py
+++ b/mash/services/__init__.py
@@ -22,6 +22,7 @@ from mash.services.jobcreator.config import JobCreatorConfig
 from mash.services.logger.config import LoggerConfig
 from mash.services.obs.config import OBSConfig
 from mash.services.publisher.config import PublisherConfig
+from mash.services.raw_image_uploader.config import RawImageUploaderConfig
 from mash.services.replication.config import ReplicationConfig
 from mash.services.testing.config import TestingConfig
 from mash.services.uploader.config import UploaderConfig
@@ -43,6 +44,8 @@ def get_configuration(service, config_file=None):
         return OBSConfig(config_file=config_file)
     elif service == 'publisher':
         return PublisherConfig(config_file=config_file)
+    elif service == 'raw_image_uploader':
+        return RawImageUploaderConfig(config_file=config_file)
     elif service == 'replication':
         return ReplicationConfig(config_file=config_file)
     elif service == 'testing':

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -66,6 +66,7 @@ base_job_message = {
             'enum': [
                 'uploader',
                 'testing',
+                'raw_image_uploader',
                 'replication',
                 'publisher',
                 'deprecation'
@@ -124,7 +125,10 @@ base_job_message = {
             'example': 900,
             'description': 'Time (in seconds) to wait before failing '
                            'on image conditions.'
-        }
+        },
+        'raw_image_upload_type': string_with_example('s3bucket'),
+        'raw_image_upload_location': string_with_example('my-bucket/prefix/'),
+        'raw_image_upload_account': string_with_example('my_aws_account')
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -48,8 +48,8 @@ class Defaults(object):
     @classmethod
     def get_service_names(self):
         return [
-            'obs', 'uploader', 'testing', 'replication', 'publisher',
-            'deprecation'
+            'obs', 'uploader', 'testing', 'raw_image_uploader', 'replication',
+            'publisher', 'deprecation'
         ]
 
     @staticmethod

--- a/mash/services/job_factory.py
+++ b/mash/services/job_factory.py
@@ -23,6 +23,7 @@ from mash.services.deprecation.gce_job import GCEDeprecationJob
 from mash.services.publisher.azure_job import AzurePublisherJob
 from mash.services.publisher.ec2_job import EC2PublisherJob
 from mash.services.publisher.gce_job import GCEPublisherJob
+from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob
 from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
 from mash.services.replication.gce_job import GCEReplicationJob
@@ -43,6 +44,9 @@ jobs = {
         'azure': AzurePublisherJob,
         'ec2': EC2PublisherJob,
         'gce': GCEPublisherJob
+    },
+    'raw_image_uploader': {
+        's3bucket': S3BucketUploaderJob
     },
     'replication': {
         'azure': AzureReplicationJob,
@@ -74,7 +78,12 @@ class JobFactory(object):
         Create new instance of job based on service exchange and cloud name,
         """
         try:
-            job_class = jobs[service_exchange][cloud]
+            if service_exchange == 'raw_image_uploader':
+                # raw image uploader job type depends on a separate parameter
+                # instead of the cloud framework
+                job_class = jobs['raw_image_uploader'][job_config['raw_image_upload_type']]
+            else:
+                job_class = jobs[service_exchange][cloud]
         except KeyError:
             raise MashJobException(
                 'Cloud {0} is not supported in {1} service.'.format(

--- a/mash/services/job_factory.py
+++ b/mash/services/job_factory.py
@@ -24,6 +24,7 @@ from mash.services.publisher.azure_job import AzurePublisherJob
 from mash.services.publisher.ec2_job import EC2PublisherJob
 from mash.services.publisher.gce_job import GCEPublisherJob
 from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob
+from mash.services.raw_image_uploader.skip_raw_image_uploader_job import SkipRawImageUploaderJob
 from mash.services.replication.azure_job import AzureReplicationJob
 from mash.services.replication.ec2_job import EC2ReplicationJob
 from mash.services.replication.gce_job import GCEReplicationJob
@@ -81,7 +82,10 @@ class JobFactory(object):
             if service_exchange == 'raw_image_uploader':
                 # raw image uploader job type depends on a separate parameter
                 # instead of the cloud framework
-                job_class = jobs['raw_image_uploader'][job_config['raw_image_upload_type']]
+                if job_config.get('raw_image_upload_type'):
+                    job_class = jobs['raw_image_uploader'][job_config['raw_image_upload_type']]
+                else:
+                    job_class = SkipRawImageUploaderJob
             else:
                 job_class = jobs[service_exchange][cloud]
         except KeyError:

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -59,6 +59,9 @@ class BaseJob(object):
         self.notification_email = kwargs.get('notification_email')
         self.notification_type = kwargs.get('notification_type', 'single')
         self.profile = kwargs.get('profile')
+        self.raw_image_upload_type = kwargs.get('raw_image_upload_type')
+        self.raw_image_upload_location = kwargs.get('raw_image_upload_location')
+        self.raw_image_upload_account = kwargs.get('raw_image_upload_account')
         self.kwargs = kwargs
 
         self.base_message = {
@@ -219,6 +222,23 @@ class BaseJob(object):
                 self.cloud_architecture
 
         return JsonFormat.json_message(uploader_message)
+
+    def get_raw_image_uploader_message(self):
+        """
+        Build raw image uploader job message.
+        """
+        raw_image_uploader_message = {
+            'raw_image_uploader_job': {
+                'cloud_image_name': self.cloud_image_name,
+                'cloud': self.cloud,
+                'raw_image_upload_type': self.raw_image_upload_type,
+                'raw_image_upload_account': self.raw_image_upload_account,
+                'raw_image_upload_location': self.raw_image_upload_location
+            }
+        }
+        raw_image_uploader_message['raw_image_uploader_job'].update(self.base_message)
+
+        return JsonFormat.json_message(raw_image_uploader_message)
 
     def get_uploader_regions(self):
         """

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -127,6 +127,10 @@ class JobCreatorService(MashService):
                 self.publish_job_doc(
                     'uploader', job.get_uploader_message()
                 )
+            elif service == 'raw_image_uploader':
+                self.publish_job_doc(
+                    'raw_image_uploader', job.get_raw_image_uploader_message()
+                )
 
             if service == job.last_service:
                 break

--- a/mash/services/raw_image_uploader/config.py
+++ b/mash/services/raw_image_uploader/config.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.base_config import BaseConfig
+
+
+class RawImageUploaderConfig(BaseConfig):
+    """
+    Implements reading of raw image uploader configuration from the mash
+    configuration file:
+
+    * /etc/mash/mash_config.yaml
+
+    The mash configuration file is a yaml formatted file containing
+    information to control the behavior of the mash services.
+    """
+
+    def __init__(self, config_file=None):
+        super(RawImageUploaderConfig, self).__init__(config_file)

--- a/mash/services/raw_image_uploader/s3bucket_job.py
+++ b/mash/services/raw_image_uploader/s3bucket_job.py
@@ -31,6 +31,7 @@ class S3BucketUploaderJob(MashJob):
     """
 
     def post_init(self):
+        self.cloud = 'ec2'
         self.image_file = None
         self._image_size = 0
         self._total_bytes_transferred = 0
@@ -60,16 +61,12 @@ class S3BucketUploaderJob(MashJob):
                 progress=str(self._last_percentage_logged)
             ))
 
-    def _get_credentials(self):
-        # FIXME: get credentials from API
-        credentials = {'access_key_id': None, 'secret_access_key': None}
-        return credentials
-
     def run_job(self):
         self.status = SUCCESS
         self.send_log('Uploading raw image.')
 
-        credentials = self._get_credentials()
+        self.request_credentials([self.account])
+        credentials = self.credentials[self.account]
 
         bucket_name, key_name = str.split(self.location, '/', 1)
         if key_name[-1] == '/':

--- a/mash/services/raw_image_uploader/s3bucket_job.py
+++ b/mash/services/raw_image_uploader/s3bucket_job.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2019 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from os import stat, path
+
+# project
+from mash.services.mash_job import MashJob
+from mash.mash_exceptions import MashUploadException
+from mash.utils.ec2 import get_client
+from mash.services.status_levels import SUCCESS
+
+
+class S3BucketUploaderJob(MashJob):
+    """
+    Implements raw image upload to Amazon S3 bucket
+    """
+
+    def post_init(self):
+        self.image_file = None
+        self._image_size = 0
+        self._total_bytes_transferred = 0
+        self._last_percentage_logged = 0
+        self._percentage_log_step = 20
+
+        try:
+            self.account = self.job_config['raw_image_upload_account']
+            self.location = self.job_config['raw_image_upload_location']
+        except KeyError as error:
+            raise MashUploadException(
+                'S3 bucket uploader jobs require a(n) {0} '
+                'key in the job doc.'.format(
+                    error
+                )
+            )
+
+    def _log_progress(self, bytes_transferred):
+        self._total_bytes_transferred += bytes_transferred
+        percent_transferred = (self._total_bytes_transferred * 100) / self._image_size
+        if percent_transferred >= \
+           (self._last_percentage_logged + self._percentage_log_step):
+            self._last_percentage_logged = int(
+                percent_transferred - (percent_transferred % self._percentage_log_step)
+            )
+            self.send_log('Raw image {progress}% uploaded.'.format(
+                progress=str(self._last_percentage_logged)
+            ))
+
+    def _get_credentials(self):
+        # FIXME: get credentials from API
+        credentials = {'access_key_id': None, 'secret_access_key': None}
+        return credentials
+
+    def run_job(self):
+        self.status = SUCCESS
+        self.send_log('Uploading raw image.')
+
+        credentials = self._get_credentials()
+
+        bucket_name, key_name = str.split(self.location, '/', 1)
+        if key_name[-1] == '/':
+            # take suffix from file name, should always consist of two parts
+            suffix = '.'.join(str.split(self.image_file, '.')[-2:])
+            key_name += '{}.{}'.format(
+                path.basename(self.cloud_image_name),
+                suffix
+            )
+
+        try:
+            statinfo = stat(self.image_file)
+            self._image_size = statinfo.st_size
+
+            client = get_client(
+                's3', credentials['access_key_id'],
+                credentials['secret_access_key'], None
+            )
+
+            client.upload_file(
+                self.image_file,
+                bucket_name,
+                key_name,
+                Callback=self._log_progress
+            )
+
+        except Exception as e:
+            raise MashUploadException(
+                'Raw upload to S3 bucket failed with: {0}'.format(e)
+            )

--- a/mash/services/raw_image_uploader/skip_raw_image_uploader_job.py
+++ b/mash/services/raw_image_uploader/skip_raw_image_uploader_job.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+# project
+from mash.services.mash_job import MashJob
+from mash.services.status_levels import SUCCESS
+
+
+class SkipRawImageUploaderJob(MashJob):
+    """
+    Does nothing but skip to next service
+    """
+
+    def post_init(self):
+        pass
+
+    def run_job(self):
+        self.status = SUCCESS
+        self.send_log('Skipping raw image upload.')

--- a/mash/services/raw_image_uploader_service.py
+++ b/mash/services/raw_image_uploader_service.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 SUSE Software Solutions Germany GmbH. All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+import sys
+import traceback
+
+# project
+from mash.mash_exceptions import MashException
+from mash.services.listener_service import ListenerService
+
+
+def main():
+    """
+    mash - uploader service application entry point
+    """
+    try:
+        logging.basicConfig()
+        log = logging.getLogger('MashService')
+        log.setLevel(logging.DEBUG)
+        # run service, enter main loop
+        ListenerService(
+            service_exchange='raw_image_uploader',
+            custom_args={
+                'listener_msg_args': ['cloud_image_name', 'image_file'],
+                'status_msg_args': ['cloud_image_name', 'source_regions']
+            }
+        )
+    except MashException as e:
+        # known exception
+        log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        traceback.print_exc()
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
+    except SystemExit:
+        # user exception, program aborted by user
+        sys.exit(0)
+    except Exception as e:
+        # exception we did no expect, show python backtrace
+        log.error('Unexpected error: {0}'.format(e))
+        traceback.print_exc()
+        sys.exit(1)

--- a/mash/services/raw_image_uploader_service.py
+++ b/mash/services/raw_image_uploader_service.py
@@ -37,7 +37,7 @@ def main():
             service_exchange='raw_image_uploader',
             custom_args={
                 'listener_msg_args': ['cloud_image_name', 'image_file'],
-                'status_msg_args': ['cloud_image_name', 'source_regions']
+                'status_msg_args': ['source_regions']
             }
         )
     except MashException as e:

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -83,6 +83,8 @@ class EC2TestingJob(MashJob):
         if not os.path.exists(self.ssh_private_key_file):
             create_ssh_key_pair(self.ssh_private_key_file)
 
+        self.image_file = None
+
     def run_job(self):
         """
         Tests image with img-proof and update status and results.

--- a/mash/services/testing_service.py
+++ b/mash/services/testing_service.py
@@ -39,7 +39,7 @@ def main():
             service_exchange='testing',
             custom_args={
                 'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
-                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
+                'status_msg_args': ['source_regions', 'image_file']
             }
         )
     except MashException as e:

--- a/mash/services/testing_service.py
+++ b/mash/services/testing_service.py
@@ -38,8 +38,8 @@ def main():
         ListenerService(
             service_exchange='testing',
             custom_args={
-                'listener_msg_args': ['cloud_image_name', 'source_regions'],
-                'status_msg_args': ['source_regions']
+                'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
+                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
             }
         )
     except MashException as e:

--- a/mash/services/uploader_service.py
+++ b/mash/services/uploader_service.py
@@ -37,7 +37,7 @@ def main():
             service_exchange='uploader',
             custom_args={
                 'listener_msg_args': ['image_file'],
-                'status_msg_args': ['source_regions']
+                'status_msg_args': ['source_regions', 'image_file']
             }
         )
     except MashException as e:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ config = {
             'mash-uploader-service=mash.services.uploader_service:main',
             'mash-replication-service=mash.services.replication_service:main',
             'mash-publisher-service=mash.services.publisher_service:main',
-            'mash-deprecation-service=mash.services.deprecation_service:main'
+            'mash-deprecation-service=mash.services.deprecation_service:main',
+            'mash-raw-image-uploader-service=mash.services.raw_image_uploader_service:main'
         ]
     },
     'include_package_data': True,

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -32,5 +32,8 @@
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
   "publish_offer": true,
-  "cleanup_images": true
+  "cleanup_images": true,
+  "raw_image_upload_type": "s3bucket",
+  "raw_image_upload_account": "account",
+  "raw_image_upload_location": "location"
 }

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -21,5 +21,8 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_email": "test@fake.com"
+  "notification_email": "test@fake.com",
+  "raw_image_upload_type": "s3bucket",
+  "raw_image_upload_account": "account",
+  "raw_image_upload_location": "location"
 }

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -26,5 +26,8 @@
   "cloud_architecture": "aarch64",
   "notification_email": "test@fake.com",
   "profile": "Proxy",
-  "conditions_wait_time": 500
+  "conditions_wait_time": 500,
+  "raw_image_upload_type": "s3bucket",
+  "raw_image_upload_account": "account",
+  "raw_image_upload_location": "location"
 }

--- a/test/unit/services/base/config_factory_test.py
+++ b/test/unit/services/base/config_factory_test.py
@@ -8,6 +8,7 @@ from mash.services.jobcreator.config import JobCreatorConfig
 from mash.services.logger.config import LoggerConfig
 from mash.services.obs.config import OBSConfig
 from mash.services.publisher.config import PublisherConfig
+from mash.services.raw_image_uploader.config import RawImageUploaderConfig
 from mash.services.replication.config import ReplicationConfig
 from mash.services.testing.config import TestingConfig
 from mash.services.uploader.config import UploaderConfig
@@ -21,6 +22,7 @@ from mash.services.uploader.config import UploaderConfig
         ('logger', LoggerConfig),
         ('obs', OBSConfig),
         ('publisher', PublisherConfig),
+        ('raw_image_uploader', RawImageUploaderConfig),
         ('replication', ReplicationConfig),
         ('testing', TestingConfig),
         ('uploader', UploaderConfig)

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -43,8 +43,8 @@ class TestBaseConfig(object):
     def test_get_services_names(self):
         # Services requiring credentials
         expected = [
-            'uploader', 'testing', 'replication', 'publisher',
-            'deprecation'
+            'uploader', 'testing', 'raw_image_uploader', 'replication',
+            'publisher', 'deprecation'
         ]
         services = self.empty_config.get_service_names(
             credentials_required=True

--- a/test/unit/services/base/job_factory_test.py
+++ b/test/unit/services/base/job_factory_test.py
@@ -4,6 +4,7 @@ from mash.services.job_factory import JobFactory
 from mash.mash_exceptions import MashJobException
 from mash.services.testing.gce_job import GCETestingJob
 from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob
+from mash.services.raw_image_uploader.skip_raw_image_uploader_job import SkipRawImageUploaderJob
 
 
 @patch.object(GCETestingJob, '__init__')
@@ -23,6 +24,7 @@ def test_job_factory_create(mock_job_init):
         'raw_image_upload_account': 'account',
         'raw_image_upload_location': 'location',
         'id': '123',
+        'requesting_user': 'user1',
         'last_service': 'raw_image_uploader',
         'cloud': 'gce',
         'utctime': 'now'
@@ -31,6 +33,18 @@ def test_job_factory_create(mock_job_init):
         'gce', 'raw_image_uploader', job_config, service_config
     )
     assert isinstance(value, S3BucketUploaderJob)
+
+    job_config = {
+        'id': '123',
+        'requesting_user': 'user1',
+        'last_service': 'raw_image_uploader',
+        'cloud': 'gce',
+        'utctime': 'now'
+    }
+    value = JobFactory.create_job(
+        'gce', 'raw_image_uploader', job_config, service_config
+    )
+    assert isinstance(value, SkipRawImageUploaderJob)
 
 def test_job_factory_create_invalid_cloud():
     service_config = Mock()

--- a/test/unit/services/base/job_factory_test.py
+++ b/test/unit/services/base/job_factory_test.py
@@ -46,6 +46,7 @@ def test_job_factory_create(mock_job_init):
     )
     assert isinstance(value, SkipRawImageUploaderJob)
 
+
 def test_job_factory_create_invalid_cloud():
     service_config = Mock()
     job_config = {}

--- a/test/unit/services/base/job_factory_test.py
+++ b/test/unit/services/base/job_factory_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from mash.services.job_factory import JobFactory
 from mash.mash_exceptions import MashJobException
 from mash.services.testing.gce_job import GCETestingJob
+from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob
 
 
 @patch.object(GCETestingJob, '__init__')
@@ -17,6 +18,19 @@ def test_job_factory_create(mock_job_init):
     )
     assert isinstance(value, GCETestingJob)
 
+    job_config = {
+        'raw_image_upload_type': 's3bucket',
+        'raw_image_upload_account': 'account',
+        'raw_image_upload_location': 'location',
+        'id': '123',
+        'last_service': 'raw_image_uploader',
+        'cloud': 'gce',
+        'utctime': 'now'
+    }
+    value = JobFactory.create_job(
+        'gce', 'raw_image_uploader', job_config, service_config
+    )
+    assert isinstance(value, S3BucketUploaderJob)
 
 def test_job_factory_create_invalid_cloud():
     service_config = Mock()

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -30,8 +30,8 @@ class TestBaseService(object):
 
         config = Mock()
         config.get_service_names.return_value = [
-            'obs', 'uploader', 'testing', 'replication', 'publisher',
-            'deprecation'
+            'obs', 'uploader', 'testing', 'raw_image_uploader' 'replication',
+            'publisher', 'deprecation'
         ]
         mock_get_configuration.return_value = config
 

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -34,7 +34,7 @@ class TestJobCreatorService(object):
         self.jobcreator.service_queue = 'service'
         self.jobcreator.job_document_key = 'job_document'
         self.jobcreator.services = [
-            'obs', 'uploader', 'testing', 'replication',
+            'obs', 'uploader', 'testing', 'raw_image_uploader', 'replication',
             'publisher', 'deprecation'
         ]
 
@@ -152,9 +152,17 @@ class TestJobCreatorService(object):
                 assert region == 'us-gov-west-1'
                 assert info['account'] == 'test-aws-gov'
 
+        # Raw Image Uploader Job Doc
+
+        data = json.loads(mock_publish.mock_calls[3][1][2])['raw_image_uploader_job']
+        check_base_attrs(data)
+        assert data['raw_image_upload_type'] == 's3bucket'
+        assert data['raw_image_upload_account'] == 'account'
+        assert data['raw_image_upload_location'] == 'location'
+
         # Replication Job Doc
 
-        data = json.loads(mock_publish.mock_calls[3][1][2])['replication_job']
+        data = json.loads(mock_publish.mock_calls[4][1][2])['replication_job']
         check_base_attrs(data)
         assert data['image_description'] == 'New Image #123'
 
@@ -171,7 +179,7 @@ class TestJobCreatorService(object):
 
         # Publisher Job Doc
 
-        data = json.loads(mock_publish.mock_calls[4][1][2])['publisher_job']
+        data = json.loads(mock_publish.mock_calls[5][1][2])['publisher_job']
         check_base_attrs(data)
         assert data['allow_copy'] is False
         assert data['share_with'] == 'all'
@@ -189,7 +197,7 @@ class TestJobCreatorService(object):
 
         # Deprecation Job Doc
 
-        data = json.loads(mock_publish.mock_calls[5][1][2])['deprecation_job']
+        data = json.loads(mock_publish.mock_calls[6][1][2])['deprecation_job']
         check_base_attrs(data)
         assert data['old_cloud_image_name'] == 'old_new_image_123'
 
@@ -297,9 +305,17 @@ class TestJobCreatorService(object):
                 assert region == 'southcentralus'
                 assert info['account'] == 'test-azure'
 
+        # Raw Image Uploader Job Doc
+
+        data = json.loads(mock_publish.mock_calls[3][1][2])['raw_image_uploader_job']
+        check_base_attrs(data)
+        assert data['raw_image_upload_type'] == 's3bucket'
+        assert data['raw_image_upload_account'] == 'account'
+        assert data['raw_image_upload_location'] == 'location'
+
         # Replication Job Doc
 
-        data = json.loads(mock_publish.mock_calls[3][1][2])['replication_job']
+        data = json.loads(mock_publish.mock_calls[4][1][2])['replication_job']
         check_base_attrs(data)
         assert data['cleanup_images']
         assert data['image_description'] == 'New Image #123'
@@ -325,7 +341,7 @@ class TestJobCreatorService(object):
 
         # Publisher Job Doc
 
-        data = json.loads(mock_publish.mock_calls[4][1][2])['publisher_job']
+        data = json.loads(mock_publish.mock_calls[5][1][2])['publisher_job']
         check_base_attrs(data)
         assert data['emails'] == 'jdoe@fake.com'
         assert data['image_description'] == 'New Image #123'
@@ -348,7 +364,7 @@ class TestJobCreatorService(object):
 
         # Deprecation Job Doc
 
-        data = json.loads(mock_publish.mock_calls[5][1][2])['deprecation_job']
+        data = json.loads(mock_publish.mock_calls[6][1][2])['deprecation_job']
         check_base_attrs(data)
 
     @patch.object(JobCreatorService, '_publish')
@@ -447,19 +463,27 @@ class TestJobCreatorService(object):
                 assert info['testing_account'] == 'testacnt1'
                 assert info['is_publishing_account']
 
+        # Raw Image Uploader Job Doc
+
+        data = json.loads(mock_publish.mock_calls[3][1][2])['raw_image_uploader_job']
+        check_base_attrs(data)
+        assert data['raw_image_upload_type'] == 's3bucket'
+        assert data['raw_image_upload_account'] == 'account'
+        assert data['raw_image_upload_location'] == 'location'
+
         # Replication Job Doc
 
-        data = json.loads(mock_publish.mock_calls[3][1][2])['replication_job']
+        data = json.loads(mock_publish.mock_calls[4][1][2])['replication_job']
         check_base_attrs(data)
 
         # Publisher Job Doc
 
-        data = json.loads(mock_publish.mock_calls[4][1][2])['publisher_job']
+        data = json.loads(mock_publish.mock_calls[5][1][2])['publisher_job']
         check_base_attrs(data)
 
         # Deprecation Job Doc
 
-        data = json.loads(mock_publish.mock_calls[5][1][2])['deprecation_job']
+        data = json.loads(mock_publish.mock_calls[6][1][2])['publisher_job']
         check_base_attrs(data)
         assert data['old_cloud_image_name'] == 'old_new_image_123'
         assert 'test-gce' in data['deprecation_accounts']

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -483,7 +483,7 @@ class TestJobCreatorService(object):
 
         # Deprecation Job Doc
 
-        data = json.loads(mock_publish.mock_calls[6][1][2])['publisher_job']
+        data = json.loads(mock_publish.mock_calls[6][1][2])['deprecation_job']
         check_base_attrs(data)
         assert data['old_cloud_image_name'] == 'old_new_image_123'
         assert 'test-gce' in data['deprecation_accounts']

--- a/test/unit/services/raw_image_uploader/config_test.py
+++ b/test/unit/services/raw_image_uploader/config_test.py
@@ -1,0 +1,21 @@
+from pytest import raises
+from test.unit.test_helper import patch_open
+
+from mash.mash_exceptions import MashConfigException
+from mash.services.raw_image_uploader.config import RawImageUploaderConfig
+
+
+class TestRawImagerUploaderConfig(object):
+    def setup(self):
+        self.config = RawImageUploaderConfig(
+            '../data/mash_config.yaml'
+        )
+        self.config_defaults = RawImageUploaderConfig(
+            '../data/empty_mash_config.yaml'
+        )
+
+    @patch_open
+    def test_init_error(self, mock_open):
+        mock_open.side_effect = Exception
+        with raises(MashConfigException):
+            RawImageUploaderConfig('../data/mash_config.yaml')

--- a/test/unit/services/raw_image_uploader/config_test.py
+++ b/test/unit/services/raw_image_uploader/config_test.py
@@ -8,14 +8,14 @@ from mash.services.raw_image_uploader.config import RawImageUploaderConfig
 class TestRawImagerUploaderConfig(object):
     def setup(self):
         self.config = RawImageUploaderConfig(
-            '../data/mash_config.yaml'
+            'test/data/mash_config.yaml'
         )
         self.config_defaults = RawImageUploaderConfig(
-            '../data/empty_mash_config.yaml'
+            'test/data/empty_mash_config.yaml'
         )
 
     @patch_open
     def test_init_error(self, mock_open):
         mock_open.side_effect = Exception
         with raises(MashConfigException):
-            RawImageUploaderConfig('../data/mash_config.yaml')
+            RawImageUploaderConfig('test/data/mash_config.yaml')

--- a/test/unit/services/raw_image_uploader/main_test.py
+++ b/test/unit/services/raw_image_uploader/main_test.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+from unittest.mock import Mock
+
+from mash.mash_exceptions import MashException
+from mash.services.raw_image_uploader_service import main
+
+
+class TestRawImageUploader(object):
+    def setup(self):
+        self.config = Mock()
+        self.config.get_log_file = Mock(
+            return_value='/tmp/raw_image_uploader_service.log'
+        )
+
+    @patch('mash.services.raw_image_uploader_service.ListenerService')
+    def test_main(self, mock_RawUploadImageService):
+        main()
+        mock_RawUploadImageService.assert_called_once_with(
+            custom_args={
+                'listener_msg_args': ['cloud_image_name', 'image_file'],
+                'status_msg_args': ['cloud_image_name', 'source_regions']
+            },
+            service_exchange='raw_image_uploader'
+        )
+
+    @patch('mash.services.raw_image_uploader_service.ListenerService')
+    @patch('sys.exit')
+    def test_main_mash_error(
+        self, mock_exit, mock_RawUploadImageService
+    ):
+        mock_RawUploadImageService.side_effect = MashException('error')
+        main()
+        mock_exit.assert_called_once_with(1)
+
+    @patch('mash.services.raw_image_uploader_service.ListenerService')
+    @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+        self, mock_exit, mock_RawUploadImageService
+    ):
+        mock_RawUploadImageService.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.raw_image_uploader_service.ListenerService')
+    @patch('sys.exit')
+    def test_main_system_exit(
+        self, mock_exit, mock_RawUploadImageService
+    ):
+        mock_RawUploadImageService.side_effect = SystemExit
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.raw_image_uploader_service.ListenerService')
+    @patch('sys.exit')
+    def test_main_unexpected_error(
+        self, mock_exit, mock_RawUploadImageService
+    ):
+        mock_RawUploadImageService.side_effect = Exception
+        main()
+        mock_exit.assert_called_once_with(1)

--- a/test/unit/services/raw_image_uploader/main_test.py
+++ b/test/unit/services/raw_image_uploader/main_test.py
@@ -18,7 +18,7 @@ class TestRawImageUploader(object):
         mock_RawUploadImageService.assert_called_once_with(
             custom_args={
                 'listener_msg_args': ['cloud_image_name', 'image_file'],
-                'status_msg_args': ['cloud_image_name', 'source_regions']
+                'status_msg_args': ['source_regions']
             },
             service_exchange='raw_image_uploader'
         )

--- a/test/unit/services/raw_image_uploader/s3bucket_job_test.py
+++ b/test/unit/services/raw_image_uploader/s3bucket_job_test.py
@@ -2,7 +2,7 @@ from pytest import raises
 from unittest.mock import Mock, patch
 
 from test.unit.test_helper import (
-    patch_open, context_manager
+    patch_open
 )
 
 from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob

--- a/test/unit/services/raw_image_uploader/s3bucket_job_test.py
+++ b/test/unit/services/raw_image_uploader/s3bucket_job_test.py
@@ -13,7 +13,7 @@ from mash.services.raw_image_uploader.config import RawImageUploaderConfig
 class TestS3BucketUploaderJob(object):
     def setup(self):
         self.config = RawImageUploaderConfig(
-            config_file='../data/mash_config.yaml'
+            config_file='test/data/mash_config.yaml'
         )
 
         self.credentials = {

--- a/test/unit/services/raw_image_uploader/s3bucket_job_test.py
+++ b/test/unit/services/raw_image_uploader/s3bucket_job_test.py
@@ -1,0 +1,103 @@
+from pytest import raises
+from unittest.mock import Mock, patch
+
+from test.unit.test_helper import (
+    patch_open, context_manager
+)
+
+from mash.services.raw_image_uploader.s3bucket_job import S3BucketUploaderJob
+from mash.mash_exceptions import MashUploadException
+from mash.services.raw_image_uploader.config import RawImageUploaderConfig
+
+
+class TestS3BucketUploaderJob(object):
+    def setup(self):
+        self.config = RawImageUploaderConfig(
+            config_file='../data/mash_config.yaml'
+        )
+
+        self.credentials = {
+            'test': {
+                'access_key_id': 'access-key',
+                'secret_access_key': 'secret-access-key'
+            }
+        }
+        job_doc = {
+            'cloud_architecture': 'x86_64',
+            'id': '1',
+            'last_service': 'raw_image_uploader',
+            'cloud': 'ec2',
+            'requesting_user': 'user1',
+            'utctime': 'now',
+            'target_regions': {
+                'us-east-1': {
+                    'account': 'test',
+                    'helper_image': 'ami-bc5b48d0',
+                    'billing_codes': None,
+                    'use_root_swap': False,
+                    'subnet': 'subnet-123456789'
+                }
+            },
+            'cloud_image_name': 'name',
+            'image_description': 'description',
+            'raw_image_upload_type': 's3bucket',
+            'raw_image_upload_location': 'my-bucket/some-prefix/',
+            'raw_image_upload_account': 'test'
+        }
+        self.job = S3BucketUploaderJob(job_doc, self.config)
+        self.job.image_file = 'file.raw.gz'
+        self.job.cloud_image_name = 'name'
+        self.job.credentials = self.credentials
+
+    def test_post_init_incomplete_arguments(self):
+        job_doc = {
+            'id': '1',
+            'last_service': 'raw_image_uploader',
+            'requesting_user': 'user1',
+            'cloud': 'ec2',
+            'utctime': 'now'
+        }
+
+        with raises(MashUploadException):
+            S3BucketUploaderJob(job_doc, self.config)
+
+        job_doc['cloud_image_name'] = 'name'
+        with raises(MashUploadException):
+            S3BucketUploaderJob(job_doc, self.config)
+
+    @patch('mash.services.raw_image_uploader.s3bucket_job.stat')
+    @patch('mash.services.raw_image_uploader.s3bucket_job.get_client')
+    @patch_open
+    def test_upload(
+        self, mock_request_credentials, mock_get_client, mock_stat
+    ):
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        stat_info = Mock()
+        stat_info.st_size = 100
+        mock_stat.return_value = stat_info
+
+        self.job.run_job()
+        mock_get_client.assert_called_once_with(
+            's3', 'access-key', 'secret-access-key', None,
+        )
+        mock_client.upload_file.assert_called_once_with(
+            'file.raw.gz',
+            'my-bucket',
+            'some-prefix/name.raw.gz',
+            Callback=self.job._log_progress
+        )
+
+        mock_client.upload_file.side_effect = Exception
+
+        with raises(MashUploadException):
+            self.job.run_job()
+
+    @patch.object(S3BucketUploaderJob, 'send_log')
+    def test_log_progress(self, mock_send_log):
+        self.job._image_size = 100
+        self.job._log_progress(100)
+        mock_send_log.assert_called_once_with(
+            'Raw image 100% uploaded.'
+        )

--- a/test/unit/services/raw_image_uploader/skip_raw_image_uploader_job_test.py
+++ b/test/unit/services/raw_image_uploader/skip_raw_image_uploader_job_test.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock
+
+from mash.services.raw_image_uploader.skip_raw_image_uploader_job import SkipRawImageUploaderJob
+
+
+class TestSkipRawImageUploaderJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'last_service': 'raw_image_uploader',
+            'requesting_user': 'user1',
+            'cloud': 'gce',
+            'utctime': 'now'
+        }
+        self.config = Mock()
+        self.job = SkipRawImageUploaderJob(self.job_config, self.config)
+
+    def test_replicate(self):
+        self.job.run_job()

--- a/test/unit/services/testing/main_test.py
+++ b/test/unit/services/testing/main_test.py
@@ -11,8 +11,8 @@ class TestImgProofTestingServiceMain(object):
         mock_testing_service.assert_called_once_with(
             service_exchange='testing',
             custom_args={
-                'listener_msg_args': ['cloud_image_name', 'source_regions'],
-                'status_msg_args': ['source_regions']
+                'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
+                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
             }
         )
 
@@ -26,8 +26,8 @@ class TestImgProofTestingServiceMain(object):
         mock_testing_service.assert_called_once_with(
             service_exchange='testing',
             custom_args={
-                'listener_msg_args': ['cloud_image_name', 'source_regions'],
-                'status_msg_args': ['source_regions']
+                'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
+                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
             }
         )
         mock_exit.assert_called_once_with(1)

--- a/test/unit/services/testing/main_test.py
+++ b/test/unit/services/testing/main_test.py
@@ -12,7 +12,7 @@ class TestImgProofTestingServiceMain(object):
             service_exchange='testing',
             custom_args={
                 'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
-                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
+                'status_msg_args': ['source_regions', 'image_file']
             }
         )
 
@@ -27,7 +27,7 @@ class TestImgProofTestingServiceMain(object):
             service_exchange='testing',
             custom_args={
                 'listener_msg_args': ['cloud_image_name', 'image_file', 'source_regions'],
-                'status_msg_args': ['source_regions', 'image_file', 'cloud_image_name']
+                'status_msg_args': ['source_regions', 'image_file']
             }
         )
         mock_exit.assert_called_once_with(1)

--- a/test/unit/services/uploader/main_test.py
+++ b/test/unit/services/uploader/main_test.py
@@ -18,7 +18,7 @@ class TestUploader(object):
         mock_UploadImageService.assert_called_once_with(
             custom_args={
                 'listener_msg_args': ['image_file'],
-                'status_msg_args': ['source_regions']
+                'status_msg_args': ['source_regions', 'image_file']
             },
             service_exchange='uploader'
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
This adds a service to upload raw image files to a specified location. Only supported job type at the moment supports uploading to an S3 bucket using the credentials from a specified AWS account.
