### PR TITLE
Cleanup azure image and blob on test failure.

### DIFF
--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -133,14 +133,7 @@ class AzureJob(BaseJob):
         """
         Return a dictionary of target test regions.
         """
-        test_regions = {}
-
-        for source_region, value in self.target_account_info.items():
-            test_regions[source_region] = {
-                'account': value['account']
-            }
-
-        return test_regions
+        return self.target_account_info
 
     def get_uploader_regions(self):
         """

--- a/mash/services/uploader/azure_job.py
+++ b/mash/services/uploader/azure_job.py
@@ -96,6 +96,7 @@ class AzureUploaderJob(MashJob):
                 info['resource_group'],
                 self.cloud_image_name, {
                     'location': region,
+                    'hyper_vgeneration': 'V1',
                     'storage_profile': {
                         'os_disk': {
                             'os_type': 'Linux',

--- a/test/unit/services/uploader/azure_job_test.py
+++ b/test/unit/services/uploader/azure_job_test.py
@@ -125,7 +125,9 @@ class TestAzureUploaderJob(object):
         )
         client.images.create_or_update.assert_called_once_with(
             'group_name', 'name', {
-                'location': 'region', 'storage_profile': {
+                'location': 'region',
+                'hyper_vgeneration': 'V1',
+                'storage_profile': {
                     'os_disk': {
                         'blob_uri':
                         'https://storage.blob.core.windows.net/'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If testing is last service or on test failure attempt to cleanup artifacts. Unless cleanup_images is set to False.

Also to fix the upload I've set hyper_vgeneration to V1. This can be updated after discussion in a future PR.

### How will these changes be tested?

Unit and E2E tests.