### PR TITLE
Add additional upload option and raw tarball upload for Azure

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -34,5 +34,6 @@
   "vm_images_key": "key123",
   "notification_email": "test@fake.com",
   "publish_offer": true,
-  "cleanup_images": true
+  "cleanup_images": true,
+  "additional_uploads": ["sha256"]
 }

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -264,6 +264,19 @@ base_job_message = {
                            'the image is tested once for each firmware '
                            'setting.'
         },
+        'additional_uploads': {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+                'enum': ['sha256', 'sha256.asc']
+            },
+            'example': ['sha256.asc'],
+            'description': 'A list of additional image artifacts to upload '
+                           'to the cloud provider bucket alongside the '
+                           'image tarball. This allows the checksum and/or '
+                           'signature to also be uploaded for image '
+                           'verification.'
+        }
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -192,6 +192,10 @@ class AzureJob(BaseJob):
             }
         }
 
+        if self.additional_uploads:
+            uploader_message['uploader_job']['additional_uploads'] = \
+                self.additional_uploads
+
         uploader_message['uploader_job'].update(self.base_message)
 
         return JsonFormat.json_message(uploader_message)

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -65,6 +65,7 @@ class BaseJob(object):
         self.disallow_licenses = kwargs.get('disallow_licenses')
         self.disallow_packages = kwargs.get('disallow_packages')
         self.boot_firmware = kwargs.get('boot_firmware', ['bios'])
+        self.additional_uploads = kwargs.get('additional_uploads')
         self.kwargs = kwargs
 
         if self.raw_image_upload_type and self.last_service == 'uploader':

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -65,7 +65,7 @@ class MashJob(object):
         """
         return {'job_id': self.id}
 
-    def request_credentials(self, accounts):
+    def request_credentials(self, accounts, cloud=None):
         """
         Request credentials from credential service.
 
