### PR TITLE
Implement Azure SAS URL upload.

### DIFF
--- a/mash/services/api/schema/jobs/azure.py
+++ b/mash/services/api/schema/jobs/azure.py
@@ -57,6 +57,13 @@ azure_job_message['properties']['destination_storage_account'] = string_with_exa
     'storage_account2'
 )
 azure_job_message['properties']['region'] = string_with_example('westus')
+azure_job_message['properties']['sas_token'] = string_with_example(
+    'sv=2015-07-08&sr=b&sig=123456789&se=2016-10-18T21&sp=row'
+)
+azure_job_message['properties']['sas_container'] = string_with_example('container1')
+azure_job_message['properties']['sas_storage_account'] = string_with_example(
+    'storage_account1'
+)
 
 azure_job_message['required'].append('cloud_account')
 azure_job_message['properties']['image']['example'] = \

--- a/mash/services/api/schema/jobs/azure.py
+++ b/mash/services/api/schema/jobs/azure.py
@@ -58,11 +58,6 @@ azure_job_message['properties']['destination_storage_account'] = string_with_exa
 )
 azure_job_message['properties']['region'] = string_with_example('westus')
 
-azure_job_message['required'].append('emails')
-azure_job_message['required'].append('label')
-azure_job_message['required'].append('offer_id')
-azure_job_message['required'].append('publisher_id')
-azure_job_message['required'].append('sku')
 azure_job_message['required'].append('cloud_account')
 azure_job_message['properties']['image']['example'] = \
     'openSUSE-Leap-15.0-Azure'

--- a/mash/services/api/wsgi.py
+++ b/mash/services/api/wsgi.py
@@ -4,4 +4,4 @@ from mash.services.api.config import Config
 application = create_app(Config())
 
 if __name__ == '__main__':
-    application.run(port=5000)
+    application.run(port=5005)

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -53,6 +53,9 @@ class AzureJob(BaseJob):
         self.offer_id = self.kwargs.get('offer_id')
         self.publisher_id = self.kwargs.get('publisher_id')
         self.sku = self.kwargs.get('sku')
+        self.sas_token = self.kwargs.get('sas_token')
+        self.sas_container = self.kwargs.get('sas_container')
+        self.sas_storage_account = self.kwargs.get('sas_storage_account')
 
     def get_deprecation_message(self):
         """
@@ -165,17 +168,29 @@ class AzureJob(BaseJob):
         """
         Build uploader job message.
         """
-        uploader_message = {
-            'uploader_job': {
-                'cloud_image_name': self.cloud_image_name,
-                'cloud': self.cloud,
-                'account': self.cloud_account,
-                'region': self.region,
-                'container': self.source_container,
-                'resource_group': self.source_resource_group,
-                'storage_account': self.source_storage_account
+        if self.sas_token:
+            uploader_message = {
+                'uploader_job': {
+                    'cloud_image_name': self.cloud_image_name,
+                    'cloud': self.cloud,
+                    'container': self.sas_container,
+                    'storage_account': self.sas_storage_account,
+                    'sas_token': self.sas_token
+                }
             }
-        }
+        else:
+            uploader_message = {
+                'uploader_job': {
+                    'cloud_image_name': self.cloud_image_name,
+                    'cloud': self.cloud,
+                    'account': self.cloud_account,
+                    'region': self.region,
+                    'container': self.source_container,
+                    'resource_group': self.source_resource_group,
+                    'storage_account': self.source_storage_account
+                }
+            }
+
         uploader_message['uploader_job'].update(self.base_message)
 
         if self.cloud_architecture:

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -32,11 +32,6 @@ class AzureJob(BaseJob):
         """
         try:
             self.cloud_account = self.kwargs['cloud_account']
