### PR TITLE
Add disk generation option for Azure publish.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -29,7 +29,7 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "generation_id": "gen2",
+  "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",

--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -29,6 +29,8 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
+  "generation_id": "gen2",
+  "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
   "publish_offer": true,

--- a/mash/services/api/schema/jobs/azure.py
+++ b/mash/services/api/schema/jobs/azure.py
@@ -31,6 +31,10 @@ azure_job_message['properties']['label'] = string_with_example(
 azure_job_message['properties']['offer_id'] = string_with_example('leap')
 azure_job_message['properties']['publisher_id'] = string_with_example('suse')
 azure_job_message['properties']['sku'] = string_with_example('15')
+azure_job_message['properties']['generation_id'] = string_with_example('gen2')
+azure_job_message['properties']['cloud_image_name_generation_suffix'] = string_with_example(
+    'gen2'
+)
 azure_job_message['properties']['vm_images_key'] = string_with_example(
     'microsoft-azure-corevm.vmImagesPublicAzure'
 )

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -53,6 +53,10 @@ class AzureJob(BaseJob):
         self.offer_id = self.kwargs.get('offer_id')
         self.publisher_id = self.kwargs.get('publisher_id')
         self.sku = self.kwargs.get('sku')
+        self.generation_id = self.kwargs.get('generation_id')
+        self.cloud_image_name_generation_suffix = self.kwargs.get(
+            'cloud_image_name_generation_suffix'
+        )
         self.sas_token = self.kwargs.get('sas_token')
         self.sas_container = self.kwargs.get('sas_container')
         self.sas_storage_account = self.kwargs.get('sas_storage_account')
@@ -95,6 +99,14 @@ class AzureJob(BaseJob):
         if self.vm_images_key:
             publisher_message['publisher_job']['vm_images_key'] = \
                 self.vm_images_key
+
+        if self.generation_id:
+            publisher_message['publisher_job']['generation_id'] = \
+                self.generation_id
+
+        if self.cloud_image_name_generation_suffix:
+            publisher_message['publisher_job']['cloud_image_name_generation_suffix'] = \
+                self.cloud_image_name_generation_suffix
 
         publisher_message['publisher_job'].update(self.base_message)
 

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -63,6 +63,10 @@ class AzurePublisherJob(MashJob):
 
         self.vm_images_key = self.job_config.get('vm_images_key')
         self.publish_offer = self.job_config.get('publish_offer', False)
+        self.generation_id = self.job_config.get('generation_id')
+        self.cloud_image_name_generation_suffix = self.job_config.get(
+            'cloud_image_name_generation_suffix'
+        )
 
     def run_job(self):
         """
@@ -96,10 +100,13 @@ class AzurePublisherJob(MashJob):
                     self.publisher_id
                 )
 
+                kwargs = {
+                    'generation_id': self.generation_id,
+                    'cloud_image_name_generation_suffix': self.cloud_image_name_generation_suffix
+                }
+
                 if self.vm_images_key:
-                    kwargs = {'vm_images_key': self.vm_images_key}
-                else:
-                    kwargs = {}
+                    kwargs['vm_images_key'] = self.vm_images_key
 
                 offer_doc = update_cloud_partner_offer_doc(
                     offer_doc,

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -29,7 +29,7 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
-  "generation_id": "gen2",
+  "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -29,6 +29,8 @@
   "publisher_id": "suse",
   "label": "New Image 123",
   "sku": "123",
+  "generation_id": "gen2",
+  "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
   "publish_offer": true,

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -375,7 +375,7 @@ def test_update_cloud_partner_offer_doc():
             'plans': [
                 {
                     'planId': 'gen1',
-                    'diskGenerations': [{'planId': 'gen2'}]
+                    'diskGenerations': [{'planId': 'image-gen2'}]
                 }
             ]
         }
@@ -388,7 +388,8 @@ def test_update_cloud_partner_offer_doc():
         'new-image',
         'New Image 123',
         'gen1',
-        generation_id='gen2'
+        generation_id='image-gen2',
+        cloud_image_name_generation_suffix='gen2'
     )
 
     plan = doc['definition']['plans'][0]

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -373,7 +373,10 @@ def test_update_cloud_partner_offer_doc():
     doc = {
         'definition': {
             'plans': [
-                {'planId': '123'}
+                {
+                    'planId': 'gen1',
+                    'diskGenerations': [{'planId': 'gen2'}]
+                }
             ]
         }
     }
@@ -382,13 +385,16 @@ def test_update_cloud_partner_offer_doc():
         doc,
         'blob/url/.vhd',
         'New image for v123',
-        'New Image',
+        'new-image',
         'New Image 123',
-        '123'
+        'gen1',
+        generation_id='gen2'
     )
 
-    assert doc['definition']['plans'][0][vm_images_key][release]['label'] == \
-        'New Image 123'
+    plan = doc['definition']['plans'][0]
+    assert plan[vm_images_key][release]['label'] == 'New Image 123'
+    assert plan['diskGenerations'][0][vm_images_key][release]['mediaName'] == \
+        'new-image-gen2'
 
 
 def test_update_cloud_partner_offer_doc_existing_date():

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -304,6 +304,8 @@ class TestJobCreatorService(object):
         assert data['offer_id'] == 'sles'
         assert data['publisher_id'] == 'suse'
         assert data['sku'] == '123'
+        assert data['generation_id'] == 'gen2'
+        assert data['cloud_image_name_generation_suffix'] == 'gen2'
         assert data['vm_images_key'] == 'key123'
         assert data['account'] == 'test-azure'
         assert data['container'] == 'container2'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -304,7 +304,7 @@ class TestJobCreatorService(object):
         assert data['offer_id'] == 'sles'
         assert data['publisher_id'] == 'suse'
         assert data['sku'] == '123'
-        assert data['generation_id'] == 'gen2'
+        assert data['generation_id'] == 'image-gen2'
         assert data['cloud_image_name_generation_suffix'] == 'gen2'
         assert data['vm_images_key'] == 'key123'
         assert data['account'] == 'test-azure'


### PR DESCRIPTION
## What does this PR do? Why are we making this change?

Publishing to a second generation is possible using disk generations by providing the generation_id and an optional suffix to be appended to the media name. If no suffix is provided the generation_id is appended instead.

### How will these changes be tested?

Unit + integration. E2E when all changes merged and ready for deployment.