### PR TITLE
Add cloud_account option for ec2 jobs.

### DIFF
--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -54,6 +54,9 @@ ec2_job_message['properties']['cloud_accounts'] = {
     'minItems': 1,
     'example': [{'name': 'account1'}]
 }
+ec2_job_message['properties']['cloud_account'] = string_with_example(
+    'account1'
+)
 ec2_job_message['properties']['cloud_groups'] = {
     'type': 'array',
     'items': non_empty_string,
@@ -62,6 +65,7 @@ ec2_job_message['properties']['cloud_groups'] = {
     'example': ['group1']
 }
 ec2_job_message['anyOf'] = [
+    {'required': ['cloud_accounts']},
     {'required': ['cloud_accounts']},
     {'required': ['cloud_groups']}
 ]

--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -65,7 +65,7 @@ ec2_job_message['properties']['cloud_groups'] = {
     'example': ['group1']
 }
 ec2_job_message['anyOf'] = [
-    {'required': ['cloud_accounts']},
+    {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},
     {'required': ['cloud_groups']}
 ]

--- a/mash/services/api/utils/jobs/ec2.py
+++ b/mash/services/api/utils/jobs/ec2.py
@@ -113,6 +113,12 @@ def update_ec2_job_accounts(job_doc):
 
     accounts = {}
     target_accounts = []
+
+    if job_doc.get('cloud_account'):
+        account_name = job_doc['cloud_account']
+        cloud_account = get_ec2_account_by_id(account_name, user.id)
+        target_accounts.append(cloud_account)
+
     for group_name in job_doc.get('cloud_groups', []):
         group = get_ec2_group(group_name, user.id)
         target_accounts += group.accounts
@@ -133,6 +139,9 @@ def update_ec2_job_accounts(job_doc):
 
     if 'cloud_groups' in job_doc:
         del job_doc['cloud_groups']
+
+    if 'cloud_account' in job_doc:
+        del job_doc['cloud_account']
 
     if 'cloud_accounts' in job_doc:
         del job_doc['cloud_accounts']

--- a/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
@@ -171,3 +171,13 @@ def test_update_ec2_job_accounts(
     }
 
     update_ec2_job_accounts(job_doc)
+
+    # Test doc using cloud_account
+    job_doc = {
+        'requesting_user': 'user1',
+        'cloud_account': 'acnt1'
+    }
+
+    result = update_ec2_job_accounts(job_doc)
+
+    assert 'cloud_account' not in result


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

A cloud_account name can be provided for the job instead of the cloud_accounts list or cloud_groups list.

### How will these changes be tested?

Unit tests.

### Additional Information

Fixes #595 