### PR TITLE
Add API for getting job doc schema.

### DIFF
--- a/mash/services/api/routes/jobs/azure.py
+++ b/mash/services/api/routes/jobs/azure.py
@@ -43,15 +43,14 @@ azure_job = api.schema_model('azure_job', azure_job_message)
 
 
 @api.route('/')
-@api.doc(security='apiKey')
-@api.response(400, 'Validation error', validation_error_response)
-@api.response(401, 'Unauthorized', default_response)
-@api.response(422, 'Not processable', default_response)
 class AzureJobCreate(Resource):
-    @api.doc('add_azure_job')
+    @api.doc('add_azure_job', security='apiKey')
     @jwt_required
     @api.expect(azure_job)
     @api.response(201, 'Job added', job_response)
+    @api.response(400, 'Validation error', validation_error_response)
+    @api.response(401, 'Unauthorized', default_response)
+    @api.response(422, 'Not processable', default_response)
     def post(self):
         """
         Add Azure job.
@@ -79,3 +78,11 @@ class AzureJobCreate(Resource):
             jsonify(marshal(job, job_response, skip_none=True)),
             201
         )
+
+    @api.doc('get_azure_job_doc_schema')
+    @api.response(200, 'Success', azure_job)
+    def get(self):
+        """
+        Get azure job doc schema.
+        """
+        return make_response(jsonify(azure_job_message), 200)

--- a/mash/services/api/routes/jobs/ec2.py
+++ b/mash/services/api/routes/jobs/ec2.py
@@ -44,15 +44,14 @@ validation_error_response = api.schema_model(
 
 
 @api.route('/')
-@api.doc(security='apiKey')
-@api.response(400, 'Validation error', validation_error_response)
-@api.response(401, 'Unauthorized', default_response)
-@api.response(422, 'Not processable', default_response)
 class EC2JobCreate(Resource):
-    @api.doc('add_ec2_job')
+    @api.doc('add_ec2_job', security='apiKey')
     @jwt_required
     @api.expect(ec2_job)
     @api.response(201, 'Job added', job_response)
+    @api.response(400, 'Validation error', validation_error_response)
+    @api.response(401, 'Unauthorized', default_response)
+    @api.response(422, 'Not processable', default_response)
     def post(self):
         """
         Add EC2 job.
@@ -80,3 +79,11 @@ class EC2JobCreate(Resource):
             jsonify(marshal(job, job_response, skip_none=True)),
             201
         )
+
+    @api.doc('get_ec2_job_doc_schema')
+    @api.response(200, 'Success', ec2_job)
+    def get(self):
+        """
+        Get ec2 job doc schema.
+        """
+        return make_response(jsonify(ec2_job_message), 200)

--- a/mash/services/api/routes/jobs/gce.py
+++ b/mash/services/api/routes/jobs/gce.py
@@ -43,15 +43,14 @@ validation_error_response = api.schema_model(
 
 
 @api.route('/')
-@api.doc(security='apiKey')
-@api.response(400, 'Validation error', validation_error_response)
-@api.response(401, 'Unauthorized', default_response)
-@api.response(422, 'Not processable', default_response)
-class GCEJobCreate(Resource):
-    @api.doc('add_gce_job')
+class GCEJob(Resource):
+    @api.doc('add_gce_job', security='apiKey')
     @jwt_required
     @api.expect(gce_job)
     @api.response(201, 'Job added', job_response)
+    @api.response(400, 'Validation error', validation_error_response)
+    @api.response(401, 'Unauthorized', default_response)
+    @api.response(422, 'Not processable', default_response)
     def post(self):
         """
         Add GCE job.
@@ -79,3 +78,11 @@ class GCEJobCreate(Resource):
             jsonify(marshal(job, job_response, skip_none=True)),
             201
         )
+
+    @api.doc('get_gce_job_doc_schema')
+    @api.response(200, 'Success', gce_job)
+    def get(self):
+        """
+        Get GCE job doc schema.
+        """
+        return make_response(jsonify(gce_job_message), 200)

--- a/mash/services/api/routes/jobs/oci.py
+++ b/mash/services/api/routes/jobs/oci.py
@@ -43,15 +43,14 @@ validation_error_response = api.schema_model(
 
 
 @api.route('/')
-@api.doc(security='apiKey')
-@api.response(400, 'Validation error', validation_error_response)
-@api.response(401, 'Unauthorized', default_response)
-@api.response(422, 'Not processable', default_response)
 class OCIJobCreate(Resource):
-    @api.doc('add_oci_job')
+    @api.doc('add_oci_job', security='apiKey')
     @jwt_required
     @api.expect(oci_job)
     @api.response(201, 'Job added', job_response)
+    @api.response(400, 'Validation error', validation_error_response)
+    @api.response(401, 'Unauthorized', default_response)
+    @api.response(422, 'Not processable', default_response)
     def post(self):
         """
         Add OCI job.
@@ -79,3 +78,11 @@ class OCIJobCreate(Resource):
             jsonify(marshal(job, job_response, skip_none=True)),
             201
         )
+
+    @api.doc('get_oci_job_doc_schema')
+    @api.response(200, 'Success', oci_job)
+    def get(self):
+        """
+        Get OCI job doc schema.
+        """
+        return make_response(jsonify(oci_job_message), 200)

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -30,7 +30,8 @@ image_conditions = {
         'release': string_with_example('1.1'),
         'condition': {
             'type': 'string',
-            'enum': ['>=', '==', '<=', '>', '<']
+            'enum': ['>=', '==', '<=', '>', '<'],
+            'example': '=='
         }
     },
     'additionalProperties': False,
