### PR TITLE
- Update the version for obs-img-utils

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -30,4 +30,4 @@ img-proof>=4.2.0
 lxml
 requests
 urllib3<1.25,>=1.20
-obs-img-utils<=0.0.3
+obs-img-utils<0.1.0

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -51,7 +51,7 @@ BuildRequires:  python3-Flask-SQLAlchemy
 BuildRequires:  python3-Flask-Migrate
 BuildRequires:  python3-flask-jwt-extended
 BuildRequires:  python3-requests
-BuildRequires:  python3-obs-img-utils <= 0.0.3
+BuildRequires:  python3-obs-img-utils < 0.1.0
 Requires:       rabbitmq-server
 Requires:       python3-adal
 Requires:       python3-apache-libcloud
@@ -77,7 +77,7 @@ Requires:       python3-Flask-SQLAlchemy
 Requires:       python3-Flask-Migrate
 Requires:       python3-flask-jwt-extended
 Requires:       python3-requests
-Requires:       python3-obs-img-utils <= 0.0.3
+Requires:       python3-obs-img-utils < 0.1.0
 Requires:       apache2
 Requires:       apache2-mod_wsgi-python3
 Requires(pre):  pwdutils


### PR DESCRIPTION
  + Set the version requirement to 0.1.0 to cover minor improvements in
    obs-img-utils. If the API of obs-img-utils changes it should at least a
    bump in minor version.

### What does this PR do? Why are we making this change?
Update the dependency to a higher version of obs-img-utils. The change is being made to cover a larger range of minor changes in the dependency.

### How will these changes be tested?
No additional tests needed.

### How will this change be deployed? Any special considerations?
Update the package in OBS

### Additional Information
Closes #590 