### PR TITLE
Fix GCE cleanup integration.

### DIFF
--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -178,6 +178,9 @@ class BaseJob(object):
                 self.cleanup_images in [True, None]:
             testing_message['testing_job']['cleanup_images'] = True
 
+        elif self.cleanup_images is False:
+            testing_message['testing_job']['cleanup_images'] = False
+
         if self.test_fallback_regions or self.test_fallback is False:
             testing_message['testing_job']['test_fallback_regions'] = \
                 self.test_fallback_regions

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -100,7 +100,8 @@ class GCEJob(BaseJob):
         for source_region, value in self.target_account_info.items():
             test_regions[source_region] = {
                 'account': value['account'],
-                'is_publishing_account': value['is_publishing_account']
+                'is_publishing_account': value['is_publishing_account'],
+                'bucket': value['bucket']
             }
 
             if value.get('testing_account'):

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -59,6 +59,11 @@ class TestJobCreatorBaseJob(object):
     @patch.object(BaseJob, 'get_testing_regions')
     def test_get_testing_message_cleanup(self, mock_get_testing_regions):
         mock_get_testing_regions.return_value = {}
-        message = self.job.get_testing_message()
 
+        message = self.job.get_testing_message()
         assert JsonFormat.json_loads(message)['testing_job']['cleanup_images']
+
+        # Explicit False for no cleanup even on failure
+        self.job.cleanup_images = False
+        message = self.job.get_testing_message()
+        assert JsonFormat.json_loads(message)['testing_job']['cleanup_images'] is False

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -19,7 +19,8 @@ class TestGCETestingJob(object):
                 'us-west1': {
                     'account': 'test-gce',
                     'testing_account': 'testingacnt',
-                    'is_publishing_account': False
+                    'is_publishing_account': False,
+                    'bucket': 'bucket'
                 }
             },
             'tests': ['test_stuff'],

--- a/test/unit/utils/gce_test.py
+++ b/test/unit/utils/gce_test.py
@@ -17,12 +17,29 @@
 #
 
 from unittest.mock import Mock, patch
-from mash.utils.gce import cleanup_gce_image
-from mash.utils.gce import get_region_list
+from mash.utils.gce import (
+    cleanup_gce_image,
+    get_region_list,
+    delete_gce_image,
+    delete_image_tarball
+)
+
+
+@patch('mash.utils.gce.delete_image_tarball')
+@patch('mash.utils.gce.delete_gce_image')
+def test_cleanup_gce_image(mock_delete_image, mock_delete_tarball):
+    creds = {
+        'client_email': 'fake@fake.com',
+        'project_id': '123'
+    }
+    cleanup_gce_image(creds, 'image_123', 'bucket')
+
+    assert mock_delete_image.call_count == 1
+    assert mock_delete_tarball.call_count == 1
 
 
 @patch('mash.utils.gce.get_driver')
-def test_get_client(mock_get_driver):
+def test_delete_gce_image(mock_get_driver):
     compute_engine = Mock()
     driver = Mock()
     mock_get_driver.return_value = compute_engine
@@ -33,9 +50,28 @@ def test_get_client(mock_get_driver):
         'project_id': '123'
     }
 
-    cleanup_gce_image(creds, 'image_123')
+    delete_gce_image(creds, 'auth_file', 'image_123')
 
     driver.ex_delete_image.assert_called_once_with('image_123')
+
+
+@patch('mash.utils.gce.GoogleStorageDriver')
+def test_delete_image_tarball(mock_get_driver):
+    driver = Mock()
+    obj = Mock()
+
+    driver.get_object.return_value = obj
+    mock_get_driver.return_value = driver
+
+    creds = {
+        'client_email': 'fake@fake.com',
+        'project_id': '123'
+    }
+
+    delete_image_tarball(creds, 'auth_file', 'image_123', 'bucket')
+
+    driver.get_object.assert_called_once_with('bucket', 'image_123.tar.gz')
+    driver.delete_object.assert_called_once_with(obj)
 
 
 @patch('mash.utils.gce.get_driver')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If False is explicitly provided for cleanup_images do not cleanup images even on failure. Otherwise on failure attempt to cleanup image and tarball. Also, if the job is testing only cleanup by default.

### How will these changes be tested?

Unit and E2E testing.

### How will this change be deployed?

Magic