### PR TITLE
Remove account list handling from GCE.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 omit =
     */version.py
     */wsgi.py
-
+    */img_proof_helper.py

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -21,5 +21,6 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_email": "test@fake.com"
+  "notification_email": "test@fake.com",
+  "guest_os_features": ["UEFI_COMPATIBLE"]
 }

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -23,14 +23,11 @@ import random
 from mash.mash_exceptions import MashTestingException
 from mash.services.mash_job import MashJob
 from mash.services.status_levels import SUCCESS
-from mash.services.testing.utils import (
-    get_testing_account,
-    create_testing_thread,
-    process_test_result
-)
+from mash.services.testing.utils import process_test_result
 from mash.utils.mash_utils import create_ssh_key_pair
 from mash.utils.gce import cleanup_gce_image
 from mash.utils.gce import get_region_list
+from mash.services.testing.img_proof_helper import img_proof_test
 
 instance_types = [
     'n1-standard-1',
@@ -50,7 +47,10 @@ class GCETestingJob(MashJob):
         Post initialization method.
         """
         try:
-            self.test_regions = self.job_config['test_regions']
+            self.account = self.job_config['account']
+            self.region = self.job_config['region']
+            self.bucket = self.job_config['bucket']
+            self.testing_account = self.job_config['testing_account']
             self.tests = self.job_config['tests']
         except KeyError as error:
             raise MashTestingException(
@@ -81,8 +81,6 @@ class GCETestingJob(MashJob):
         Tests image with img-proof and update status and results.
         """
         results = {}
-        jobs = []
-
         self.status = SUCCESS
         self.send_log(
             'Running img-proof tests against image with '
@@ -91,67 +89,64 @@ class GCETestingJob(MashJob):
             )
         )
 
-        for region, info in self.test_regions.items():
-            account = get_testing_account(info)
-            self.request_credentials([account])
-            creds = self.credentials[account]
+        accounts = [self.account]
+        if self.testing_account:
+            # Get both sets of credentials in case cleanup method is run.
+            accounts.append(self.testing_account)
 
-            if self.test_fallback_regions == []:
-                # fallback testing explicitly disabled
-                fallback_regions = []
+        self.request_credentials(accounts)
+        creds = self.credentials[self.testing_account or self.account]
+
+        if self.test_fallback_regions == []:
+            # fallback testing explicitly disabled
+            fallback_regions = []
+        else:
+            if self.test_fallback_regions is None:
+                fallback_regions = get_region_list(creds)
             else:
-                if self.test_fallback_regions is None:
-                    fallback_regions = get_region_list(creds)
-                else:
-                    fallback_regions = self.test_fallback_regions.copy()
-                if region in fallback_regions:
-                    fallback_regions.remove(region)
+                fallback_regions = self.test_fallback_regions.copy()
+            if self.region in fallback_regions:
+                fallback_regions.remove(self.region)
 
-            img_proof_kwargs = {
-                'cloud': self.cloud,
-                'description': self.description,
-                'distro': self.distro,
-                'fallback_regions': fallback_regions,
-                'image_id': self.source_regions[region],
-                'instance_type': self.instance_type,
-                'img_proof_timeout': self.img_proof_timeout,
-                'region': region,
-                'service_account_credentials': json.dumps(creds),
-                'ssh_private_key_file': self.ssh_private_key_file,
-                'ssh_user': self.ssh_user,
-                'tests': self.tests
-            }
+        img_proof_test(
+            results,
+            cloud=self.cloud,
+            description=self.description,
+            distro=self.distro,
+            fallback_regions=fallback_regions,
+            image_id=self.source_regions[self.region],
+            instance_type=self.instance_type,
+            img_proof_timeout=self.img_proof_timeout,
+            region=self.region,
+            service_account_credentials=json.dumps(creds),
+            ssh_private_key_file=self.ssh_private_key_file,
+            ssh_user=self.ssh_user,
+            tests=self.tests
+        )
 
-            process = create_testing_thread(results, img_proof_kwargs)
-            jobs.append(process)
+        self.status = process_test_result(
+            results[self.region],
+            self.send_log,
+            self.region
+        )
 
-        for job in jobs:
-            job.join()
+        if self.cleanup_images or \
+                (self.status != SUCCESS and self.cleanup_images is not False):
+            self.cleanup_image()
 
-        for region, result in results.items():
-            status = process_test_result(result, self.send_log, region)
-            if status != SUCCESS:
-                self.status = status
-
-            if self.cleanup_images or \
-                    (status != SUCCESS and self.cleanup_images is not False):
-                self.cleanup_image(region)
-
-    def cleanup_image(self, region):
-        account = self.test_regions[region]['account']
-        bucket = self.test_regions[region]['bucket']
-        credentials = self.credentials[account]
-        cloud_image_name = self.source_regions[region]
+    def cleanup_image(self):
+        credentials = self.credentials[self.account]
+        cloud_image_name = self.source_regions[self.region]
 
         self.send_log(
             'Cleaning up image: {0} in region: {1}.'.format(
                 cloud_image_name,
-                region
+                self.region
             )
         )
 
         try:
