### PR TITLE
Add source_regions to raw image uploader args.

### DIFF
--- a/mash/services/raw_image_uploader_service.py
+++ b/mash/services/raw_image_uploader_service.py
@@ -38,7 +38,9 @@ def main():
             service_exchange='raw_image_uploader',
             config=BaseConfig(),
             custom_args={
-                'listener_msg_args': ['cloud_image_name', 'image_file'],
+                'listener_msg_args': [
+                    'cloud_image_name', 'image_file', 'source_regions'
+                ],
                 'status_msg_args': ['source_regions']
             }
         )

--- a/test/unit/services/raw_image_uploader/main_test.py
+++ b/test/unit/services/raw_image_uploader/main_test.py
@@ -16,7 +16,9 @@ class TestRawImageUploader(object):
             service_exchange='raw_image_uploader',
             config=config,
             custom_args={
-                'listener_msg_args': ['cloud_image_name', 'image_file'],
+                'listener_msg_args': [
+                    'cloud_image_name', 'image_file', 'source_regions'
+                ],
                 'status_msg_args': ['source_regions']
             }
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Raw image uploader expects and parses a source_regions argument from testing service.
