### PR TITLE
Add flask mgmt command for cleanup tokens.

### DIFF
--- a/mash/services/api/app.py
+++ b/mash/services/api/app.py
@@ -43,6 +43,8 @@ from mash.services.api.routes.jobs.ec2 import api as ec2_jobs_api
 from mash.services.api.routes.jobs.gce import api as gce_jobs_api
 from mash.services.api.routes.jobs.azure import api as azure_jobs_api
 
+from mash.services.api.commands import tokens_cli
+
 
 @jwt.token_in_blacklist_loader
 def check_if_token_in_blacklist(decoded_token):
@@ -57,6 +59,7 @@ def create_app(config_object):
     app.config.from_object(config_object)
     register_extensions(app)
     register_namespaces()
+    register_commands(app)
     configure_logger(app)
     return app
 
@@ -108,3 +111,8 @@ def register_extensions(app):
 
     # Required for flask-restplus to play nicely with flask-jwt-extended
     jwt._set_error_handler_callbacks(api)
+
+
+def register_commands(app):
+    """Register Click commands."""
+    app.cli.add_command(tokens_cli)

--- a/mash/services/api/commands.py
+++ b/mash/services/api/commands.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import click
+
+from flask.cli import AppGroup, with_appcontext
+from mash.services.api.utils.tokens import prune_expired_tokens
+
+tokens_cli = AppGroup('tokens')
+
+
+@tokens_cli.command(name='cleanup')
+@with_appcontext
+def cleanup_tokens():
+    try:
+        rows_deleted = prune_expired_tokens()
+    except Exception as error:
+        click.echo(
+            'Unable to cleanup tokens: {error}'.format(
+                error=error
+            )
+        )
+    else:
+        click.echo(
+            'Removed {rows_deleted} expired token(s).'.format(
+                rows_deleted=rows_deleted
+            )
+        )

--- a/mash/services/api/utils/tokens.py
+++ b/mash/services/api/utils/tokens.py
@@ -122,7 +122,7 @@ def prune_expired_tokens():
     Delete tokens that have expired from the database.
     """
     now = datetime.now()
-    rows_deleted = Token.query.filter(Token.expires < now).all().delete()
+    rows_deleted = Token.query.filter(Token.expires < now).delete()
     db.session.commit()
 
     return rows_deleted

--- a/test/unit/services/api/commands_test.py
+++ b/test/unit/services/api/commands_test.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from mash.services.api.app import create_app
+from mash.services.api.config import Config
+from mash.services.api.commands import tokens_cli
+
+flask_config = Config(
+    config_file='test/data/mash_config.yaml',
+    testing=True
+)
+app = create_app(flask_config)
+
+
+@patch('mash.services.api.commands.prune_expired_tokens')
+def test_tokens_cleanup(mock_pruned_tokens):
+    mock_pruned_tokens.return_value = 1
+
+    runner = app.test_cli_runner()
+
+    # Success
+    result = runner.invoke(tokens_cli, ['cleanup'])
+    assert 'Removed 1 expired token(s).' in result.output
+
+    # Failure
+    mock_pruned_tokens.side_effect = Exception('Access denied!')
+    result = runner.invoke(tokens_cli, ['cleanup'])
+    assert 'Unable to cleanup tokens: Access denied!' in result.output

--- a/test/unit/services/api/utils/token_utils_test.py
+++ b/test/unit/services/api/utils/token_utils_test.py
@@ -108,9 +108,7 @@ def test_revoke_tokens(mock_db, mock_get_user):
 def test_prune_expired_tokens(mock_db, mock_token):
     queryset = Mock()
     queryset.delete.return_value = 1
-    queryset1 = Mock()
-    queryset1.all.return_value = queryset
-    mock_token.query.filter.return_value = queryset1
+    mock_token.query.filter.return_value = queryset
     mock_token.expires = datetime.now()
 
     assert prune_expired_tokens() == 1


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Command will clear out any tokens in the database that have already expired.

`flask tokens cleanup`