### PR TITLE
Update snapshot sharing option for ec2 jobs.

### DIFF
--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -17,7 +17,7 @@
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "share_with": "all",
-  "allow_copy": false,
+  "allow_copy": "none",
   "image_description": "New Image #123",
   "distro": "sles",
   "instance_type": "t2.micro",
@@ -25,6 +25,5 @@
   "notification_email": "test@fake.com",
   "conditions_wait_time": 500,
   "disallow_licenses": ["MIT"],
-  "disallow_packages": ["*-mini"],
-  "share_snapshot_with": "123456789012,987654321210"
+  "disallow_packages": ["*-mini"]
 }

--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -21,18 +21,6 @@ import copy
 from mash.services.api.schema import string_with_example, non_empty_string
 from mash.services.api.schema.jobs import base_job_message
 
-share_with = {
-    'type': 'string',
-    'format': 'regex',
-    'pattern': '^[0-9]{12}(,[0-9]{12})*$|^(all|none)$',
-    'example': '123456789012,098765432109',
-    'examples': ['all', 'none', '123456789012,098765432109'],
-    'description': 'Sharing image to "all" shares the image publicly. '
-                   'Sharing to "none" keeps the image private and sharing '
-                   'to a comma-separated list of accounts makes it available '
-                   'to only those accounts.'
-}
-
 ec2_job_account = {
     'type': 'object',
     'properties': {
@@ -66,11 +54,30 @@ ec2_job_account = {
 }
 
 ec2_job_message = copy.deepcopy(base_job_message)
-ec2_job_message['properties']['share_with'] = share_with
+ec2_job_message['properties']['share_with'] = {
+    'type': 'string',
+    'format': 'regex',
+    'pattern': '^[0-9]{12}(,[0-9]{12})*$|^(all|none)$',
+    'example': '123456789012,098765432109',
+    'examples': ['all', 'none', '123456789012,098765432109'],
+    'description': 'Sharing image to "all" shares the image publicly. '
+                   'Sharing to "none" keeps the image private and sharing '
+                   'to a comma-separated list of accounts makes it available '
+                   'to only those accounts.'
+}
 ec2_job_message['properties']['allow_copy'] = {
-    'type': 'boolean',
-    'description': 'Whether to allow copy of the snapshot with which '
-                   'the image is associated.'
+    'type': 'string',
+    'format': 'regex',
+    'pattern': '^[0-9]{12}(,[0-9]{12})*$|^(image|none)$',
+    'example': '123456789012,098765432109',
+    'examples': ['image', 'none', '123456789012,098765432109'],
+    'description': 'Set the image copy permissions. Supports '
+                   'the keyword "image" to allow those that the image is '
+                   'shared with to copy it; the keyword "none" which does '
+                   'not allow copy access and is the default behavior. And '
+                   'an AWS account number or a comma-separated list with no '
+                   'white space to specify multiple account numbers to allow '
+                   'those accounts to copy the image.'
 }
 ec2_job_message['properties']['billing_codes'] = string_with_example(
     'bp-1234567890,bp-0987654321',

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -32,10 +32,9 @@ class EC2Job(BaseJob):
         Post initialization method.
         """
         self.share_with = self.kwargs.get('share_with', 'all')
-        self.allow_copy = self.kwargs.get('allow_copy', True)
+        self.allow_copy = self.kwargs.get('allow_copy', 'none')
         self.billing_codes = self.kwargs.get('billing_codes')
         self.use_root_swap = self.kwargs.get('use_root_swap', False)
-        self.share_snapshot_with = self.kwargs.get('share_snapshot_with')
 
     def _get_target_regions_list(self):
         """
@@ -86,10 +85,6 @@ class EC2Job(BaseJob):
             }
         }
         publisher_message['publisher_job'].update(self.base_message)
-
-        if self.share_snapshot_with:
-            publisher_message['publisher_job']['share_snapshot_with'] = \
-                self.share_snapshot_with
 
         return JsonFormat.json_message(publisher_message)
 

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -21,7 +21,6 @@ from ec2imgutils.ec2publishimg import EC2PublishImage
 from mash.mash_exceptions import MashPublisherException
 from mash.services.mash_job import MashJob
 from mash.services.status_levels import SUCCESS
-from mash.utils.ec2 import share_image_snapshot
 
 
 class EC2PublisherJob(MashJob):
@@ -43,9 +42,8 @@ class EC2PublisherJob(MashJob):
                 )
             )
 
-        self.allow_copy = self.job_config.get('allow_copy', True)
+        self.allow_copy = self.job_config.get('allow_copy', 'none')
         self.share_with = self.job_config.get('share_with', 'all')
