### PR TITLE
Add snapshot sharing for EC2 images

### DIFF
--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -25,5 +25,6 @@
   "notification_email": "test@fake.com",
   "conditions_wait_time": 500,
   "disallow_licenses": ["MIT"],
-  "disallow_packages": ["*-mini"]
+  "disallow_packages": ["*-mini"],
+  "share_snapshot_with": "123456789012"
 }

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -26,5 +26,5 @@
   "conditions_wait_time": 500,
   "disallow_licenses": ["MIT"],
   "disallow_packages": ["*-mini"],
-  "share_snapshot_with": "123456789012"
+  "share_snapshot_with": "123456789012,987654321210"
 }

--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -114,6 +114,14 @@ ec2_job_message['properties']['skip_replication'] = {
                    'the image that is uploaded will not be replicated'
                    'to any regions.'
 }
+ec2_job_message['properties']['share_snapshot_with'] = {
+    'type': 'string',
+    'format': 'regex',
+    'pattern': '^[0-9]{12}(,[0-9]{12})*$',
+    'example': '123456789012,098765432109',
+    'description': 'A comma-separated list of accounts to share the '
+                   'image snapshot with.'
+}
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -96,7 +96,7 @@ ec2_job_message['properties']['cloud_account'] = string_with_example(
     'account1',
     description='The name of the cloud account to use for '
                 'the job. This is mutually exclusive with the '
-                '"cloud_acconts" setting.'
+                '"cloud_accounts" setting.'
 )
 ec2_job_message['properties']['cloud_groups'] = {
     'type': 'array',
@@ -107,6 +107,12 @@ ec2_job_message['properties']['cloud_groups'] = {
     'description': 'A list of cloud groups to use for EC2 credentials. '
                    'Either a cloud_account, cloud_accounts or cloud_groups '
                    'is required for an EC2 job.'
+}
+ec2_job_message['properties']['skip_replication'] = {
+    'type': 'boolean',
+    'description': 'Whether to skip the replication step. If true '
+                   'the image that is uploaded will not be replicated'
+                   'to any regions.'
 }
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -35,6 +35,7 @@ class EC2Job(BaseJob):
         self.allow_copy = self.kwargs.get('allow_copy', True)
         self.billing_codes = self.kwargs.get('billing_codes')
         self.use_root_swap = self.kwargs.get('use_root_swap', False)
+        self.share_snapshot_with = self.kwargs.get('share_snapshot_with')
 
     def _get_target_regions_list(self):
         """
@@ -85,6 +86,10 @@ class EC2Job(BaseJob):
             }
         }
         publisher_message['publisher_job'].update(self.base_message)
+
+        if self.share_snapshot_with:
+            publisher_message['publisher_job']['share_snapshot_with'] = \
+                self.share_snapshot_with
 
         return JsonFormat.json_message(publisher_message)
 

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -21,6 +21,7 @@ from ec2imgutils.ec2publishimg import EC2PublishImage
 from mash.mash_exceptions import MashPublisherException
 from mash.services.mash_job import MashJob
 from mash.services.status_levels import SUCCESS
+from mash.utils.ec2 import share_image_snapshot
 
 
 class EC2PublisherJob(MashJob):
@@ -44,6 +45,7 @@ class EC2PublisherJob(MashJob):
 
         self.allow_copy = self.job_config.get('allow_copy', True)
         self.share_with = self.job_config.get('share_with', 'all')
+        self.share_snapshot_with = self.job_config.get('share_snapshot_with')
 
     def run_job(self):
         """
@@ -81,3 +83,22 @@ class EC2PublisherJob(MashJob):
                             cloud_image_name, region, error
                         )
                     )
+
+                if region in self.source_regions and self.share_snapshot_with:
+                    # only share snapshot once from source region
+                    try:
+                        share_image_snapshot(
+                            cloud_image_name,
+                            self.share_snapshot_with,
+                            region,
+                            creds['access_key_id'],
+                            creds['secret_access_key']
+                        )
+                    except Exception:
+                        self.send_log(
+                            'Failed to share snapshot for {0} in {1}.'.format(
+                                cloud_image_name,
+                                region
+                            ),
+                            success=False
+                        )

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -124,3 +124,31 @@ def wait_for_instance_termination(
     )
     waiter = client.get_waiter('instance_terminated')
     waiter.wait(InstanceIds=[instance_id])
+
+
+def share_image_snapshot(
+    image_name,
+    share_with,
+    region,
+    access_key_id,
+    secret_access_key
+):
+    client = get_client(
+        'ec2',
+        access_key_id,
+        secret_access_key,
+        region
+    )
+    images = describe_images(client)
+
+    for image in images:
+        if image['Name'] == image_name:
+            snapshot_id = image['BlockDeviceMappings'][0]['Ebs']['SnapshotId']
+            break
+
+    client.modify_snapshot_attribute(
+        Attribute='createVolumePermission',
+        OperationType='add',
+        SnapshotId=snapshot_id,
+        UserIds=share_with.split(',')
+    )

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -31,5 +31,6 @@
   "raw_image_upload_account": "account",
   "raw_image_upload_location": "location",
   "disallow_licenses": ["MIT"],
-  "disallow_packages": ["*-mini"]
+  "disallow_packages": ["*-mini"],
+  "share_snapshot_with": "123456789012"
 }

--- a/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/ec2_job_utils_test.py
@@ -118,6 +118,16 @@ def test_add_target_ec2_account(mock_get_regions):
 
     assert accounts['us-east-100']['helper_image'] == 'ami-987'
 
+    add_target_ec2_account(
+        account,
+        accounts,
+        cloud_accounts,
+        helper_images,
+        skip_replication=True
+    )
+
+    assert 'us-east-99' not in accounts
+
 
 def test_convert_account_dict():
     accounts = [{'name': 'acnt1', 'data': 'more_stuff'}]

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -189,6 +189,7 @@ class TestJobCreatorService(object):
         check_base_attrs(data)
         assert data['allow_copy'] is False
         assert data['share_with'] == 'all'
+        assert data['share_snapshot_with'] == '123456789012'
 
         for region in data['publish_regions']:
             if region['account'] == 'test-aws-gov':


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Add option to skip replication in EC2. If skipping replication only provide the source region in target
region list.

Add utility method to share image snapshot. The method finds an image base on name and shares the related snapshot with a list of accounts.

Implement option to share image snapshot. In ec2 jobs the image snapshot can now be shared with a list of accounts. This allows the snapshot to be shared as part of a normal publishing job or as a snapshot share only job.

### How will these changes be tested?

Unit and E2E tests.

### How will this change be deployed? Any special considerations?


### Additional Information