@@ -75,7 +75,7 @@ class MashJob(object):
             return
 
         data = {
-            'cloud': self.cloud,
+            'cloud': cloud or self.cloud,
             'cloud_accounts': accounts,
             'requesting_user': self.requesting_user
         }

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -18,7 +18,7 @@
 
 from mash.utils.azure import (
     get_blob_url,
-    get_classic_page_blob_service,
+    get_classic_blob_service,
     publish_cloud_partner_offer,
     put_cloud_partner_offer_doc,
     request_cloud_partner_offer_doc,
@@ -165,10 +165,11 @@ class AzurePublisherJob(MashJob):
         """
         Return a SAS url that starts 1 day in past and expires in 92 days.
         """
-        pbs = get_classic_page_blob_service(
+        pbs = get_classic_blob_service(
             auth_file,
             resource_group,
-            storage_account
+            storage_account,
+            is_page_blob=True
         )
 
         url = get_blob_url(

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -19,7 +19,7 @@
 from mash.utils.azure import (
     copy_blob_to_classic_storage,
     delete_image,
-    delete_page_blob
+    delete_blob
 )
 
 from mash.mash_exceptions import MashReplicationException
@@ -93,7 +93,8 @@ class AzureReplicationJob(MashJob):
                     self.source_storage_account,
                     self.destination_container,
                     self.destination_resource_group,
-                    self.destination_storage_account
+                    self.destination_storage_account,
+                    is_page_blob=True
                 )
 
                 if self.cleanup_images:
@@ -107,12 +108,13 @@ class AzureReplicationJob(MashJob):
                         self.source_resource_group,
                         self.cloud_image_name
                     )
-                    delete_page_blob(
+                    delete_blob(
                         auth_file,
                         self.blob_name,
                         self.source_container,
                         self.source_resource_group,
-                        self.source_storage_account
+                        self.source_storage_account,
+                        is_page_blob=True
                     )
             except Exception as error:
                 self.log_callback.error(

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -24,7 +24,7 @@ from mash.mash_exceptions import MashTestingException
 from mash.services.mash_job import MashJob
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.testing.utils import process_test_result
-from mash.utils.azure import delete_image, delete_page_blob
+from mash.utils.azure import delete_image, delete_blob
 from mash.utils.mash_utils import create_ssh_key_pair, create_json_file
 from mash.services.testing.img_proof_helper import img_proof_test
 
@@ -141,12 +141,13 @@ class AzureTestingJob(MashJob):
                     self.resource_group,
                     self.cloud_image_name
                 )
-                delete_page_blob(
+                delete_blob(
                     auth_file,
                     blob_name,
                     self.container,
                     self.resource_group,
-                    self.storage_account
+                    self.storage_account,
+                    is_page_blob=True
                 )
             except Exception as error:
                 self.log_callback.warning(

--- a/mash/services/uploader/azure_job.py
+++ b/mash/services/uploader/azure_job.py
@@ -21,7 +21,7 @@ from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
 from mash.utils.mash_utils import format_string_with_date
 from mash.services.status_levels import SUCCESS
-from mash.utils.azure import upload_azure_image
+from mash.utils.azure import upload_azure_file
 
 
 class AzureUploaderJob(MashJob):
@@ -56,7 +56,7 @@ class AzureUploaderJob(MashJob):
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]
 
-        upload_azure_image(
+        upload_azure_file(
             blob_name,
             self.container,
             self.image_file,
@@ -64,7 +64,8 @@ class AzureUploaderJob(MashJob):
             self.config.get_azure_max_workers(),
             self.storage_account,
             credentials=credentials,
-            resource_group=self.resource_group
+            resource_group=self.resource_group,
+            is_page_blob=True
         )
 
         self.source_regions = {

--- a/mash/services/uploader/azure_raw_job.py
+++ b/mash/services/uploader/azure_raw_job.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2020 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+from mash.services.mash_job import MashJob
+from mash.mash_exceptions import MashUploadException
+from mash.services.status_levels import SUCCESS
+from mash.utils.azure import upload_azure_file
+
+
+class AzureRawUploaderJob(MashJob):
+    """
+    Implements raw image upload to Azure.
+
+    The image tarball is not expanded during upload.
+    """
+    def post_init(self):
+        try:
+            self.container = self.job_config['container']
+            self.storage_account = self.job_config['storage_account']
+            self.account = self.job_config.get('account')
+            self.region = self.job_config.get('region')
+            self.resource_group = self.job_config.get('resource_group')
+        except KeyError as error:
+            raise MashUploadException(
+                'Azure raw uploader jobs require a(n) {0} '
+                'key in the job doc.'.format(
+                    error
+                )
+            )
+
+        self.additional_uploads = self.job_config.get(
+            'additional_uploads',
+            []
+        )
+
+    def run_job(self):
+        self.status = SUCCESS
+        self.log_callback.info('Uploading image.')
+
+        self.request_credentials([self.account], 'azure')
+        credentials = self.credentials[self.account]
+
+        file_name = self.image_file.rsplit(os.sep, maxsplit=1)[-1]
+        self.additional_uploads.append('')
+
+        for extension in self.additional_uploads:
+            upload_file_name = '.'.join(filter(None, [file_name, extension]))
+            file_path = '.'.join(filter(None, [self.image_file, extension]))
+
+            upload_azure_file(
+                upload_file_name,
+                self.container,
+                file_path,
+                self.config.get_azure_max_retry_attempts(),
+                self.config.get_azure_max_workers(),
+                self.storage_account,
+                credentials=credentials,
+                resource_group=self.resource_group,
+                expand_image=False
+            )
+
+        self.source_regions = {
+            'cloud_image_name': file_name,
+            'blob_name': file_name
+        }
+        self.log_callback.info(
+            'Uploaded image: {0}, to the container: {1}'.format(
+                file_name,
+                self.container
+            )
+        )

--- a/mash/services/uploader/azure_sas_job.py
+++ b/mash/services/uploader/azure_sas_job.py
@@ -23,7 +23,7 @@ from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
 from mash.utils.mash_utils import format_string_with_date
 from mash.services.status_levels import SUCCESS
-from mash.utils.azure import upload_azure_image
+from mash.utils.azure import upload_azure_file
 
 
 # https://[storage-account].[maangement-url]/[container]?[SAS token]
@@ -62,14 +62,15 @@ class AzureSASUploaderJob(MashJob):
 
         build = re.search(sas_url_match, self.raw_image_upload_location)
 
-        upload_azure_image(
+        upload_azure_file(
             self.blob_name,
             build.group(2),
             self.image_file,
             self.config.get_azure_max_retry_attempts(),
             self.config.get_azure_max_workers(),
             build.group(1),
-            sas_token=build.group(3)
+            sas_token=build.group(3),
+            is_page_blob=True
         )
         self.log_callback.info(
             'Uploaded blob: {blob} using sas token.'.format(

--- a/mash/services/uploader_service.py
+++ b/mash/services/uploader_service.py
@@ -26,6 +26,7 @@ from mash.services.listener_service import ListenerService
 from mash.services.job_factory import BaseJobFactory
 
 from mash.services.uploader.azure_job import AzureUploaderJob
+from mash.services.uploader.azure_raw_job import AzureRawUploaderJob
 from mash.services.uploader.azure_sas_job import AzureSASUploaderJob
 from mash.services.uploader.gce_job import GCEUploaderJob
 from mash.services.no_op_job import NoOpJob
@@ -49,6 +50,7 @@ def main():
             service_name=service_name,
             job_types={
                 'azure': AzureUploaderJob,
+                'azure_raw': AzureRawUploaderJob,
                 'azure_sas': AzureSASUploaderJob,
                 'ec2': NoOpJob,
                 's3bucket': S3BucketUploaderJob,

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -37,5 +37,6 @@
   "cleanup_images": true,
   "raw_image_upload_type": "s3bucket",
   "raw_image_upload_account": "account",
-  "raw_image_upload_location": "location"
+  "raw_image_upload_location": "location",
+  "additional_uploads": ["sha256"]
 }

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -264,6 +264,7 @@ class TestJobCreatorService(object):
         assert data['container'] == 'container1'
         assert data['resource_group'] == 'rg-1'
         assert data['storage_account'] == 'sa1'
+        assert data['additional_uploads'] == ['sha256']
 
         # create Job Doc
 

--- a/test/unit/services/publisher/azure_job_test.py
+++ b/test/unit/services/publisher/azure_job_test.py
@@ -133,12 +133,12 @@ class TestAzurePublisherJob(object):
         )
 
     @patch('mash.services.publisher.azure_job.get_blob_url')
-    @patch('mash.services.publisher.azure_job.get_classic_page_blob_service')
+    @patch('mash.services.publisher.azure_job.get_classic_blob_service')
     def test_get_blob_url(
-        self, mock_get_pbs, mock_get_blob_url
+        self, mock_get_bs, mock_get_blob_url
     ):
-        pbs = Mock()
-        mock_get_pbs.return_value = pbs
+        bs = Mock()
+        mock_get_bs.return_value = bs
         mock_get_blob_url.return_value = 'blob/url'
 
         url = self.job._get_blob_url(

--- a/test/unit/services/replication/azure_job_test.py
+++ b/test/unit/services/replication/azure_job_test.py
@@ -62,15 +62,15 @@ class TestAzureReplicationJob(object):
 
         self.job_config['account'] = 'acnt1'
 
-    @patch('mash.services.replication.azure_job.delete_page_blob')
+    @patch('mash.services.replication.azure_job.delete_blob')
     @patch('mash.services.replication.azure_job.delete_image')
     @patch('mash.services.replication.azure_job.create_json_file')
     @patch('mash.services.replication.azure_job.copy_blob_to_classic_storage')
     def test_replicate(
         self, mock_copy_blob, mock_create_json_file,
-        mock_delete_image, mock_delete_page_blob
+        mock_delete_image, mock_delete_blob
     ):
-        mock_delete_page_blob.side_effect = Exception('Cannot delete image.')
+        mock_delete_blob.side_effect = Exception('Cannot delete image.')
         mock_create_json_file.return_value.__enter__.return_value = \
             '/tmp/file.auth'
 
@@ -85,12 +85,13 @@ class TestAzureReplicationJob(object):
         )
         mock_copy_blob.assert_called_once_with(
             '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1',
-            'container2', 'rg-2', 'sa2'
+            'container2', 'rg-2', 'sa2', is_page_blob=True
         )
         mock_delete_image.assert_called_once_with(
             '/tmp/file.auth', 'rg-1', 'image123'
         )
-        mock_delete_page_blob.assert_called_once_with(
-            '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1'
+        mock_delete_blob.assert_called_once_with(
+            '/tmp/file.auth', 'image123.vhd', 'container1', 'rg-1', 'sa1',
+            is_page_blob=True
         )
         assert self.job.status == FAILED

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -34,7 +34,7 @@ class TestAzureTestingJob(object):
             AzureTestingJob(self.job_config, self.config)
 
     @patch('mash.services.testing.azure_job.delete_image')
-    @patch('mash.services.testing.azure_job.delete_page_blob')
+    @patch('mash.services.testing.azure_job.delete_blob')
     @patch('mash.services.testing.azure_job.os')
     @patch('mash.services.testing.azure_job.create_ssh_key_pair')
     @patch('mash.services.testing.azure_job.random')

--- a/test/unit/services/uploader/azure_job_test.py
+++ b/test/unit/services/uploader/azure_job_test.py
@@ -67,10 +67,10 @@ class TestAzureUploaderJob(object):
         with raises(MashUploadException):
             AzureUploaderJob(job_doc, self.config)
 
-    @patch('mash.services.uploader.azure_job.upload_azure_image')
+    @patch('mash.services.uploader.azure_job.upload_azure_file')
     @patch('builtins.open')
     def test_upload(
-        self, mock_open, mock_upload_azure_image
+        self, mock_open, mock_upload_azure_file
     ):
         open_handle = MagicMock()
         open_handle.__enter__.return_value = open_handle
@@ -78,7 +78,7 @@ class TestAzureUploaderJob(object):
 
         self.job.run_job()
 
-        mock_upload_azure_image.assert_called_once_with(
+        mock_upload_azure_file.assert_called_once_with(
             'name.vhd',
             'container',
             'file.vhdfixed.xz',
@@ -86,5 +86,6 @@ class TestAzureUploaderJob(object):
             8,
             'storage',
             credentials=self.credentials['test'],
-            resource_group='group_name'
+            resource_group='group_name',
+            is_page_blob=True
         )

--- a/test/unit/services/uploader/azure_raw_job_test.py
+++ b/test/unit/services/uploader/azure_raw_job_test.py
@@ -1,0 +1,106 @@
+from pytest import raises
+from unittest.mock import (
+    MagicMock,
+    patch,
+    call
+)
+
+from mash.services.uploader.azure_raw_job import AzureRawUploaderJob
+from mash.mash_exceptions import MashUploadException
+from mash.services.uploader.config import UploaderConfig
+
+
+class TestAzureRawUploaderJob(object):
+    def setup(self):
+        self.credentials = {
+            'test': {
+                'clientId': 'a',
+                'clientSecret': 'b',
+                'subscriptionId': 'c',
+                'tenantId': 'd',
+                'activeDirectoryEndpointUrl':
+                    'https://login.microsoftonline.com',
+                'resourceManagerEndpointUrl':
+                    'https://management.azure.com/',
+                'activeDirectoryGraphResourceId':
+                    'https://graph.windows.net/',
+                'sqlManagementEndpointUrl':
+                    'https://management.core.windows.net:8443/',
+                'galleryEndpointUrl':
+                    'https://gallery.azure.com/',
+                'managementEndpointUrl':
+                    'https://management.core.windows.net/'
+            }
+        }
+        job_doc = {
+            'id': '1',
+            'last_service': 'uploader',
+            'cloud': 'azure_raw',
+            'requesting_user': 'user1',
+            'utctime': 'now',
+            'account': 'test',
+            'resource_group': 'group_name',
+            'container': 'container',
+            'storage_account': 'storage',
+            'region': 'region',
+            'cloud_image_name': 'name',
+            'additional_uploads': ['sha256.asc']
+        }
+
+        self.config = UploaderConfig(
+            config_file='test/data/mash_config.yaml'
+        )
+
+        self.job = AzureRawUploaderJob(job_doc, self.config)
+        self.job.image_file = 'file.vhdfixed.xz'
+        self.job.credentials = self.credentials
+        self.job._log_callback = MagicMock()
+
+    def test_post_init_incomplete_arguments(self):
+        job_doc = {
+            'cloud_architecture': 'aarch64',
+            'id': '1',
+            'last_service': 'uploader',
+            'requesting_user': 'user1',
+            'cloud': 'gce',
+            'utctime': 'now'
+        }
+
+        with raises(MashUploadException):
+            AzureRawUploaderJob(job_doc, self.config)
+
+    @patch('mash.services.uploader.azure_raw_job.upload_azure_file')
+    @patch('builtins.open')
+    def test_upload(
+        self, mock_open, mock_upload_azure_file
+    ):
+        open_handle = MagicMock()
+        open_handle.__enter__.return_value = open_handle
+        mock_open.return_value = open_handle
+
+        self.job.run_job()
+
+        mock_upload_azure_file.assert_has_calls([
+            call(
+                'file.vhdfixed.xz.sha256.asc',
+                'container',
+                'file.vhdfixed.xz.sha256.asc',
+                5,
+                8,
+                'storage',
+                credentials=self.credentials['test'],
+                resource_group='group_name',
+                expand_image=False
+            ),
+            call(
+                'file.vhdfixed.xz',
+                'container',
+                'file.vhdfixed.xz',
+                5,
+                8,
+                'storage',
+                credentials=self.credentials['test'],
+                resource_group='group_name',
+                expand_image=False
+            )
+        ])

--- a/test/unit/services/uploader/azure_sas_job_test.py
+++ b/test/unit/services/uploader/azure_sas_job_test.py
@@ -41,7 +41,7 @@ class TestAzureSASUploaderJob(object):
         with raises(MashUploadException):
             AzureSASUploaderJob(job_doc, self.config)
 
-    @patch('mash.services.uploader.azure_sas_job.upload_azure_image')
+    @patch('mash.services.uploader.azure_sas_job.upload_azure_file')
     @patch('builtins.open')
     def test_sas_upload_only(
         self, mock_open, mock_upload_azure_image
@@ -58,10 +58,11 @@ class TestAzureSASUploaderJob(object):
             5,
             8,
             'storage',
-            sas_token='sas_token'
+            sas_token='sas_token',
+            is_page_blob=True
         )
 
-    @patch('mash.services.uploader.azure_sas_job.upload_azure_image')
+    @patch('mash.services.uploader.azure_sas_job.upload_azure_file')
     @patch('builtins.open')
     def test_sas_upload(
         self, mock_open, mock_upload_azure_image
@@ -84,5 +85,6 @@ class TestAzureSASUploaderJob(object):
             5,
             8,
             'storage',
-            sas_token='sas_token'
+            sas_token='sas_token',
+            is_page_blob=True
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Update Azure utils to be more generic. For all blob methods accept both page and block blob usage. And for upload method accept block files or expanded image uploads.

Add additional uploads option. To provide a way for image checcksum and/or signature to be
uploaded alongside the image.

Add class for raw Azure image upload. This will upload an Azure image as a tarball without expansion. The class also allows for multi file upload to upload checksum and/or signature files.

Fix new flake8 warnings. Format string arg is no longer used.

### How will these changes be tested?

Unit and E2E tests.

### How will this change be deployed? Any special considerations?


### Additional Information
