### PR TITLE
Add email whitelist config option.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -83,3 +83,5 @@ uploader:
   azure:
     max_retry_attempts: 5
     max_workers: 8
+email_whitelist:
+  emails@to.allow.com

--- a/mash/services/api/config.py
+++ b/mash/services/api/config.py
@@ -67,3 +67,7 @@ class Config(object):
     @property
     def SQLALCHEMY_DATABASE_URI(self):
         return self.config.get_database_uri()
+
+    @property
+    def EMAIL_WHITELIST(self):
+        return self.config.get_email_whitelist()

--- a/mash/services/api/utils/users.py
+++ b/mash/services/api/utils/users.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
 from mash.services.api.extensions import db
@@ -32,6 +33,12 @@ def add_user(username, email, password):
     if len(password) < 8:
         raise MashDBException(
             'Password too short. Minimum length is 8 characters.'
+        )
+
+    whitelist = current_app.config['EMAIL_WHITELIST']
+    if whitelist and email not in whitelist:
+        raise MashDBException(
+            'Cannot create a user with the provided email. Access denied.'
         )
 
     user = User(

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -315,3 +315,15 @@ class BaseConfig(object):
             )
 
         return database_uri
+
+    def get_email_whitelist(self):
+        """
+        Return the list of whitelisted emails if it's configured.
+
+        :rtype: list of strings
+        """
+        email_whitelist = self._get_attribute(
+            attribute='email_whitelist'
+        )
+
+        return email_whitelist or Defaults.get_email_whitelist()

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -95,3 +95,7 @@ class Defaults(object):
     @staticmethod
     def get_credentials_url():
         return 'http://localhost:8080/'
+
+    @staticmethod
+    def get_email_whitelist():
+        return []

--- a/test/unit/services/api/utils/user_utils_test.py
+++ b/test/unit/services/api/utils/user_utils_test.py
@@ -13,8 +13,10 @@ from mash.services.api.utils.users import (
 )
 
 
+@patch('mash.services.api.utils.users.current_app')
 @patch('mash.services.api.utils.users.db')
-def test_add_user(mock_db):
+def test_add_user(mock_db, mock_current_app):
+    mock_current_app.config = {'EMAIL_WHITELIST': ['user1@fake.com']}
     user = add_user('user1', 'user1@fake.com', 'password123')
 
     assert user.username == 'user1'
@@ -30,6 +32,10 @@ def test_add_user(mock_db):
 
     with raises(MashDBException):
         add_user('user1', 'user1@fake.com', 'pass')
+
+    mock_current_app.config = {'EMAIL_WHITELIST': ['user2@fake.com']}
+    with raises(MashDBException):
+        add_user('user1', 'user1@fake.com', 'password123')
 
 
 @patch('mash.services.api.utils.users.get_user_by_username')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If a list of emails is provided only those emails can be used to create a mash user. Otherwise all emails can be used.