### PR TITLE
Change secure boot options.

### DIFF
--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -251,19 +251,18 @@ base_job_message = {
                            'a matching name the job will fail. The * wildcard '
                            'can be used to match a package name pattern.'
         },
-        'enable_uefi': {
-            'type': 'boolean',
-            'example': True,
-            'description': 'Whether to  enable the UEFI boot firmware for '
-                           'the test instance. By default this is disabled.'
-        },
-        'enable_secure_boot': {
-            'type': 'boolean',
-            'example': True,
-            'description': 'Whether to enable secure boot for the test '
-                           'instance. By default this is disabled. If it '
-                           'is set to True and enabled enable_uefi will '
-                           'automatically be enabled as well.'
+        'boot_firmware': {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+                'enum': ['bios', 'uefi'],
+            },
+            'example': ['bios'],
+            'description': 'A list of boot firmware settings to test the '
+                           'image with. The default value if left empty is '
+                           'bios only. If both bios and uefi are provided '
+                           'the image is tested once for each firmware '
+                           'setting.'
         },
     },
     'additionalProperties': False,

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -64,12 +64,8 @@ class BaseJob(object):
         self.target_account_info = kwargs.get('target_account_info')
         self.disallow_licenses = kwargs.get('disallow_licenses')
         self.disallow_packages = kwargs.get('disallow_packages')
-        self.enable_uefi = kwargs.get('enable_uefi', False)
-        self.enable_secure_boot = kwargs.get('enable_secure_boot', False)
+        self.boot_firmware = kwargs.get('boot_firmware', ['bios'])
         self.kwargs = kwargs
-
-        if self.enable_secure_boot and not self.enable_uefi:
-            self.enable_uefi = True
 
         if self.raw_image_upload_type and self.last_service == 'uploader':
             self.cloud = self.raw_image_upload_type

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -108,8 +108,7 @@ class GCEJob(BaseJob):
                 'testing_account': self.testing_account,
                 'distro': self.distro,
                 'instance_type': self.instance_type,
-                'enable_uefi': self.enable_uefi,
-                'enable_secure_boot': self.enable_secure_boot
+                'boot_firmware': self.boot_firmware
             }
         }
 

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -30,8 +30,13 @@ def img_proof_test(
     ssh_key_name=None, ssh_private_key_file=None, ssh_user=None, subnet_id=None,
     tests=None, availability_domain=None, compartment_id=None, tenancy=None,
     oci_user_id=None, signing_key_file=None, signing_key_fingerprint=None,
-    enable_uefi=False, enable_secure_boot=False, image_project=None
+    boot_firmware=None, image_project=None
 ):
+    if boot_firmware and boot_firmware == 'uefi':
+        enable_secure_boot = True
+    else:
+        enable_secure_boot = False
+
     status, result = test_image(
         cloud,
         access_key_id=access_key_id,
@@ -57,7 +62,6 @@ def img_proof_test(
         tenancy=tenancy,
         tests=tests,
         timeout=img_proof_timeout,
-        enable_uefi=enable_uefi,
         enable_secure_boot=enable_secure_boot,
         image_project=image_project
     )

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -21,7 +21,7 @@ class TestJobCreatorBaseJob(object):
             'cleanup_images': True,
             'test_fallback_regions': [],
             'target_account_info': {},
-            'enable_secure_boot': True
+            'boot_firmware': ['bios']
         })
 
     def test_base_job_post_init(self):

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -59,8 +59,7 @@ def test_gce_job_testing_message(mock_init):
     job.cloud_architecture = 'x86_64'
     job.test_fallback = False
     job.test_fallback_regions = None
-    job.enable_uefi = False
-    job.enable_secure_boot = True
+    job.boot_firmware = ['uefi']
     job.base_message = {}
 
     # Test explicit no cleanup images

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -103,7 +103,6 @@ class TestAzureTestingJob(object):
             tenancy=None,
             tests=['test_stuff'],
             timeout=None,
-            enable_uefi=False,
             enable_secure_boot=False,
             image_project=None
         )

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -112,7 +112,6 @@ class TestEC2TestingJob(object):
             tenancy=None,
             tests=['test_stuff'],
             timeout=None,
-            enable_uefi=False,
             enable_secure_boot=False,
             image_project=None
         )

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -21,7 +21,8 @@ class TestGCETestingJob(object):
             'bucket': 'bucket',
             'tests': ['test_stuff'],
             'utctime': 'now',
-            'cleanup_images': True
+            'cleanup_images': True,
+            'boot_firmware': ['uefi']
         }
         self.config = Mock()
         self.config.get_ssh_private_key_file.return_value = \
@@ -111,8 +112,7 @@ class TestGCETestingJob(object):
                 tenancy=None,
                 tests=['test_stuff'],
                 timeout=None,
-                enable_uefi=False,
-                enable_secure_boot=False,
+                enable_secure_boot=True,
                 image_project=None
             )
         ])
@@ -187,8 +187,7 @@ class TestGCETestingJob(object):
                 tenancy=None,
                 tests=['test_stuff'],
                 timeout=None,
-                enable_uefi=False,
-                enable_secure_boot=False,
+                enable_secure_boot=True,
                 image_project=None
             ),
             call(
@@ -216,8 +215,7 @@ class TestGCETestingJob(object):
                 tenancy=None,
                 tests=['test_stuff'],
                 timeout=None,
-                enable_uefi=False,
-                enable_secure_boot=False,
+                enable_secure_boot=True,
                 image_project=None
             )
         ])

--- a/test/unit/services/testing/oci_job_test.py
+++ b/test/unit/services/testing/oci_job_test.py
@@ -102,7 +102,6 @@ class TestOCITestingJob(object):
             tenancy='ocid1.tenancy.oc1..',
             tests=['test_stuff'],
             timeout=600,
-            enable_uefi=False,
             enable_secure_boot=False,
             image_project=None
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

There is now a list of boot_firmwares with two options, uefi and bios. The arg is optional and by default is a list with only bios. Providing both options means the image will be tested twice in GCE framework. Once for bios and once for UEFI/Secure Boot.

### How will these changes be tested?

Unit and integration.

### How will this change be deployed? Any special considerations?

Job doc templates have been updated in a separate PR.

### Additional Information