-            cleanup_gce_image(credentials, cloud_image_name, bucket)
+            cleanup_gce_image(credentials, cloud_image_name, self.bucket)
         except Exception as error:
             self.send_log(
                 'Failed to cleanup image: {0}'.format(error),

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -22,6 +22,7 @@
   "family": "sles-15",
   "tests": ["test_stuff"],
   "notification_email": "test@fake.com",
+  "guest_os_features": ["UEFI_COMPATIBLE"],
   "raw_image_upload_type": "s3bucket",
   "raw_image_upload_account": "account",
   "raw_image_upload_location": "location"

--- a/test/unit/services/api/utils/jobs/gce_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/gce_job_utils_test.py
@@ -21,19 +21,14 @@ from unittest.mock import patch, Mock
 from pytest import raises
 
 from mash.mash_exceptions import MashJobException
-from mash.services.api.utils.jobs.gce import (
-    update_gce_job_accounts,
-    add_target_gce_account
-)
+from mash.services.api.utils.jobs.gce import update_gce_job_accounts
 
 
-@patch('mash.services.api.utils.jobs.gce.add_target_gce_account')
 @patch('mash.services.api.utils.jobs.gce.get_gce_account_by_id')
 @patch('mash.services.api.utils.jobs.gce.get_user_by_username')
 def test_update_gce_job_accounts(
     mock_get_user,
-    mock_get_gce_account,
-    mock_add_target_account
+    mock_get_gce_account
 ):
     user = Mock()
     user.id = '1'
@@ -41,66 +36,35 @@ def test_update_gce_job_accounts(
 
     account = Mock()
     account.name = 'acnt1'
+    account.region = 'us-east1'
+    account.bucket = 'images'
+    account.testing_account = 'acnt2'
+    account.is_publishing_account = True
     mock_get_gce_account.return_value = account
 
     job_doc = {
         'requesting_user': 'user1',
-        'cloud_account': 'acnt1'
+        'cloud_account': 'acnt1',
+        'bucket': 'images2',
+        'family': 'sles'
     }
 
     result = update_gce_job_accounts(job_doc)
 
-    assert 'target_account_info' in result
-    assert 'cloud_accounts' not in result
-
-
-def test_add_target_gce_account():
-    account = Mock()
-    account.region = 'us-east1'
-    account.bucket = 'images'
-    account.name = 'acnt1'
-    account.testing_account = 'acnt2'
-    account.is_publishing_account = True
-
-    accounts = {}
-
-    add_target_gce_account(
-        account,
-        accounts,
-        None,
-        None,
-        None,
-        family='sles'
-    )
-
-    assert 'us-east1' in accounts
-    assert accounts['us-east1']['account'] == 'acnt1'
-    assert accounts['us-east1']['bucket'] == 'images'
-    assert accounts['us-east1']['testing_account'] == 'acnt2'
-    assert accounts['us-east1']['is_publishing_account']
+    assert result['region'] == 'us-east1'
+    assert result['bucket'] == 'images2'
+    assert result['testing_account'] == 'acnt2'
 
     # Missing family
+    del job_doc['family']
 
     with raises(MashJobException):
-        add_target_gce_account(
-            account,
-            accounts,
-            None,
-            None,
-            None
-        )
+        update_gce_job_accounts(job_doc)
 
     # Publishing account has no testing account
-
+    del job_doc['testing_account']
+    job_doc['family'] = 'sles'
     account.testing_account = None
-    account.is_publishing_account = True
 
     with raises(MashJobException):
-        add_target_gce_account(
-            account,
-            accounts,
-            None,
-            None,
-            None,
-            family='sles'
-        )
+        update_gce_job_accounts(job_doc)

--- a/test/unit/services/deprecation/gce_job_test.py
+++ b/test/unit/services/deprecation/gce_job_test.py
@@ -13,7 +13,7 @@ class TestGCEDeprecationJob(object):
             'cloud': 'gce',
             'requesting_user': 'user1',
             'old_cloud_image_name': 'old_image_123',
-            'deprecation_accounts': ['test-gce'],
+            'account': 'test-gce',
             'utctime': 'now'
         }
 
@@ -27,10 +27,12 @@ class TestGCEDeprecationJob(object):
         }
 
     def test_deprecation_gce_missing_key(self):
-        del self.job_config['deprecation_accounts']
+        del self.job_config['account']
 
         with raises(MashDeprecationException):
             GCEDeprecationJob(self.job_config, self.config)