-            self.emails = self.kwargs['emails']
-            self.label = self.kwargs['label']
-            self.offer_id = self.kwargs['offer_id']
-            self.publisher_id = self.kwargs['publisher_id']
-            self.sku = self.kwargs['sku']
         except KeyError as error:
             raise MashJobCreatorException(
                 'Azure jobs require a(n) {0} key in the job doc.'.format(
@@ -53,6 +48,11 @@ class AzureJob(BaseJob):
         self.destination_container = self.kwargs.get('destination_container')
         self.destination_resource_group = self.kwargs.get('destination_resource_group')
         self.destination_storage_account = self.kwargs.get('destination_storage_account')
+        self.emails = self.kwargs.get('emails')
+        self.label = self.kwargs.get('label')
+        self.offer_id = self.kwargs.get('offer_id')
+        self.publisher_id = self.kwargs.get('publisher_id')
+        self.sku = self.kwargs.get('sku')
 
     def get_deprecation_message(self):
         """

--- a/test/unit/services/api/utils/jobs/azure_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/azure_job_utils_test.py
@@ -62,3 +62,14 @@ def test_update_azure_job_accounts(
     result = update_azure_job_accounts(job_doc)
 
     assert result['region'] == 'southcentralus'
+
+    # Not all sas args
+    job_doc['sas_token'] = 'sas_token'
+    with raises(MashJobException):
+        update_azure_job_accounts(job_doc)
+
+    # SAS with last_service not uploader
+    job_doc['sas_container'] = 'sas_container'
+    job_doc['sas_storage_account'] = 'sas_storage_account'
+    with raises(MashJobException):
+        update_azure_job_accounts(job_doc)

--- a/test/unit/services/api/utils/jobs/azure_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/azure_job_utils_test.py
@@ -16,8 +16,10 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from pytest import raises
 from unittest.mock import patch, Mock
 
+from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.jobs.azure import update_azure_job_accounts
 
 
@@ -37,6 +39,7 @@ def test_update_azure_job_accounts(
     mock_get_azure_account.return_value = account
 
     job_doc = {
+        'last_service': 'deprecation',
         'requesting_user': 'user1',
         'cloud_account': 'acnt1',
         'source_resource_group': 'rg-1',
@@ -44,9 +47,18 @@ def test_update_azure_job_accounts(
         'source_storage_account': 'sa1',
         'destination_resource_group': 'rg-2',
         'destination_container': 'container2',
-        'destination_storage_account': 'sa2'
+        'destination_storage_account': 'sa2',
+        'emails': 'jdoe@fake.com',
+        'label': 'New Image 123',
+        'offer_id': 'sles',
+        'publisher_id': 'suse'
     }
 
+    # Missing args causes exception
+    with raises(MashJobException):
+        update_azure_job_accounts(job_doc)
+
+    job_doc['sku'] = '123'
     result = update_azure_job_accounts(job_doc)
 
     assert result['region'] == 'southcentralus'

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -78,3 +78,30 @@ def test_azure_job_cleanup(mock_init):
 
     testing_message = json.loads(job.get_testing_message())
     assert testing_message['testing_job']['cleanup_images'] is True
+
+
+@patch.object(AzureJob, '__init__')
+def test_azure_uploader_message(mock_init):
+    mock_init.return_value = None
+
+    job = AzureJob({
+        'job_id': '123',
+        'cloud': 'azure',
+        'requesting_user': 'test-user',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here',
+        'sas_token': 'sas_token'
+    })
+    job.sas_token = 'sas_token'
+    job.sas_container = 'sas_container'
+    job.sas_storage_account = 'sas_storage_account'
+    job.cloud_image_name = 'cloud image 123'
+    job.cloud = 'azure'
+    job.cloud_architecture = 'x86_64'
+    job.base_message = {}
+    job.get_uploader_message()

--- a/test/unit/services/uploader/azure_job_test.py
+++ b/test/unit/services/uploader/azure_job_test.py
@@ -95,13 +95,14 @@ class TestAzureUploaderJob(object):
             args=(
                 'name.vhd',
                 'container',
-                self.credentials['test'],
                 'file.vhdfixed.xz',
                 5,
                 8,
-                'group_name',
                 'storage',
-                queue
+                queue,
+                self.credentials['test'],
+                'group_name',
+                None
             )
         )
 
@@ -123,6 +124,27 @@ class TestAzureUploaderJob(object):
             }
         )
         async_create_image.wait.assert_called_once_with()
+
+        # Test sas upload route
+        self.job.sas_token = 'sas_token'
+        mock_process.reset_mock()
+
+        self.job.run_job()
+        mock_process.assert_called_once_with(
+            target=mock_upload_azure_image,
+            args=(
+                'name.vhd',
+                'container',
+                'file.vhdfixed.xz',
+                5,
+                8,
+                'storage',
+                queue,
+                None,
+                'group_name',
+                'sas_token'
+            )
+        )
 
         queue.empty.return_value = False
         queue.get.return_value = 'Failed!'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Validate Azure job args based on last service.
- Publishing args are not required for testing or upload only jobs.
- Implement Azure SAS URL upload.
- If a SAS token, container and storage account are provided use Azure sas upload workflow. The image is uploaded with provided sas information to a page blob and job is finished.

Fixes #515 

### How will these changes be tested?

Unit and E2E testing.
