### PR TITLE
Azure remove account list

### DIFF
--- a/mash/services/api/utils/jobs/azure.py
+++ b/mash/services/api/utils/jobs/azure.py
@@ -20,63 +20,25 @@ from mash.services.api.utils.users import get_user_by_username
 from mash.services.api.utils.accounts.azure import get_azure_account_by_id
 
 
-def add_target_azure_account(
-    account,
-    accounts,
-    region,
-    source_container,
-    source_resource_group,
-    source_storage_account,
-    destination_container,
-    destination_resource_group,
-    destination_storage_account
-):
-    """
-    Update job with account information.
-    """
-    region = region or account.region
-    source_container = source_container or account.source_container
-    source_resource_group = \
-        source_resource_group or account.source_resource_group
-    source_storage_account = \
-        source_storage_account or account.source_storage_account
-    destination_container = destination_container or account.destination_container
-    destination_resource_group = \
-        destination_resource_group or account.destination_resource_group
-    destination_storage_account = \
-        destination_storage_account or account.destination_storage_account
-
-    accounts[region] = {
-        'account': account.name,
-        'source_container': source_container,
-        'source_resource_group': source_resource_group,
-        'source_storage_account': source_storage_account,
-        'destination_container': destination_container,
-        'destination_resource_group': destination_resource_group,
-        'destination_storage_account': destination_storage_account
-    }
-
-
 def update_azure_job_accounts(job_doc):
     """
     Update target_account_info for given job doc.
     """
     user = get_user_by_username(job_doc['requesting_user'])
     cloud_account = get_azure_account_by_id(job_doc['cloud_account'], user.id)
-    accounts = {}
 
-    add_target_azure_account(
-        cloud_account,
-        accounts,
-        job_doc.get('region'),
-        job_doc.get('source_container'),
-        job_doc.get('source_resource_group'),
-        job_doc.get('source_storage_account'),
-        job_doc.get('destination_container'),
-        job_doc.get('destination_resource_group'),
-        job_doc.get('destination_storage_account')
-    )
+    attrs = [
+        'region',
+        'source_container',
+        'source_resource_group',
+        'source_storage_account',
+        'destination_container',
+        'destination_resource_group',
+        'destination_storage_account'
+    ]
 
-    job_doc['target_account_info'] = accounts
+    for attr in attrs:
+        if attr not in job_doc:
+            job_doc[attr] = getattr(cloud_account, attr)
 
     return job_doc

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -38,7 +38,6 @@ class BaseJob(object):
             self.image_description = kwargs['image_description']
             self.distro = kwargs['distro']
             self.download_url = kwargs['download_url']
