### PR TITLE
Update default development port for credentials.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -10,7 +10,7 @@ smtp_host: localhost
 smtp_port: 25
 smtp_ssl: False
 smtp_user: test@fake.com
-credentials_url: http://localhost:5000/
+credentials_url: http://localhost:5006/
 database_uri: sqlite:////var/lib/mash/app.db
 services:
   - obs

--- a/mash/services/credentials/wsgi.py
+++ b/mash/services/credentials/wsgi.py
@@ -22,4 +22,4 @@ from mash.services.credentials.flask_config import Config
 application = create_app(Config())
 
 if __name__ == '__main__':
-    application.run(port=5001)
+    application.run(port=5006)

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -8,7 +8,7 @@ amqp_user: guest
 amqp_pass: guest
 smtp_user: user@test.com
 smtp_pass: super.secret
-credentials_url: http://localhost:5000/
+credentials_url: http://localhost:5006/
 database_uri: sqlite:////var/lib/mash/app.db
 max_oci_attempts: 500
 max_oci_wait_seconds: 1000

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -128,7 +128,7 @@ class TestBaseConfig(object):
             '/var/log/mash/jobs/1234.log'
 
     def test_get_credentials_url(self):
-        assert self.config.get_credentials_url() == 'http://localhost:5000/'
+        assert self.config.get_credentials_url() == 'http://localhost:5006/'
         assert self.empty_config.get_credentials_url() == \
             'http://localhost:8080/'
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Match with examples at 5006 and 1 above API dev port which is 5005.