+
+        self.job_config['account'] = 'test-gce'
 
     @patch.object(GCEDeprecationJob, 'send_log')
     @patch('mash.services.deprecation.gce_job.Provider')

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -1,0 +1,80 @@
+import json
+import pytest
+
+from unittest.mock import patch
+
+from mash.mash_exceptions import MashJobCreatorException
+from mash.services.jobcreator.gce_job import GCEJob
+
+
+@patch.object(GCEJob, '__init__')
+def test_gce_job_missing_keys(mock_init):
+    mock_init.return_value = None
+
+    job = GCEJob({
+        'job_id': '123',
+        'cloud': 'gce',
+        'requesting_user': 'test-user',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here'
+    })
+    job.kwargs = {}
+
+    with pytest.raises(MashJobCreatorException):
+        job.post_init()
+
+
+@patch.object(GCEJob, '__init__')
+def test_gce_job_testing_message(mock_init):
+    mock_init.return_value = None
+
+    job = GCEJob({
+        'job_id': '123',
+        'cloud': 'gce',
+        'requesting_user': 'test-user',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here'
+    })
+    job.kwargs = {
+        'cloud_account': 'acnt1',
+        'bucket': 'images',
+        'cloud': 'gce',
+        'region': 'westus',
+        'testing_account': None
+    }
+    job.cloud = 'gce'
+    job.tests = ['test1']
+    job.distro = 'sles'
+    job.instance_type = 'b1'
+    job.cloud_architecture = 'x86_64'
+    job.test_fallback = False
+    job.test_fallback_regions = None
+    job.base_message = {}
+
+    # Test explicit no cleanup images
+    job.last_service = 'deprecation'
+    job.cleanup_images = False
+
+    job.post_init()
+
+    testing_message = json.loads(job.get_testing_message())
+    assert testing_message['testing_job']['cleanup_images'] is False
+
+    # Test cleanup images on testing only
+    job.last_service = 'testing'
+    job.cleanup_images = True
+
+    job.post_init()
+
+    testing_message = json.loads(job.get_testing_message())
+    assert testing_message['testing_job']['cleanup_images'] is True

--- a/test/unit/services/uploader/gce_job_test.py
+++ b/test/unit/services/uploader/gce_job_test.py
@@ -40,12 +40,9 @@ class TestGCEUploaderJob(object):
             'utctime': 'now',
             'family': 'sles-12',
             'guest_os_features': ['UEFI_COMPATIBLE'],
-            'target_regions': {
-                'us-west1-a': {
-                    'account': 'test',
-                    'bucket': 'images'
-                }
-            },
+            'region': 'us-west1-a',
+            'account': 'test',
+            'bucket': 'images',
             'cloud_image_name': 'sles-12-sp4-v20180909',
             'image_description': 'description 20180909'
         }
@@ -66,27 +63,31 @@ class TestGCEUploaderJob(object):
         with raises(MashUploadException):
             GCEUploaderJob(job_doc, self.config)
 
-        job_doc['target_regions'] = {'us-west1-a': {'account': 'test'}}
+    def test_post_init_sles_11(self):
+        job_doc = {
+            'id': '1',
+            'last_service': 'uploader',
+            'cloud': 'gce',
+            'requesting_user': 'user1',
+            'utctime': 'now',
+            'family': 'sles-11',
+            'guest_os_features': ['UEFI_COMPATIBLE'],
+            'region': 'us-west1-a',
+            'account': 'test',
+            'bucket': 'images',
+            'cloud_image_name': 'sles-11-sp4-v20180909',
+            'image_description': 'description 20180909'
+        }
+
         with raises(MashUploadException):
             GCEUploaderJob(job_doc, self.config)
 
-        job_doc['cloud_image_name'] = 'test image 123'
-        with raises(MashUploadException):
-            GCEUploaderJob(job_doc, self.config)
-
-        job_doc['cloud_image_name'] = 'sles-11'
-        job_doc['image_description'] = 'test image description'
-        with raises(MashUploadException):
-            GCEUploaderJob(job_doc, self.config)
-
-    @patch('mash.services.uploader.gce_job.NamedTemporaryFile')
     @patch('mash.services.uploader.gce_job.Provider')
     @patch('mash.services.uploader.gce_job.get_driver')
     @patch('mash.services.uploader.gce_job.GoogleStorageDriver')
     @patch('builtins.open')
     def test_upload(
-        self, mock_open, mock_storage_driver, mock_get_driver, mock_provider,
-        mock_NamedTemporaryFile
+        self, mock_open, mock_storage_driver, mock_get_driver, mock_provider
     ):
         open_handle = MagicMock()
         open_handle.__enter__.return_value = open_handle
@@ -100,10 +101,6 @@ class TestGCEUploaderJob(object):
 
         storage_driver = Mock()
         mock_storage_driver.return_value = storage_driver
-
-        tempfile = Mock()
-        tempfile.name = 'tempfile'
-        mock_NamedTemporaryFile.return_value = tempfile
 
         self.job.run_job()
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Only a single account is used with GCE. The account list handling is an artifact from EC2 implementation. Simplifies workflow in all GCE jobs.

Note: Temporarily ignored img_proof_helper module from coverage check. Currently the retry regions functionality is not covered since it's broken. This will be resolved in the next PR.
