### PR TITLE
Add configuration options for thread pool count.

### DIFF
--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -370,3 +370,25 @@ class BaseConfig(object):
             attribute='oci_upload_process_count'
         )
         return oci_upload_process_count or Defaults.get_oci_upload_process_count()
+
+    def get_base_thread_pool_count(self):
+        """
+        Return the thread pool count for listener services background scheduler.
+
+        :return: int
+        """
+        base_thread_pool_count = self._get_attribute(
+            attribute='base_thread_pool_count'
+        )
+        return base_thread_pool_count or Defaults.get_base_thread_pool_count()
+
+    def get_publisher_thread_pool_count(self):
+        """
+        Return the thread pool count for publisher background scheduler.
+
+        :return: int
+        """
+        publisher_thread_pool_count = self._get_attribute(
+            attribute='publisher_thread_pool_count'
+        )
+        return publisher_thread_pool_count or Defaults.get_publisher_thread_pool_count()

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -115,3 +115,11 @@ class Defaults(object):
     @staticmethod
     def get_oci_upload_process_count():
         return 3
+
+    @staticmethod
+    def get_base_thread_pool_count():
+        return 10
+
+    @staticmethod
+    def get_publisher_thread_pool_count():
+        return 50

--- a/mash/services/publisher_service.py
+++ b/mash/services/publisher_service.py
@@ -52,14 +52,17 @@ def main():
             }
         )
 
+        config = BaseConfig()
+
         # run service, enter main loop
         ListenerService(
             service_exchange=service_name,
-            config=BaseConfig(),
+            config=config,
             custom_args={
                 'listener_msg_args': ['source_regions'],
                 'status_msg_args': ['source_regions'],
-                'job_factory': job_factory
+                'job_factory': job_factory,
+                'thread_pool_count': config.get_publisher_thread_pool_count()
             }
         )
     except MashException as e:

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -13,6 +13,8 @@ database_uri: sqlite:////var/lib/mash/app.db
 max_oci_attempts: 500
 max_oci_wait_seconds: 1000
 oci_upload_process_count: 2
+base_thread_pool_count: 20
+publisher_thread_pool_count: 60
 services:
   - obs
   - uploader

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -150,3 +150,11 @@ class TestBaseConfig(object):
     def test_get_oci_upload_process_count(self):
         assert self.config.get_oci_upload_process_count() == 2
         assert self.empty_config.get_oci_upload_process_count() == 3
+
+    def test_get_base_thread_pool_count(self):
+        assert self.config.get_base_thread_pool_count() == 20
+        assert self.empty_config.get_base_thread_pool_count() == 10
+
+    def test_get_publisher_thread_pool_count(self):
+        assert self.config.get_publisher_thread_pool_count() == 60
+        assert self.empty_config.get_publisher_thread_pool_count() == 50

--- a/test/unit/services/publisher/main_test.py
+++ b/test/unit/services/publisher/main_test.py
@@ -12,6 +12,7 @@ class TestPublisherServiceMain(object):
         self, mock_publisher_service, mock_config, mock_factory
     ):
         config = Mock()
+        config.get_publisher_thread_pool_count.return_value = 50
         mock_config.return_value = config
 
         factory = Mock()
@@ -24,7 +25,8 @@ class TestPublisherServiceMain(object):
             custom_args={
                 'listener_msg_args': ['source_regions'],
                 'status_msg_args': ['source_regions'],
-                'job_factory': factory
+                'job_factory': factory,
+                'thread_pool_count': 50
             }
         )
 
@@ -36,6 +38,7 @@ class TestPublisherServiceMain(object):
         self, mock_exit, mock_publisher_service, mock_config, mock_factory
     ):
         config = Mock()
+        config.get_publisher_thread_pool_count.return_value = 50
         mock_config.return_value = config
         mock_publisher_service.side_effect = MashPublisherException('error')
 
@@ -49,7 +52,8 @@ class TestPublisherServiceMain(object):
             custom_args={
                 'listener_msg_args': ['source_regions'],
                 'status_msg_args': ['source_regions'],
-                'job_factory': factory
+                'job_factory': factory,
+                'thread_pool_count': 50
             }
         )
         mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

By default publishing service needs more threads to handle long running Azure jobs without blocking pipeline.

Also, log any missed job events. This should not happen because no jobs are scheduled but the log will catch anything not working as expected.

### How will these changes be tested?

Unit and integration tests.

### How will this change be deployed? Any special considerations?


### Additional Information

Fixes #632 