-            self.target_account_info = kwargs['target_account_info']
         except KeyError as error:
             raise MashJobCreatorException(
                 'Jobs require a(n) {0} key in the job doc.'.format(
@@ -62,6 +61,7 @@ class BaseJob(object):
         self.raw_image_upload_type = kwargs.get('raw_image_upload_type')
         self.raw_image_upload_location = kwargs.get('raw_image_upload_location')
         self.raw_image_upload_account = kwargs.get('raw_image_upload_account')
+        self.target_account_info = kwargs.get('target_account_info')
         self.kwargs = kwargs
 
         self.base_message = {

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -127,7 +127,7 @@ class EC2TestingJob(MashJob):
                 'tests': self.tests
             }
 
-            process = create_testing_thread(results, img_proof_kwargs, region)
+            process = create_testing_thread(results, img_proof_kwargs)
             jobs.append(process)
 
         for job in jobs:

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -122,7 +122,7 @@ class GCETestingJob(MashJob):
                 'tests': self.tests
             }
 
-            process = create_testing_thread(results, img_proof_kwargs, region)
+            process = create_testing_thread(results, img_proof_kwargs)
             jobs.append(process)
 
         for job in jobs:

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -43,7 +43,6 @@ def img_proof_test(
     fallback_regions=None
 ):
     saved_args = locals()
-    name = threading.current_thread().getName()
     security_group_id = None
     service_account_file = None
     key_name = None
@@ -109,16 +108,16 @@ def img_proof_test(
             fallback_regions.remove(retry_region)
         else:
             status = FAILED
-            results[name] = {
+            results[region] = {
                 'status': EXCEPTION, 'msg': str(error)
             }
     except Exception:
-        results[name] = {
+        results[region] = {
             'status': EXCEPTION, 'msg': str(traceback.format_exc())
         }
     else:
         status = SUCCESS if status == 0 else FAILED
-        results[name] = {
+        results[region] = {
             'status': status,
             'results_file': result['info']['results_file']
         }

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -18,7 +18,6 @@
 
 import logging
 import os
-import threading
 import traceback
 import random
 

--- a/mash/services/testing/utils.py
+++ b/mash/services/testing/utils.py
@@ -26,10 +26,11 @@ def get_testing_account(account_info):
     return account_info.get('testing_account', account_info['account'])
 
 
-def create_testing_thread(results, img_proof_kwargs, region):
+def create_testing_thread(results, img_proof_kwargs):
     process = Thread(
-        name=region, target=img_proof_test,
-        args=(results,), kwargs=img_proof_kwargs
+        target=img_proof_test,
+        args=(results,),
+        kwargs=img_proof_kwargs
     )
     process.start()
 

--- a/mash/services/uploader/azure_job.py
+++ b/mash/services/uploader/azure_job.py
@@ -17,7 +17,6 @@
 #
 
 from multiprocessing import Process, SimpleQueue
-from tempfile import NamedTemporaryFile
 
 from azure.common.client_factory import get_client_from_auth_file
 from azure.mgmt.compute import ComputeManagementClient
@@ -25,8 +24,7 @@ from azure.mgmt.compute import ComputeManagementClient
 # project
 from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
-from mash.utils.json_format import JsonFormat
-from mash.utils.mash_utils import format_string_with_date
+from mash.utils.mash_utils import format_string_with_date, create_json_file
 from mash.services.status_levels import SUCCESS
 from mash.utils.azure import upload_azure_image
 
@@ -41,7 +39,11 @@ class AzureUploaderJob(MashJob):
         self.cloud_image_name = ''
 
         try:
-            self.target_regions = self.job_config['target_regions']
+            self.account = self.job_config['account']
+            self.region = self.job_config['region']
+            self.container = self.job_config['container']
+            self.resource_group = self.job_config['resource_group']
+            self.storage_account = self.job_config['storage_account']
             self.base_cloud_image_name = self.job_config['cloud_image_name']
         except KeyError as error:
             raise MashUploadException(
@@ -59,43 +61,40 @@ class AzureUploaderJob(MashJob):
             self.base_cloud_image_name
         )
 
-        for region, info in self.target_regions.items():
-            account = info['account']
-            self.request_credentials([account])
-            credentials = self.credentials[account]
-            blob_name = ''.join([self.cloud_image_name, '.vhd'])
+        self.request_credentials([self.account])
+        credentials = self.credentials[self.account]
+        blob_name = ''.join([self.cloud_image_name, '.vhd'])
 
-            result = SimpleQueue()
-            args = (
-                blob_name,
-                info['container'],
-                credentials,
-                self.image_file,
-                self.config.get_azure_max_retry_attempts(),
-                self.config.get_azure_max_workers(),
-                info['resource_group'],
-                info['storage_account'],
-                result
-            )
-            upload_process = Process(
-                target=upload_azure_image,
-                args=args
-            )
-            upload_process.start()
-            upload_process.join()
+        result = SimpleQueue()
+        args = (
+            blob_name,
+            self.container,
+            credentials,
+            self.image_file,
+            self.config.get_azure_max_retry_attempts(),
+            self.config.get_azure_max_workers(),
+            self.resource_group,
+            self.storage_account,
+            result
+        )
+        upload_process = Process(
+            target=upload_azure_image,
+            args=args
+        )
+        upload_process.start()
+        upload_process.join()
 
-            if result.empty() is False:
-                raise MashUploadException(result.get())
+        if result.empty() is False:
+            raise MashUploadException(result.get())
 
-            self._create_auth_file(credentials)
-
+        with create_json_file(credentials) as auth_file:
             compute_client = get_client_from_auth_file(
-                ComputeManagementClient, auth_path=self.auth_file.name
+                ComputeManagementClient, auth_path=auth_file
             )
             async_create_image = compute_client.images.create_or_update(
-                info['resource_group'],
+                self.resource_group,
                 self.cloud_image_name, {
-                    'location': region,
+                    'location': self.region,
                     'hyper_vgeneration': 'V1',
                     'storage_profile': {
                         'os_disk': {
@@ -103,9 +102,9 @@ class AzureUploaderJob(MashJob):
                             'os_state': 'Generalized',
                             'caching': 'ReadWrite',
                             'blob_uri': 'https://{0}.{1}/{2}/{3}'.format(
-                                info['storage_account'],
+                                self.storage_account,
                                 'blob.core.windows.net',
-                                info['container'],
+                                self.container,
                                 blob_name
                             )
                         }
@@ -113,18 +112,14 @@ class AzureUploaderJob(MashJob):
                 }
             )
             async_create_image.wait()
-            self.source_regions[region] = self.cloud_image_name
-            self.send_log(
-                'Uploaded image has ID: {0} in region {1}'.format(
-                    self.cloud_image_name,
-                    region
-                )
-            )
 
-    def _create_auth_file(self, credentials):
-        self.auth_file = NamedTemporaryFile()
-        with open(self.auth_file.name, 'w') as azure_auth:
-            azure_auth.write(JsonFormat.json_message(credentials))
+        self.source_regions[self.region] = self.cloud_image_name
+        self.send_log(
+            'Uploaded image has ID: {0} in region {1}'.format(
+                self.cloud_image_name,
+                self.region
+            )
+        )
 
     @property
     def image_file(self):

--- a/test/unit/services/api/utils/jobs/azure_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/azure_job_utils_test.py
@@ -18,32 +18,27 @@
 
 from unittest.mock import patch, Mock
 
-from mash.services.api.utils.jobs.azure import (
-    update_azure_job_accounts,
-    add_target_azure_account
-)
+from mash.services.api.utils.jobs.azure import update_azure_job_accounts
 
 
-@patch('mash.services.api.utils.jobs.azure.add_target_azure_account')
 @patch('mash.services.api.utils.jobs.azure.get_azure_account_by_id')
 @patch('mash.services.api.utils.jobs.azure.get_user_by_username')
 def test_update_azure_job_accounts(
     mock_get_user,
-    mock_get_azure_account,
-    mock_add_target_account
+    mock_get_azure_account
 ):
     user = Mock()
     user.id = '1'
     mock_get_user.return_value = user
 
     account = Mock()
+    account.region = 'southcentralus'
     account.name = 'acnt1'
     mock_get_azure_account.return_value = account
 
     job_doc = {
         'requesting_user': 'user1',
         'cloud_account': 'acnt1',
-        'region': 'southcentralus',
         'source_resource_group': 'rg-1',
         'source_container': 'container1',
         'source_storage_account': 'sa1',
@@ -54,39 +49,4 @@ def test_update_azure_job_accounts(
 
     result = update_azure_job_accounts(job_doc)
 
-    assert 'target_account_info' in result
-
-
-def test_add_target_azure_account():
-    account = Mock()
-    account.region = 'useast'
-    account.name = 'acnt1'
-    account.source_container = 'container1'
-    account.source_resource_group = 'group1'
-    account.source_storage_account = 'account1'
-    account.destination_container = 'container2'
-    account.destination_resource_group = 'group2'
-    account.destination_storage_account = 'account2'
-
-    accounts = {}
-
-    add_target_azure_account(
-        account,
-        accounts,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None
-    )
-
-    assert 'useast' in accounts
-    assert accounts['useast']['account'] == 'acnt1'
-    assert accounts['useast']['source_container'] == 'container1'
-    assert accounts['useast']['source_resource_group'] == 'group1'
-    assert accounts['useast']['source_storage_account'] == 'account1'
-    assert accounts['useast']['destination_container'] == 'container2'
-    assert accounts['useast']['destination_resource_group'] == 'group2'
-    assert accounts['useast']['destination_storage_account'] == 'account2'
+    assert result['region'] == 'southcentralus'

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from unittest.mock import patch
@@ -20,10 +21,60 @@ def test_azure_job_missing_keys(mock_init):
         'cloud_image_name': 'test-cloud-image',
         'image_description': 'image description',
         'distro': 'sles',
-        'download_url': 'https://download.here',
-        'target_account_info': {}
+        'download_url': 'https://download.here'
     })
     job.kwargs = {}
 
     with pytest.raises(MashJobCreatorException):
         job.post_init()
+
+
+@patch.object(AzureJob, '__init__')
+def test_azure_job_cleanup(mock_init):
+    mock_init.return_value = None
+
+    job = AzureJob({
+        'job_id': '123',
+        'cloud': 'azure',
+        'requesting_user': 'test-user',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here'
+    })
+    job.kwargs = {
+        'cloud_account': 'acnt1',
+        'emails': 'test@test.com',
+        'label': 'Great Image',
+        'offer_id': 'sles',
+        'publisher_id': 'suse',
+        'sku': 'sp1',
+        'cloud': 'azure'
+    }
+    job.cloud = 'azure'
+    job.tests = ['test1']
+    job.distro = 'sles'
+    job.instance_type = 'b1'
+    job.cloud_architecture = 'x86_64'
+    job.base_message = {}
+
+    # Test explicit no cleanup images
+    job.last_service = 'deprecation'
+    job.cleanup_images = False
+
+    job.post_init()
+
+    testing_message = json.loads(job.get_testing_message())
+    assert testing_message['testing_job']['cleanup_images'] is False
+
+    # Test cleanup images on testing only
+    job.last_service = 'testing'
+    job.cleanup_images = True
+
+    job.post_init()
+
+    testing_message = json.loads(job.get_testing_message())
+    assert testing_message['testing_job']['cleanup_images'] is True

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -227,27 +227,6 @@ class TestJobCreatorService(object):
         with open('test/data/azure_job.json', 'r') as job_doc:
             job = json.load(job_doc)
 
-        job['target_account_info'] = {
-            'southcentralus': {
-                'account': 'test-azure',
-                'source_resource_group': 'rg-1',
-                'source_container': 'container1',
-                'source_storage_account': 'sa1',
-                'destination_resource_group': 'rg-2',
-                'destination_container': 'container2',
-                'destination_storage_account': 'sa2'
-            },
-            'centralus': {
-                'account': 'test-azure2',
-                'source_resource_group': 'c_res_group1',
-                'source_container': 'ccontainer1',
-                'source_storage_account': 'cstorage1',
-                'destination_resource_group': 'c_res_group2',
-                'destination_container': 'ccontainer2',
-                'destination_storage_account': 'cstorage2'
-            }
-        }
-
         message = MagicMock()
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
@@ -275,20 +254,10 @@ class TestJobCreatorService(object):
         check_base_attrs(data)
         assert data['cloud_architecture'] == 'x86_64'
         assert data['cloud_image_name'] == 'new_image_123'
-        assert data['image_description'] == 'New Image #123'
-
-        for region, info in data['target_regions'].items():
-            if region == 'centralus':
-                assert info['account'] == 'test-azure2'
-                assert info['container'] == 'ccontainer1'
-                assert info['resource_group'] == 'c_res_group1'
-                assert info['storage_account'] == 'cstorage1'
-            else:
-                assert region == 'southcentralus'
-                assert info['account'] == 'test-azure'
-                assert info['container'] == 'container1'
-                assert info['resource_group'] == 'rg-1'
-                assert info['storage_account'] == 'sa1'
+        assert data['account'] == 'test-azure'
+        assert data['container'] == 'container1'
+        assert data['resource_group'] == 'rg-1'
+        assert data['storage_account'] == 'sa1'
 
         # Testing Job Doc
 
@@ -297,13 +266,11 @@ class TestJobCreatorService(object):
         assert data['distro'] == 'sles'
         assert data['instance_type'] == 'Basic_A2'
         assert data['tests'] == ['test_stuff']
-
-        for region, info in data['test_regions'].items():
-            if region == 'centralus':
-                assert info['account'] == 'test-azure2'
-            else:
-                assert region == 'southcentralus'
-                assert info['account'] == 'test-azure'
+        assert data['region'] == 'southcentralus'
+        assert data['account'] == 'test-azure'
+        assert data['container'] == 'container1'
+        assert data['resource_group'] == 'rg-1'
+        assert data['storage_account'] == 'sa1'
 
         # Raw Image Uploader Job Doc
 
@@ -318,26 +285,14 @@ class TestJobCreatorService(object):
         data = json.loads(mock_publish.mock_calls[4][1][2])['replication_job']
         check_base_attrs(data)
         assert data['cleanup_images']
-        assert data['image_description'] == 'New Image #123'
-
-        for region, info in data['replication_source_regions'].items():
-            if region == 'centralus':
-                assert info['account'] == 'test-azure2'
-                assert info['source_container'] == 'ccontainer1'
-                assert info['source_resource_group'] == 'c_res_group1'
-                assert info['source_storage_account'] == 'cstorage1'
-                assert info['destination_container'] == 'ccontainer2'
-                assert info['destination_resource_group'] == 'c_res_group2'
-                assert info['destination_storage_account'] == 'cstorage2'
-            else:
-                assert region == 'southcentralus'
-                assert info['account'] == 'test-azure'
-                assert info['source_container'] == 'container1'
-                assert info['source_resource_group'] == 'rg-1'
-                assert info['source_storage_account'] == 'sa1'
-                assert info['destination_container'] == 'container2'
-                assert info['destination_resource_group'] == 'rg-2'
-                assert info['destination_storage_account'] == 'sa2'
+        assert data['region'] == 'southcentralus'
+        assert data['account'] == 'test-azure'
+        assert data['source_container'] == 'container1'
+        assert data['source_resource_group'] == 'rg-1'
+        assert data['source_storage_account'] == 'sa1'
+        assert data['destination_container'] == 'container2'
+        assert data['destination_resource_group'] == 'rg-2'
+        assert data['destination_storage_account'] == 'sa2'
 
         # Publisher Job Doc
 
@@ -350,17 +305,10 @@ class TestJobCreatorService(object):
         assert data['publisher_id'] == 'suse'
         assert data['sku'] == '123'
         assert data['vm_images_key'] == 'key123'
-
-        for region in data['publish_regions']:
-            assert region['account'] in ('test-azure', 'test-azure2')
-            if region['account'] == 'test-azure':
-                assert region['destination_container'] == 'container2'
-                assert region['destination_resource_group'] == 'rg-2'
-                assert region['destination_storage_account'] == 'sa2'
-            else:
-                assert region['destination_container'] == 'ccontainer2'
-                assert region['destination_resource_group'] == 'c_res_group2'
-                assert region['destination_storage_account'] == 'cstorage2'
+        assert data['account'] == 'test-azure'
+        assert data['container'] == 'container2'
+        assert data['resource_group'] == 'rg-2'
+        assert data['storage_account'] == 'sa2'
 
         # Deprecation Job Doc
 

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -16,14 +16,11 @@ class TestAzurePublisherJob(object):
             'requesting_user': 'user1',
             'offer_id': 'sles',
             'cloud': 'azure',
-            'publish_regions': [
-                {
-                    'account': 'acnt1',
-                    'destination_resource_group': 'rg-2',
-                    'destination_container': 'container2',
-                    'destination_storage_account': 'sa2'
-                }
-            ],
+            'account': 'acnt1',
+            'resource_group': 'rg-2',
+            'container': 'container2',
+            'storage_account': 'sa2',
+            'region': 'East US',
             'publisher_id': 'suse',
             'sku': '123',
             'utctime': 'now',
@@ -54,7 +51,7 @@ class TestAzurePublisherJob(object):
         self.job.cloud_image_name = 'New Image'
 
     def test_publish_ec2_missing_key(self):
-        del self.job_config['publish_regions']
+        del self.job_config['account']
 
         with raises(MashPublisherException):
             AzurePublisherJob(self.job_config, self.config)

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -15,17 +15,14 @@ class TestAzureReplicationJob(object):
             'requesting_user': 'user1',
             'cloud': 'azure',
             'utctime': 'now',
-            "replication_source_regions": {
-                "westus": {
-                    'account': 'acnt1',
-                    'source_resource_group': 'rg-1',
-                    'source_container': 'container1',
-                    'source_storage_account': 'sa1',
-                    'destination_resource_group': 'rg-2',
-                    'destination_container': 'container2',
-                    'destination_storage_account': 'sa2'
-                }
-            },
+            'account': 'acnt1',
+            'source_resource_group': 'rg-1',
+            'source_container': 'container1',
+            'source_storage_account': 'sa1',
+            'region': 'East US',
+            'destination_resource_group': 'rg-2',
+            'destination_container': 'container2',
+            'destination_storage_account': 'sa2',
             "cleanup_images": True
         }
 
@@ -53,10 +50,12 @@ class TestAzureReplicationJob(object):
         self.job.cloud_image_name = 'image123'
 
     def test_replicate_ec2_missing_key(self):
-        del self.job_config['replication_source_regions']
+        del self.job_config['account']
 
         with raises(MashReplicationException):
             AzureReplicationJob(self.job_config, self.config)
+
+        self.job_config['account'] = 'acnt1'
 
     @patch('mash.services.replication.azure_job.delete_page_blob')
     @patch('mash.services.replication.azure_job.delete_image')

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -14,14 +14,11 @@ class TestAzureTestingJob(object):
             'cloud': 'azure',
             'requesting_user': 'user1',
             'ssh_private_key_file': 'private_ssh_key.file',
-            'test_regions': {
-                'East US': {
-                    'account': 'test-azure',
-                    'source_resource_group': 'srg',
-                    'source_container': 'sc',
-                    'source_storage_account': 'ssa'
-                }
-            },
+            'account': 'test-azure',
+            'resource_group': 'srg',
+            'container': 'sc',
+            'storage_account': 'ssa',
+            'region': 'East US',
             'tests': ['test_stuff'],
             'utctime': 'now',
         }
@@ -31,7 +28,7 @@ class TestAzureTestingJob(object):
         self.config.get_img_proof_timeout.return_value = None
 
     def test_testing_azure_missing_key(self):
-        del self.job_config['test_regions']
+        del self.job_config['account']
 
         with pytest.raises(MashTestingException):
             AzureTestingJob(self.job_config, self.config)

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -21,6 +21,12 @@ class TestGCETestingJob(object):
                     'testing_account': 'testingacnt',
                     'is_publishing_account': False,
                     'bucket': 'bucket'
+                },
+                'us-central1-c': {
+                    'account': 'test-gce',
+                    'testing_account': 'testingacnt',
+                    'is_publishing_account': False,
+                    'bucket': 'bucket'
                 }
             },
             'tests': ['test_stuff'],
@@ -83,7 +89,10 @@ class TestGCETestingJob(object):
                 'credentials': '321'
             }
         }
-        job.source_regions = {'us-west1': 'ami-123'}
+        job.source_regions = {
+            'us-west1': 'ami-123',
+            'us-central1-c': 'ami-123'
+        }
         job.run_job()
 
         test_image_calls = [call(
@@ -137,9 +146,7 @@ class TestGCETestingJob(object):
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
         job.run_job()
-        assert mock_send_log.mock_calls[1] == call(
-            'Image tests failed in region: us-west1.', success=False
-        )
+        assert 'Image tests failed' in mock_send_log.mock_calls[1][1][0]
         assert 'Tests broken!' in mock_send_log.mock_calls[2][1][0]
         assert mock_send_log.mock_calls[2][2] == {'success': False}
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Cleanup test thread naming. Region is already available in function args.
- Remove the complexity of account list. This is not used in Azure or GCE. It is an artifact that carried over from EC2 implementation. Instead of sending a list of 1 account in job messages send the attrs directly in the base message. This removes the necessity for loops and threading for each test run in img-proof.

### How will these changes be tested?

Unit and E2E.
