### PR TITLE
Move send email methods to new class.

### DIFF
--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -296,7 +296,7 @@ class ListenerService(MashService):
                 and job.last_service != self.service_exchange:
             self._publish_message(job)
 
-        self.send_email_notification(
+        self.send_notification(
             job.id, job.notification_email, job.notification_type, job.status,
             job.utctime, job.last_service, job.cloud_image_name,
             job.iteration_count, event.exception

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -264,7 +264,7 @@ class OBSImageBuildResultService(MashService):
 
         job_worker = OBSImageBuildResult(**kwargs)
         job_worker.set_result_handler(self._send_job_result_for_uploader)
-        job_worker.set_notification_handler(self.send_email_notification)
+        job_worker.set_notification_handler(self.send_notification)
         job_worker.start_watchdog(
             nonstop=nonstop, isotime=time
         )

--- a/mash/utils/email_notification.py
+++ b/mash/utils/email_notification.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import smtplib
+
+from email.message import EmailMessage
+
+
+class EmailNotification(object):
+    """
+    For sending job notification emails.
+    """
+
+    def __init__(self, host, port, user, password, subject, ssl, log_callback=None):
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.subject = subject
+        self.log_callback = log_callback
+
+        if ssl:
+            self.smtp_class = smtplib.SMTP_SSL
+        else:
+            self.smtp_class = smtplib.SMTP
+
+    def _create_email_message(self, msg, to_email):
+        """
+        Return notification email message object.
+        """
+        email_msg = EmailMessage()
+
+        email_msg['Subject'] = self.subject
+        email_msg['From'] = self.user
+        email_msg['To'] = to_email
+
+        email_msg.set_content(msg)
+
+        return email_msg
+
+    def _send_email(self, email_msg):
+        """
+        Send email message using smtp server.
+
+        :param email_msg:  email.message.EmailMessage
+        """
+        try:
+            smtp_server = self.smtp_class(self.host, self.port)
+
+            if self.user and self.password:
+                smtp_server.login(self.user, self.password)
+
+            smtp_server.send_message(email_msg)
+        except Exception as error:
+            if self.log_callback:
+                self.log_callback.warning(
+                    'Unable to send notification email: {0}'.format(error)
+                )
+
+    def send_notification(self, content, notification_email):
+        """
+        Send job notification email.
+        """
+        email_msg = self._create_email_message(content, notification_email)
+        self._send_email(email_msg)

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -308,7 +308,7 @@ class TestListenerService(object):
             ' line 1 column 1 (char 0).'
         )
 
-    @patch.object(ListenerService, 'send_email_notification')
+    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_service_process_job_result(
@@ -340,7 +340,7 @@ class TestListenerService(object):
         mock_publish_message.assert_called_once_with(job)
         msg.ack.assert_called_once_with()
 
-    @patch.object(ListenerService, 'send_email_notification')
+    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_service_process_job_result_exception(
@@ -367,7 +367,7 @@ class TestListenerService(object):
         )
         mock_publish_message.assert_called_once_with(job)
 
-    @patch.object(ListenerService, 'send_email_notification')
+    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_publishing_process_job_result_fail(

--- a/test/unit/utils/email_notification_test.py
+++ b/test/unit/utils/email_notification_test.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch, MagicMock
+
+from mash.utils.email_notification import EmailNotification
+
+
+@patch('mash.utils.email_notification.smtplib')
+def test_send_email_notification(mock_smtp):
+    to = 'test@fake.com'
+    content = 'Some job info in an email'
+    host = 'localhost'
+    port = 25
+    subject = '[MASH] Job Status Update'
+
+    log = MagicMock()
+    smtp_server = MagicMock()
+
+    mock_smtp.SMTP_SSL.return_value = smtp_server
+    mock_smtp.SMTP.return_value = smtp_server
+
+    notif_class = EmailNotification(
+        host,
+        port,
+        to,
+        None,
+        subject,
+        False,
+        log_callback=log
+    )
+
+    # Send email without SSL
+    notif_class.send_notification(content, to)
+    assert smtp_server.send_message.call_count == 1
+
+    notif_class = EmailNotification(
+        host,
+        port,
+        to,
+        'super.secret',
+        subject,
+        True,
+        log_callback=log
+    )
+
+    # Send email with SSL
+    notif_class.send_notification(content, to)
+    assert smtp_server.send_message.call_count == 2
+
+    # Send error
+    smtp_server.send_message.side_effect = Exception('Broke!')
+    notif_class.send_notification(content, to)
+
+    log.warning.assert_called_once_with(
+        'Unable to send notification email: Broke!'
+    )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Methods specific to sending emails move to a new class to make notifications types injectable in the future.

The mash service still builds the notification message content.