### PR TITLE
Update job deletion message.

### DIFF
--- a/mash/services/api/routes/jobs/__init__.py
+++ b/mash/services/api/routes/jobs/__init__.py
@@ -97,7 +97,7 @@ class Job(Resource):
 
         if rows_deleted:
             return make_response(
-                jsonify({'msg': 'Job deleted'}),
+                jsonify({'msg': 'Job deletion request submitted'}),
                 200
             )
         else:

--- a/test/unit/services/api/routes/jobs/base_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/base_job_routes_test.py
@@ -18,7 +18,7 @@ def test_api_delete_job(
     )
 
     assert response.status_code == 200
-    assert response.data == b'{"msg":"Job deleted"}\n'
+    assert response.data == b'{"msg":"Job deletion request submitted"}\n'
 
     # Not found
     mock_delete_job.return_value = 0


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Job deletion is only submitted to message queue. It's not guaranteed to be cleaned up in services if it's already finished through obs service.

### How will these changes be tested?

Unit tests.