-        self.share_snapshot_with = self.job_config.get('share_snapshot_with')
 
     def run_job(self):
         """
@@ -83,22 +81,3 @@ class EC2PublisherJob(MashJob):
                             cloud_image_name, region, error
                         )
                     )
-
-                if region in self.source_regions and self.share_snapshot_with:
-                    # only share snapshot once from source region
-                    try:
-                        share_image_snapshot(
-                            cloud_image_name,
-                            self.share_snapshot_with,
-                            region,
-                            creds['access_key_id'],
-                            creds['secret_access_key']
-                        )
-                    except Exception:
-                        self.log_callback.error(
-                            'Failed to share snapshot for {0} in {1}.'.format(
-                                cloud_image_name,
-                                region
-                            ),
-                            success=False
-                        )

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -128,34 +128,6 @@ def wait_for_instance_termination(
     waiter.wait(InstanceIds=[instance_id])
 
 
-def share_image_snapshot(
-    image_name,
-    share_with,
-    region,
-    access_key_id,
-    secret_access_key
-):
-    client = get_client(
-        'ec2',
-        access_key_id,
-        secret_access_key,
-        region
-    )
-    images = describe_images(client)
-
-    for image in images:
-        if image['Name'] == image_name:
-            snapshot_id = image['BlockDeviceMappings'][0]['Ebs']['SnapshotId']
-            break
-
-    client.modify_snapshot_attribute(
-        Attribute='createVolumePermission',
-        OperationType='add',
-        SnapshotId=snapshot_id,
-        UserIds=share_with.split(',')
-    )
-
-
 def cleanup_ec2_image(
     access_key_id,
     secret_access_key,

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -17,7 +17,7 @@
   ],
   "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
   "share_with": "all",
-  "allow_copy": false,
+  "allow_copy": "none",
   "image_description": "New Image #123",
   "distro": "sles",
   "instance_type": "t2.micro",
@@ -31,6 +31,5 @@
   "raw_image_upload_account": "account",
   "raw_image_upload_location": "location",
   "disallow_licenses": ["MIT"],
-  "disallow_packages": ["*-mini"],
-  "share_snapshot_with": "123456789012"
+  "disallow_packages": ["*-mini"]
 }

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -187,9 +187,8 @@ class TestJobCreatorService(object):
 
         data = json.loads(mock_publish.mock_calls[6][1][2])['publisher_job']
         check_base_attrs(data)
-        assert data['allow_copy'] is False
+        assert data['allow_copy'] == 'none'
         assert data['share_with'] == 'all'
-        assert data['share_snapshot_with'] == '123456789012'
 
         for region in data['publish_regions']:
             if region['account'] == 'test-aws-gov':

--- a/test/unit/services/publisher/ec2_job_test.py
+++ b/test/unit/services/publisher/ec2_job_test.py
@@ -8,7 +8,7 @@ from mash.services.publisher.ec2_job import EC2PublisherJob
 class TestEC2PublisherJob(object):
     def setup(self):
         self.job_config = {
-            'allow_copy': False,
+            'allow_copy': '123,321',
             'id': '1',
             'last_service': 'publisher',
             'requesting_user': 'user1',
@@ -20,8 +20,7 @@ class TestEC2PublisherJob(object):
                 }
             ],
             'share_with': 'all',
-            'utctime': 'now',
-            'share_snapshot_with': '123,321'
+            'utctime': 'now'
         }
 
         self.config = Mock()
@@ -47,24 +46,15 @@ class TestEC2PublisherJob(object):
         with raises(MashPublisherException):
             EC2PublisherJob(self.job_config, self.config)
 
-    @patch('mash.services.publisher.ec2_job.share_image_snapshot')
     @patch('mash.services.publisher.ec2_job.EC2PublishImage')
-    def test_publish(self, mock_ec2_publish_image, mock_share_snapshot):
+    def test_publish(self, mock_ec2_publish_image):
         publisher = Mock()
         mock_ec2_publish_image.return_value = publisher
-        mock_share_snapshot.side_effect = Exception('Image not found')
         self.job.run_job()
 
         mock_ec2_publish_image.assert_called_once_with(
-            access_key='123456', allow_copy=False, image_name='image_name_123',
+            access_key='123456', allow_copy='123,321', image_name='image_name_123',
             secret_key='654321', verbose=False, visibility='all'
-        )
-        mock_share_snapshot.assert_called_once_with(
-            'image_name_123',
-            '123,321',
-            'us-east-2',
-            '123456',
-            '654321'
         )
 
         publisher.set_region.assert_called_once_with('us-east-2')

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -20,7 +20,6 @@ from unittest.mock import Mock, patch
 from mash.utils.ec2 import (
     get_client,
     get_vpc_id_from_subnet,
-    share_image_snapshot,
     cleanup_ec2_image
 )
 
@@ -48,28 +47,6 @@ def test_get_vpc_id_from_subnet():
     client.describe_subnets.return_value = {'Subnets': [{'VpcId': 'vpc-123456789'}]}
     assert get_vpc_id_from_subnet(client, 'subnet-123456789') == 'vpc-123456789'
     client.describe_subnets.assert_called_once_with(SubnetIds=['subnet-123456789'])
-
-
-@patch('mash.utils.ec2.get_client')
-def test_share_image_snapshot(mock_get_client):
-    images = {
-        'Images': [{
-            'Name': 'test',
-            'BlockDeviceMappings': [{'Ebs': {'SnapshotId': '123'}}]}
-        ]
-    }
-    client = Mock()
-    mock_get_client.return_value = client
-    client.describe_images.return_value = images
-
-    share_image_snapshot('test', '123,321', 'us-east-1', '123', '321')
-
-    client.modify_snapshot_attribute.assert_called_once_with(
-        Attribute='createVolumePermission',
-        OperationType='add',
-        SnapshotId='123',
-        UserIds=['123', '321']
-    )
 
 
 @patch('mash.utils.ec2.EC2RemoveImage')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Mash should not handle snapshot sharing. ec2publishimg handles the sharing instead. Update the allow_copy options in ec2 job schema and remove the snapshot sharing function.

### How will these changes be tested?

Unit tests.

### How will this change be deployed? Any special considerations?


### Additional Information
