### PR TITLE
Fix logging in listener service classes.

### DIFF
--- a/mash/log/filter.py
+++ b/mash/log/filter.py
@@ -42,11 +42,11 @@ class BaseServiceFilter(logging.Filter):
     def filter(self, record):
         record.newline = os.linesep
         if hasattr(record, 'job_id'):
-            record.job = 'Job[{0}]:'.format(record.job_id)
+            record.job = 'Job[{0}]: '.format(record.job_id)
         else:
             record.job = ''
         if hasattr(record, 'iteration'):
-            record.iteration = 'Pass[{0}]:'.format(record.iteration)
+            record.iteration = 'Pass[{0}]: '.format(record.iteration)
         else:
             record.iteration = ''
         return True

--- a/mash/services/create/azure_job.py
+++ b/mash/services/create/azure_job.py
@@ -47,7 +47,7 @@ class AzureCreateJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Creating image.')
+        self.log_callback.info('Creating image.')
 
         self.cloud_image_name = self.source_regions['cloud_image_name']
         self.blob_name = self.source_regions['blob_name']
@@ -57,7 +57,7 @@ class AzureCreateJob(MashJob):
 
         self._create_image(self.blob_name, credentials)
 
-        self.send_log(
+        self.log_callback.info(
             'Image has ID: {0} in region {1}'.format(
                 self.cloud_image_name,
                 self.region

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -62,7 +62,7 @@ class EC2CreateJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Creating image.')
+        self.log_callback.info('Creating image.')
 
         self.cloud_image_name = format_string_with_date(
             self.base_cloud_image_name
@@ -179,7 +179,7 @@ class EC2CreateJob(MashJob):
                     )
 
                 self.source_regions[region] = ami_id
-                self.send_log(
+                self.log_callback.info(
                     'Created image has ID: {0} in region {1}'.format(
                         ami_id, region
                     )

--- a/mash/services/create/gce_job.py
+++ b/mash/services/create/gce_job.py
@@ -54,7 +54,7 @@ class GCECreateJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Creating image.')
+        self.log_callback.info('Creating image.')
 
         self.cloud_image_name = self.source_regions['cloud_image_name']
         object_name = self.source_regions['object_name']
@@ -100,7 +100,7 @@ class GCECreateJob(MashJob):
                 **kwargs
             )
 
-        self.send_log(
+        self.log_callback.info(
             'Created image has ID: {0}'.format(
                 self.cloud_image_name
             )

--- a/mash/services/create/oci_job.py
+++ b/mash/services/create/oci_job.py
@@ -61,7 +61,7 @@ class OCICreateJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Creating image.')
+        self.log_callback.info('Creating image.')
 
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]
@@ -117,7 +117,7 @@ class OCICreateJob(MashJob):
             'cloud_image_name': cloud_image_name,
             'image_id': response.data.id
         }
-        self.send_log(
+        self.log_callback.info(
             'Created image has ID: {0}.'.format(
                 object_name
             )

--- a/mash/services/deprecation/ec2_job.py
+++ b/mash/services/deprecation/ec2_job.py
@@ -80,10 +80,9 @@ class EC2DeprecationJob(MashJob):
                 try:
                     result = deprecator.deprecate_images()
                     if result is False:
-                        self.send_log(
+                        self.log_callback.warning(
                             'Unable to deprecate image in {region}, '
-                            'no image found.'.format(region=region),
-                            False
+                            'no image found.'.format(region=region)
                         )
                 except Exception as error:
                     raise MashDeprecationException(

--- a/mash/services/deprecation/gce_job.py
+++ b/mash/services/deprecation/gce_job.py
@@ -88,18 +88,17 @@ class GCEDeprecationJob(MashJob):
                     self.cloud_image_name,
                     deleted=delete_timestamp
                 )
-                self.send_log(
+                self.log_callback.info(
                     'Deprecated image {0}.'.format(
                         self.old_cloud_image_name
                     )
                 )
             except Exception as error:
-                self.send_log(
+                self.log_callback.error(
                     'There was an error deprecating image in {0}:'
                     ' {1}'.format(
                         self.account,
                         error
-                    ),
-                    False
+                    )
                 )
                 self.status = FAILED

--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -136,7 +136,7 @@ class ListenerService(MashService):
                 )
             else:
                 self.jobs[job.id] = job
-                job.log_callback = self.log_job_message
+                job.log_callback = self.log
 
                 if 'job_file' not in job_config:
                     job_config['job_file'] = '{0}job-{1}.json'.format(
@@ -486,15 +486,6 @@ class ListenerService(MashService):
         Publish the result message to the listener queue on given exchange.
         """
         self._publish(exchange, self.listener_msg_key, message)
-
-    def log_job_message(self, msg, metadata, success=True):
-        """
-        Callback for job instance to log given message.
-        """
-        if success:
-            self.log.info(msg, extra=metadata)
-        else:
-            self.log.error(msg, extra=metadata)
 
     def start(self):
         """

--- a/mash/services/no_op_job.py
+++ b/mash/services/no_op_job.py
@@ -36,7 +36,7 @@ class NoOpJob(MashJob):
         Do nothing and be successful.
         """
         self.status = SUCCESS
-        self.send_log(
+        self.log_callback.info(
             'Skip {0} cloud framework, has no implementation.'.format(
                 self.cloud
             )

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -81,7 +81,7 @@ class AzurePublisherJob(MashJob):
         self.blob_name = self.source_regions['blob_name']
 
         with create_json_file(credential) as auth_file:
-            self.send_log(
+            self.log_callback.info(
                 'Publishing image for account: {},'
                 ' using cloud partner API.'.format(
                     self.account
@@ -125,7 +125,7 @@ class AzurePublisherJob(MashJob):
                     self.offer_id,
                     self.publisher_id
                 )
-                self.send_log(
+                self.log_callback.info(
                     'Updated cloud partner offer doc for account: {}.'.format(
                         self.account
                     )
@@ -141,21 +141,20 @@ class AzurePublisherJob(MashJob):
                     wait_on_cloud_partner_operation(
                         credential,
                         operation,
-                        self.send_log
+                        self.log_callback
                     )
 
-                self.send_log(
+                self.log_callback.info(
                     'Publishing finished for account: {}.'.format(
                         self.account
                     )
                 )
             except Exception as error:
-                self.send_log(
+                self.log_callback.error(
                     'There was an error publishing image in {0}: {1}'.format(
                         self.account,
                         error
-                    ),
-                    False
+                    )
                 )
                 self.status = FAILED
 

--- a/mash/services/replication/azure_job.py
+++ b/mash/services/replication/azure_job.py
@@ -77,7 +77,7 @@ class AzureReplicationJob(MashJob):
         self.blob_name = self.source_regions['blob_name']
 
         with create_json_file(credential) as auth_file:
-            self.send_log(
+            self.log_callback.info(
                 'Copying image for account: {},'
                 ' to classic storage container.'.format(
                     self.account
@@ -97,7 +97,7 @@ class AzureReplicationJob(MashJob):
                 )
 
                 if self.cleanup_images:
-                    self.send_log(
+                    self.log_callback.info(
                         'Removing ARM image and page blob for account: {}.'.format(
                             self.account
                         )
@@ -115,11 +115,10 @@ class AzureReplicationJob(MashJob):
                         self.source_storage_account
                     )
             except Exception as error:
-                self.send_log(
+                self.log_callback.error(
                     'There was an error copying image blob in {0}: {1}'.format(
                         self.account,
                         error
-                    ),
-                    False
+                    )
                 )
                 self.status = FAILED

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -68,7 +68,7 @@ class EC2ReplicationJob(MashJob):
         for source_region, reg_info in self.replication_source_regions.items():
             credential = self.credentials[reg_info['account']]
 
-            self.send_log(
+            self.log_callback.info(
                 'Replicating source region: {0} to the following regions: {1}.'
                 .format(
                     source_region, ', '.join(reg_info['target_regions'])
@@ -108,7 +108,7 @@ class EC2ReplicationJob(MashJob):
                     )
                 except Exception as error:
                     self.status = FAILED
-                    self.send_log(
+                    self.log_callback.warning(
                         'Replication to {0} region failed: {1}'.format(
                             target_region,
                             error

--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -81,7 +81,7 @@ class AzureTestingJob(MashJob):
         Tests image with img-proof and update status and results.
         """
         self.status = SUCCESS
-        self.send_log(
+        self.log_callback.info(
             'Running img-proof tests against image with '
             'type: {inst_type}.'.format(
                 inst_type=self.instance_type
@@ -115,7 +115,7 @@ class AzureTestingJob(MashJob):
 
         self.status = process_test_result(
             result,
-            self.send_log,
+            self.log_callback,
             self.region
         )
 
@@ -127,7 +127,7 @@ class AzureTestingJob(MashJob):
         credentials = self.credentials[self.account]
         blob_name = self.source_regions['blob_name']
 
-        self.send_log(
+        self.log_callback.info(
             'Cleaning up image: {0} in region: {1}.'.format(
                 self.cloud_image_name,
                 self.region
@@ -149,7 +149,6 @@ class AzureTestingJob(MashJob):
                     self.storage_account
                 )
             except Exception as error:
-                self.send_log(
-                    'Failed to cleanup image: {0}'.format(error),
-                    success=False
+                self.log_callback.warning(
+                    'Failed to cleanup image: {0}'.format(error)
                 )

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -98,7 +98,7 @@ class EC2TestingJob(MashJob):
         Tests image with img-proof and update status and results.
         """
         self.status = SUCCESS
-        self.send_log(
+        self.log_callback.info(
             'Running img-proof tests against image with '
             'type: {inst_type}.'.format(
                 inst_type=self.instance_type
@@ -147,7 +147,7 @@ class EC2TestingJob(MashJob):
                         'msg': str(traceback.format_exc())
                     }
 
-                status = process_test_result(result, self.send_log, region)
+                status = process_test_result(result, self.log_callback, region)
                 if status != SUCCESS:
                     self.status = status
 
@@ -173,7 +173,7 @@ class EC2TestingJob(MashJob):
                 )
 
     def cleanup_ec2_image(self, credentials, region, image_id):
-        self.send_log(
+        self.log_callback.info(
             'Cleaning up image: {0} in region: {1}.'.format(
                 image_id,
                 region
@@ -192,7 +192,6 @@ class EC2TestingJob(MashJob):
             ec2_remove_img.set_region(region)
             ec2_remove_img.remove_images()
         except Exception as error:
-            self.send_log(
-                'Failed to cleanup image: {0}'.format(error),
-                success=False
+            self.log_callback.warning(
+                'Failed to cleanup image: {0}'.format(error)
             )

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -108,7 +108,7 @@ class GCETestingJob(MashJob):
 
         with create_json_file(credentials) as auth_file:
             for firmware in self.boot_firmware:
-                self.send_log(
+                self.log_callback.info(
                     'Running img-proof tests against image with '
                     'type: {inst_type}. Using boot firmware setting: '
                     '{firmware}.'.format(
@@ -155,7 +155,7 @@ class GCETestingJob(MashJob):
 
                 self.status = process_test_result(
                     result,
-                    self.send_log,
+                    self.log_callback,
                     self.region
                 )
 
@@ -169,7 +169,7 @@ class GCETestingJob(MashJob):
     def cleanup_image(self):
         credentials = self.credentials[self.account]
 
-        self.send_log(
+        self.log_callback.info(
             'Cleaning up image: {0} in region: {1}.'.format(
                 self.cloud_image_name,
                 self.region
@@ -179,7 +179,6 @@ class GCETestingJob(MashJob):
         try:
             cleanup_gce_image(credentials, self.cloud_image_name, self.bucket)
         except Exception as error:
-            self.send_log(
-                'Failed to cleanup image: {0}'.format(error),
-                success=False
+            self.log_callback.warning(
+                'Failed to cleanup image: {0}'.format(error)
             )

--- a/mash/services/testing/oci_job.py
+++ b/mash/services/testing/oci_job.py
@@ -84,7 +84,7 @@ class OCITestingJob(MashJob):
         Tests image with img-proof and update status and results.
         """
         self.status = SUCCESS
-        self.send_log(
+        self.log_callback.info(
             'Running img-proof tests against image with '
             'type: {inst_type}.'.format(
                 inst_type=self.instance_type
@@ -125,7 +125,7 @@ class OCITestingJob(MashJob):
 
         self.status = process_test_result(
             result,
-            self.send_log,
+            self.log_callback,
             self.region
         )
 
@@ -134,7 +134,7 @@ class OCITestingJob(MashJob):
             self.cleanup_image(credentials, image_id)
 
     def cleanup_image(self, credentials, image_id):
-        self.send_log(
+        self.log_callback.info(
             'Cleaning up image: {0} in region: {1}.'.format(
                 self.cloud_image_name,
                 self.region
@@ -169,7 +169,6 @@ class OCITestingJob(MashJob):
                 waiter_kwargs={'max_wait_seconds': self.max_oci_wait_seconds}
             )
         except Exception as error:
-            self.send_log(
-                'Failed to cleanup image: {0}'.format(error),
-                success=False
+            self.log_callback.warning(
+                'Failed to cleanup image: {0}'.format(error)
             )

--- a/mash/services/testing/utils.py
+++ b/mash/services/testing/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+# Copyright (c) 2020 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -25,19 +25,18 @@ def get_testing_account(account_info):
 
 def process_test_result(result, log_callback, region):
     if 'results_file' in result:
-        log_callback(
+        log_callback.info(
             'Results file for {0} region: {1}'.format(
                 region, result['results_file']
             )
         )
 
     if result['status'] != SUCCESS:
-        log_callback(
-            'Image tests failed in region: {0}.'.format(region),
-            success=False
+        log_callback.warning(
+            'Image tests failed in region: {0}.'.format(region)
         )
         if result.get('msg'):
-            log_callback(result['msg'], success=False)
+            log_callback.error(result['msg'])
 
         return FAILED
 

--- a/mash/services/uploader/azure_job.py
+++ b/mash/services/uploader/azure_job.py
@@ -46,7 +46,7 @@ class AzureUploaderJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Uploading image.')
+        self.log_callback.info('Uploading image.')
 
         self.cloud_image_name = format_string_with_date(
             self.base_cloud_image_name
@@ -71,7 +71,7 @@ class AzureUploaderJob(MashJob):
             'cloud_image_name': self.cloud_image_name,
             'blob_name': blob_name
         }
-        self.send_log(
+        self.log_callback.info(
             'Uploaded image: {0}, to the container: {1}'.format(
                 blob_name,
                 self.container

--- a/mash/services/uploader/azure_sas_job.py
+++ b/mash/services/uploader/azure_sas_job.py
@@ -49,7 +49,7 @@ class AzureSASUploaderJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Uploading image.')
+        self.log_callback.info('Uploading image.')
 
         if self.cloud_image_name:
             self.cloud_image_name = format_string_with_date(
@@ -71,7 +71,7 @@ class AzureSASUploaderJob(MashJob):
             build.group(1),
             sas_token=build.group(3)
         )
-        self.send_log(
+        self.log_callback.info(
             'Uploaded blob: {blob} using sas token.'.format(
                 blob=self.blob_name
             )

--- a/mash/services/uploader/gce_job.py
+++ b/mash/services/uploader/gce_job.py
@@ -53,7 +53,7 @@ class GCEUploaderJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Uploading image.')
+        self.log_callback.info('Uploading image.')
 
         self.cloud_image_name = format_string_with_date(
             self.base_cloud_image_name
@@ -81,7 +81,7 @@ class GCEUploaderJob(MashJob):
             'cloud_image_name': self.cloud_image_name,
             'object_name': object_name
         }
-        self.send_log(
+        self.log_callback.info(
             'Uploaded image: {0}, to the bucket named: {1}'.format(
                 object_name,
                 self.bucket

--- a/mash/services/uploader/oci_job.py
+++ b/mash/services/uploader/oci_job.py
@@ -56,7 +56,7 @@ class OCIUploaderJob(MashJob):
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Uploading image.')
+        self.log_callback.info('Uploading image.')
 
         self.cloud_image_name = format_string_with_date(
             self.base_cloud_image_name
@@ -97,7 +97,7 @@ class OCIUploaderJob(MashJob):
             'object_name': object_name,
             'namespace': namespace
         }
-        self.send_log(
+        self.log_callback.info(
             'Uploaded image: {0}, to the bucket named: {1}'.format(
                 object_name,
                 self.bucket
@@ -112,7 +112,7 @@ class OCIUploaderJob(MashJob):
             current_percent = int(
                 percent_transferred - (percent_transferred % self._progress_step)
             )
-            self.send_log('Image {progress}% uploaded.'.format(
+            self.log_callback.info('Image {progress}% uploaded.'.format(
                 progress=str(current_percent)
             ))
             self._next_percent += self._progress_step

--- a/mash/services/uploader/s3bucket_job.py
+++ b/mash/services/uploader/s3bucket_job.py
@@ -57,13 +57,13 @@ class S3BucketUploaderJob(MashJob):
             self._last_percentage_logged = int(
                 percent_transferred - (percent_transferred % self._percentage_log_step)
             )
-            self.send_log('Raw image {progress}% uploaded.'.format(
+            self.log_callback.info('Raw image {progress}% uploaded.'.format(
                 progress=str(self._last_percentage_logged)
             ))
 
     def run_job(self):
         self.status = SUCCESS
-        self.send_log('Uploading raw image.')
+        self.log_callback.info('Uploading raw image.')
 
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]

--- a/mash/utils/azure.py
+++ b/mash/utils/azure.py
@@ -338,7 +338,7 @@ def log_operation_response_status(response, log_callback):
     """
     for step in response['steps']:
         if step['status'] == 'inProgress':
-            log_callback(
+            log_callback.info(
                 '{0} {1}% complete.'.format(
                     step['stepName'],
                     str(step['progressPercentage'])

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -215,7 +215,7 @@ def setup_logfile(logfile):
 def get_logging_formatter():
     return logging.Formatter(
         '%(newline)s%(levelname)s %(asctime)s %(name)s%(newline)s'
-        '    %(job)s %(message)s'
+        '    %(job)s%(iteration)s%(message)s'
     )
 
 

--- a/test/unit/log_filter_test.py
+++ b/test/unit/log_filter_test.py
@@ -36,12 +36,12 @@ class TestBaseServiceFilter(object):
         self.record.job_id = '123'
         assert self.log_filter.filter(self.record) is True
         assert self.record.newline == os.linesep
-        assert self.record.job == 'Job[123]:'
+        assert self.record.job == 'Job[123]: '
 
     def test_filter_with_iteration(self):
         self.record.iteration = '1'
         assert self.log_filter.filter(self.record) is True
-        assert self.record.iteration == 'Pass[1]:'
+        assert self.record.iteration == 'Pass[1]: '
 
     def test_filter_with_no_iteration(self):
         delattr(self.record, 'iteration')

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -309,7 +309,7 @@ def test_log_operation_response_status():
     }
 
     log_operation_response_status(response, callback)
-    callback.assert_called_once_with(
+    callback.info.assert_called_once_with(
         'Publishing the image 30% complete.'
     )
 

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -30,21 +30,6 @@ class TestMashJob(object):
         assert job.cloud == 'ec2'
         assert job.utctime == 'now'
 
-    def test_send_log(self):
-        callback = Mock()
-
-        job = MashJob(self.job_config, self.config)
-        job.log_callback = callback
-        job.iteration_count = 0
-
-        job.send_log('Starting publish.')
-
-        callback.assert_called_once_with(
-            'Pass[0]: Starting publish.',
-            {'job_id': '1'},
-            True
-        )
-
     @patch('mash.services.mash_job.handle_request')
     def test_request_credentials(self, mock_handle_request):
         callback = Mock()
@@ -102,15 +87,18 @@ class TestMashJob(object):
         job.cloud_image_name = 'name123'
         assert job.cloud_image_name == 'name123'
 
-    def test_set_log_callback(self):
+    @patch('mash.services.mash_job.logging')
+    def test_set_log_callback(self, mock_logging):
         job = MashJob(self.job_config, self.config)
-        callback = Mock()
-        job.log_callback = callback
+        adapter = Mock()
+        mock_logging.LoggerAdapter.return_value = adapter
+        job.log_callback = Mock()
 
-        assert job.log_callback == callback
+        assert job.log_callback == adapter
 
     @patch.object(MashJob, 'run_job')
     def test_process_job(self, mock_run_job):
         job = MashJob(self.job_config, self.config)
+        job._log_callback = Mock()
         job.process_job()
         mock_run_job.assert_called_once_with()

--- a/test/unit/services/create/azure_job_test.py
+++ b/test/unit/services/create/azure_job_test.py
@@ -50,6 +50,7 @@ class TestAzureCreateJob(object):
 
         self.job = AzureCreateJob(job_doc, self.config)
         self.job.credentials = self.credentials
+        self.job._log_callback = Mock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -42,6 +42,7 @@ class TestAmazonCreateJob(object):
             'image_description': 'description'
         }
         self.job = EC2CreateJob(job_doc, self.config)
+        self.job._log_callback = Mock()
         self.job.image_file = 'file'
         self.job.credentials = self.credentials
 
@@ -180,6 +181,7 @@ class TestAmazonCreateJob(object):
             'image_description': 'description'
         }
         self.job = EC2CreateJob(job_doc, self.config)
+        self.job._log_callback = Mock()
         self.job.image_file = 'file'
         self.job.credentials = self.credentials
 

--- a/test/unit/services/create/gce_job_test.py
+++ b/test/unit/services/create/gce_job_test.py
@@ -48,6 +48,7 @@ class TestGCECreateJob(object):
         }
 
         self.job = GCECreateJob(job_doc, self.config)
+        self.job._log_callback = Mock()
         self.job.credentials = self.credentials
 
     def test_post_init_incomplete_arguments(self):

--- a/test/unit/services/create/oci_job_test.py
+++ b/test/unit/services/create/oci_job_test.py
@@ -39,6 +39,7 @@ class TestOCICreateJob(object):
         }
 
         self.job = OCICreateJob(job_doc, self.config)
+        self.job._log_callback = Mock()
         self.job.credentials = self.credentials
 
     def test_post_init_incomplete_arguments(self):

--- a/test/unit/services/deprecation/ec2_job_test.py
+++ b/test/unit/services/deprecation/ec2_job_test.py
@@ -24,6 +24,7 @@ class TestEC2DeprecationJob(object):
 
         self.config = Mock()
         self.job = EC2DeprecationJob(self.job_config, self.config)
+        self.job._log_callback = Mock()
         self.job.credentials = {
             'test-aws': {
                 'access_key_id': '123456',
@@ -79,10 +80,9 @@ class TestEC2DeprecationJob(object):
             self.job.run_job()
         assert msg == str(e.value)
 
-    @patch.object(EC2DeprecationJob, 'send_log')
     @patch('mash.services.deprecation.ec2_job.EC2DeprecateImg')
     def test_deprecate_false(
-        self, mock_ec2_deprecate_image, mock_send_log
+        self, mock_ec2_deprecate_image
     ):
         deprecation = Mock()
         deprecation.deprecate_images.return_value = False
@@ -90,7 +90,6 @@ class TestEC2DeprecationJob(object):
 
         self.job.run_job()
 
-        mock_send_log.assert_called_once_with(
-            'Unable to deprecate image in us-east-2, no image found.',
-            False
+        self.job._log_callback.warning.assert_called_once_with(
+            'Unable to deprecate image in us-east-2, no image found.'
         )

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -207,7 +207,7 @@ class TestListenerService(object):
         job_config = {'id': '1', 'cloud': 'ec2'}
         self.service._add_job(job_config)
 
-        assert job.log_callback == self.service.log_job_message
+        assert job.log_callback == self.service.log
         assert job.job_file == 'tmp-dir/job-1.json'
         self.service.log.info.assert_called_once_with(
             'Job queued, awaiting listener message.',
@@ -667,23 +667,6 @@ class TestListenerService(object):
         self.channel.basic.publish.assert_called_once_with(
             body='message', exchange='exchange', mandatory=True,
             properties=self.msg_properties, routing_key='listener_msg'
-        )
-
-    def test_log_job_message(self):
-        self.service.log_job_message('Test message', {'job_id': '1'})
-
-        self.service.log.info.assert_called_once_with(
-            'Test message',
-            extra={'job_id': '1'}
-        )
-
-        self.service.log_job_message(
-            'Test error message', {'job_id': '1'}, success=False
-        )
-
-        self.service.log.error.assert_called_once_with(
-            'Test error message',
-            extra={'job_id': '1'}
         )
 
     def test_service_start_job(self):

--- a/test/unit/services/no_op_job_test.py
+++ b/test/unit/services/no_op_job_test.py
@@ -14,6 +14,7 @@ class TestNoOpJob(object):
         }
         self.config = Mock()
         self.job = NoOpJob(self.job_config, self.config)
+        self.job._log_callback = Mock()
 
     def test_run_job(self):
         self.job.run_job()

--- a/test/unit/services/publisher/ec2_job_test.py
+++ b/test/unit/services/publisher/ec2_job_test.py
@@ -25,6 +25,7 @@ class TestEC2PublisherJob(object):
 
         self.config = Mock()
         self.job = EC2PublisherJob(self.job_config, self.config)
+        self.job._log_callback = Mock()
         self.job.credentials = {
             'test-aws': {
                 'access_key_id': '123456',
@@ -57,10 +58,9 @@ class TestEC2PublisherJob(object):
         assert publisher.publish_images.call_count == 1
         assert self.job.status == 'success'
 
-    @patch.object(EC2PublisherJob, 'send_log')
     @patch('mash.services.publisher.ec2_job.EC2PublishImage')
     def test_publish_exception(
-        self, mock_ec2_publish_image, mock_send_log
+        self, mock_ec2_publish_image
     ):
         publisher = Mock()
         publisher.publish_images.side_effect = Exception('Failed to publish.')

--- a/test/unit/services/uploader/azure_job_test.py
+++ b/test/unit/services/uploader/azure_job_test.py
@@ -52,6 +52,7 @@ class TestAzureUploaderJob(object):
         self.job = AzureUploaderJob(job_doc, self.config)
         self.job.image_file = 'file.vhdfixed.xz'
         self.job.credentials = self.credentials
+        self.job._log_callback = MagicMock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {

--- a/test/unit/services/uploader/azure_sas_job_test.py
+++ b/test/unit/services/uploader/azure_sas_job_test.py
@@ -27,6 +27,7 @@ class TestAzureSASUploaderJob(object):
 
         self.job = AzureSASUploaderJob(job_doc, self.config)
         self.job.image_file = 'file.vhdfixed.xz'
+        self.job._log_callback = MagicMock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {

--- a/test/unit/services/uploader/gce_job_test.py
+++ b/test/unit/services/uploader/gce_job_test.py
@@ -50,6 +50,7 @@ class TestGCEUploaderJob(object):
         self.job = GCEUploaderJob(job_doc, self.config)
         self.job.image_file = ['sles-12-sp4-v20180909.tar.gz']
         self.job.credentials = self.credentials
+        self.job._log_callback = Mock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {

--- a/test/unit/services/uploader/oci_job_test.py
+++ b/test/unit/services/uploader/oci_job_test.py
@@ -39,6 +39,7 @@ class TestOCIUploaderJob(object):
         self.job = OCIUploaderJob(job_doc, self.config)
         self.job.image_file = ['sles-12-sp4-v20180909.qcow2']
         self.job.credentials = credentials
+        self.job._log_callback = Mock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {
@@ -88,10 +89,9 @@ class TestOCIUploaderJob(object):
             progress_callback=self.job._progress_callback
         )
 
-    @patch.object(OCIUploaderJob, 'send_log')
-    def test_progress_callback(self, mock_send_log):
+    def test_progress_callback(self):
         self.job._image_size = 112358
         self.job._progress_callback(400)
 
-        mock_send_log.assert_called_once_with('Image 0% uploaded.')
+        self.job._log_callback.info.assert_called_once_with('Image 0% uploaded.')
         assert self.job._total_bytes_transferred == 400

--- a/test/unit/services/uploader/s3bucket_job_test.py
+++ b/test/unit/services/uploader/s3bucket_job_test.py
@@ -48,6 +48,7 @@ class TestS3BucketUploaderJob(object):
         self.job.image_file = 'file.raw.gz'
         self.job.cloud_image_name = 'name'
         self.job.credentials = self.credentials
+        self.job._log_callback = Mock()
 
     def test_post_init_incomplete_arguments(self):
         job_doc = {
@@ -94,10 +95,9 @@ class TestS3BucketUploaderJob(object):
         with raises(MashUploadException):
             self.job.run_job()
 
-    @patch.object(S3BucketUploaderJob, 'send_log')
-    def test_log_progress(self, mock_send_log):
+    def test_log_progress(self):
         self.job._image_size = 100
         self.job._log_progress(100)
-        mock_send_log.assert_called_once_with(
+        self.job._log_callback.info.assert_called_once_with(
             'Raw image 100% uploaded.'
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Use logger adapter to pass in the context (job id and iteration) instead of a wrapper method. This allows job classes to use logger directly and pass the logger to any external tools used.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
