### PR TITLE
Handle ec2 job doc without cloud_accounts.

### DIFF
--- a/mash/services/api/utils/jobs/ec2.py
+++ b/mash/services/api/utils/jobs/ec2.py
@@ -109,7 +109,7 @@ def update_ec2_job_accounts(job_doc):
     """
     user = get_user_by_username(job_doc['requesting_user'])
     helper_images = get_ec2_helper_images()
-    cloud_accounts = convert_account_dict(job_doc['cloud_accounts'])
+    cloud_accounts = convert_account_dict(job_doc.get('cloud_accounts', []))
 
     accounts = {}
     target_accounts = []

--- a/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
@@ -155,3 +155,19 @@ def test_update_ec2_job_accounts(
     assert 'target_account_info' in result
     assert 'cloud_accounts' not in result
     assert 'cloud_groups' not in result
+
+    # Test doc with no accounts
+    job_doc = {
+        'requesting_user': 'user1',
+        'cloud_groups': ['group1']
+    }
+
+    update_ec2_job_accounts(job_doc)
+
+    # Test doc with no groups
+    job_doc = {
+        'requesting_user': 'user1',
+        'cloud_accounts': [{'name': 'acnt1', 'data': 'more_stuff'}]
+    }
+
+    update_ec2_job_accounts(job_doc)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Either cloud_accounts or cloud_groups could be absent from job doc. When getting cloud_accounts use get method with default of empty list.

Update unit test to cover regression.