### PR TITLE
Delete all user credentials when user deleted.

### DIFF
--- a/mash/services/api/utils/users.py
+++ b/mash/services/api/utils/users.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 from mash.services.api.extensions import db
 from mash.services.api.models import User
 from mash.mash_exceptions import MashDBException
+from mash.utils.mash_utils import handle_request
 
 
 def add_user(username, email, password):
@@ -109,6 +110,11 @@ def delete_user(username):
     if user:
         db.session.delete(user)
         db.session.commit()
+        handle_request(
+            current_app.config['CREDENTIALS_URL'],
+            'credentials/{user}'.format(user=username),
+            'delete'
+        )
         return 1
     else:
         return 0

--- a/mash/services/credentials/datastore.py
+++ b/mash/services/credentials/datastore.py
@@ -18,6 +18,7 @@
 
 import json
 import os
+import shutil
 
 from apscheduler import events
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -162,6 +163,12 @@ class CredentialsDatastore(object):
         )
         return path
 
+    def _get_user_credentials_path(self, user):
+        """
+        Return the string path to the user's credentials dir.
+        """
+        return os.path.join(self.credentials_directory, user)
+
     def _get_decrypted_credentials(self, account, cloud, user):
         """
         Return decrypted credentials string from file.
@@ -214,6 +221,19 @@ class CredentialsDatastore(object):
 
         with suppress(Exception):
             os.remove(path)
+
+    def remove_user(self, user):
+        """
+        Attempt to remove the user's credentials dir.
+        """
+        self.log_callback.info(
+            'Deleting credentials for user: {0}'.format(user)
+        )
+
+        path = self._get_user_credentials_path(user)
+
+        with suppress(Exception):
+            shutil.rmtree(path)
 
     def retrieve_credentials(self, cloud_accounts, cloud, requesting_user):
         """

--- a/mash/services/credentials/routes/credentials.py
+++ b/mash/services/credentials/routes/credentials.py
@@ -76,3 +76,15 @@ def delete_credentials():
         return make_response(jsonify({'msg': msg}), 400)
 
     return make_response(jsonify({'msg': 'Credentials deleted'}), 200)
+
+
+@blueprint.route('/<string:user>', methods=['DELETE'])
+def remove_user(user):
+    try:
+        current_app.credentials_datastore.remove_user(user)
+    except Exception as error:
+        msg = 'Unable to remove all credentials for user: {0}'.format(error)
+        current_app.logger.warning(msg)
+        return make_response(jsonify({'msg': msg}), 400)
+
+    return make_response(jsonify({'msg': 'User removed'}), 200)

--- a/test/unit/services/api/utils/user_utils_test.py
+++ b/test/unit/services/api/utils/user_utils_test.py
@@ -84,14 +84,25 @@ def test_get_user_email(mock_get_user):
     assert get_user_email('user1') == 'user1@fake.com'
 
 
+@patch('mash.services.api.utils.users.current_app')
+@patch('mash.services.api.utils.users.handle_request')
 @patch('mash.services.api.utils.users.db')
 @patch('mash.services.api.utils.users.get_user_by_username')
-def test_delete_user(mock_get_user, mock_db):
+def test_delete_user(
+    mock_get_user, mock_db, mock_handle_request, mock_current_app
+):
     user = Mock()
     mock_get_user.return_value = user
+    mock_current_app.config = {'CREDENTIALS_URL': 'http://localhost:5000/'}
 
     assert delete_user('user1') == 1
     mock_db.session.delete.assert_called_once_with(user)
+
+    mock_handle_request.assert_called_once_with(
+        'http://localhost:5000/',
+        'credentials/user1',
+        'delete'
+    )
 
     mock_get_user.return_value = None
     assert delete_user('user1') == 0

--- a/test/unit/services/credentials/credentials_api_test.py
+++ b/test/unit/services/credentials/credentials_api_test.py
@@ -139,3 +139,24 @@ def test_delete_credentials(mock_app, test_client):
     assert response.status_code == 400
     assert response.data == \
         b'{"msg":"Unable to delete credentials: Permission denied"}\n'
+
+
+@patch('mash.services.credentials.routes.credentials.current_app')
+def test_delete_user(mock_app, test_client):
+    response = test_client.delete('credentials/fakeuser101')
+
+    assert response.status_code == 200
+    assert response.data == b'{"msg":"User removed"}\n'
+
+    # Error
+    mock_app.credentials_datastore.remove_user.side_effect = Exception(
+        'Permission denied'
+    )
+    response = test_client.delete('credentials/fakeuser101')
+
+    mock_app.logger.warning.assert_called_once_with(
+        'Unable to remove all credentials for user: Permission denied'
+    )
+    assert response.status_code == 400
+    assert response.data == \
+        b'{"msg":"Unable to remove all credentials for user: Permission denied"}\n'

--- a/test/unit/services/credentials/credentials_datastore_test.py
+++ b/test/unit/services/credentials/credentials_datastore_test.py
@@ -236,3 +236,10 @@ class TestCredentialsDatastore(object):
             )
 
             assert result['super'] == 'secret'
+
+    @patch('mash.services.credentials.datastore.shutil')
+    def test_remove_user(self, mock_shutil):
+        self.datastore.remove_user('fakeuser101')
+        mock_shutil.rmtree.assert_called_once_with(
+            '/var/lib/mash/credentials/fakeuser101'
+        )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

When a user is deleted from the API call credentials remove user route to delete any encrypted credentials from disk.

### How will these changes be tested?

Unit and integration.

Resolves #629 