@@ -66,7 +67,8 @@ base_job_message = {
                 'replication',
                 'publisher',
                 'deprecation'
-            ]
+            ],
+            'example': 'create'
         },
         'utctime': utctime,
         'image': string_with_example('openSUSE-Leap-15.0-EC2-HVM'),
@@ -79,7 +81,14 @@ base_job_message = {
         'conditions': {
             'type': 'array',
             'items': image_conditions,
-            'minItems': 1
+            'minItems': 1,
+            'example': [
+                {
+                    'package_name': 'kernel-default',
+                    'version': '4.13.1',
+                    'condition': '>='
+                }
+            ]
         },
         'download_url': string_with_example(
             'https://download.opensuse.org/repositories/'
@@ -90,7 +99,8 @@ base_job_message = {
         ),
         'distro': {
             'type': 'string',
-            'enum': ['opensuse_leap', 'sles']
+            'enum': ['opensuse_leap', 'sles'],
+            'example': 'sles'
         },
         'instance_type': string_with_example('t2.micro'),
         'tests': {
@@ -99,15 +109,17 @@ base_job_message = {
             'minItems': 1,
             'example': ['test_sles']
         },
-        'cleanup_images': {'type': 'boolean'},
+        'cleanup_images': {'type': 'boolean', 'example': True},
         'cloud_architecture': {
             'type': 'string',
-            'enum': ['x86_64', 'aarch64']
+            'enum': ['x86_64', 'aarch64'],
+            'example': 'x86_64'
         },
         'notification_email': email,
         'notification_type': {
             'type': 'string',
-            'enum': ['periodic', 'single']
+            'enum': ['periodic', 'single'],
+            'example': 'single'
         },
         'profile': string_with_example('Proxy'),
         'conditions_wait_time': {

--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -52,7 +52,7 @@ ec2_job_message['properties']['cloud_accounts'] = {
     'type': 'array',
     'items': ec2_job_account,
     'minItems': 1,
-    'example': [{'name': 'account1'}]
+    'example': [{'name': 'account1', 'region': 'us-east-2'}]
 }
 ec2_job_message['properties']['cloud_account'] = string_with_example(
     'account1'
@@ -62,7 +62,7 @@ ec2_job_message['properties']['cloud_groups'] = {
     'items': non_empty_string,
     'uniqueItems': True,
     'minItems': 1,
-    'example': ['group1']
+    'example': ['group1', 'group2']
 }
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},

--- a/mash/services/api/schema/jobs/gce.py
+++ b/mash/services/api/schema/jobs/gce.py
@@ -32,12 +32,14 @@ gce_job_message['properties']['guest_os_features'] = {
     'type': 'array',
     'items': string_with_example('UEFI_COMPATIBLE'),
     'uniqueItems': True,
-    'minItems': 1
+    'minItems': 1,
+    'example': ['UEFI_COMPATIBLE']
 }
 gce_job_message['properties']['test_fallback_regions'] = {
     'type': 'array',
     'items': string_with_example('us-west1-a'),
-    'minItems': 0
+    'minItems': 0,
+    'example': ['us-west1-a']
 }
 gce_job_message['properties']['testing_account'] = string_with_example(
     'testaccount1'

--- a/test/unit/services/api/routes/jobs/azure_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/azure_job_routes_test.py
@@ -71,3 +71,10 @@ def test_api_add_job_gce(
     )
     assert response.status_code == 400
     assert response.data == b'{"msg":"Job failed: Broken"}\n'
+
+
+def test_api_get_azure_job_schema(test_client):
+    response = test_client.get('/jobs/azure/')
+    assert response.status_code == 200
+    data = json.loads(response.data)  # assert json loads
+    assert data['additionalProperties'] is False

--- a/test/unit/services/api/routes/jobs/ec2_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/ec2_job_routes_test.py
@@ -71,3 +71,10 @@ def test_api_add_job_ec2(
     )
     assert response.status_code == 400
     assert response.data == b'{"msg":"Job failed: Broken"}\n'
+
+
+def test_api_get_ec2_job_schema(test_client):
+    response = test_client.get('/jobs/ec2/')
+    assert response.status_code == 200
+    data = json.loads(response.data)  # assert json loads
+    assert data['additionalProperties'] is False

--- a/test/unit/services/api/routes/jobs/gce_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/gce_job_routes_test.py
@@ -71,3 +71,10 @@ def test_api_add_job_gce(
     )
     assert response.status_code == 400
     assert response.data == b'{"msg":"Job failed: Broken"}\n'
+
+
+def test_api_get_gce_job_schema(test_client):
+    response = test_client.get('/jobs/gce/')
+    assert response.status_code == 200
+    data = json.loads(response.data)  # assert json loads
+    assert data['additionalProperties'] is False

--- a/test/unit/services/api/routes/jobs/oci_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/oci_job_routes_test.py
@@ -73,3 +73,10 @@ def test_api_add_job_oci(
     )
     assert response.status_code == 400
     assert response.data == b'{"msg":"Job failed: Broken"}\n'
+
+
+def test_api_get_oci_job_schema(test_client):
+    response = test_client.get('/jobs/oci/')
+    assert response.status_code == 200
+    data = json.loads(response.data)  # assert json loads
+    assert data['additionalProperties'] is False


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Returns the raw the job doc jsonschema based on cloud provider.
- Also perform some cleanup of base, gce and ec job schemas.

### How will these changes be tested?

Unit and integration tests.

### How will this change be deployed? Any special considerations?


### Additional Information
