### PR TITLE
Better handle the delete message.

### DIFF
--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -125,7 +125,7 @@ class OBSImageBuildResultService(MashService):
         if 'obs_job' in job_data:
             job_id = job_data['obs_job'].get('id', None)
             result = self._add_job(job_data)
-        elif 'obs_job_delete' in job_data and job_data['obs_job_delete']:
+        elif job_data.get('obs_job_delete'):
             job_id = job_data['obs_job_delete']
             self.log.info(
                 'Deleting Job'.format(job_id),


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If the job exists in the service try to clean it up. Then send the message on to the next service in the pipeline. This helps to cleanup jobs if they have stalled for any reason.

### How will these changes be tested?

Unit and integration tests.

### How will this change be deployed? Any special considerations?


### Additional Information
