### PR TITLE
Add flag in ec2 testing.

### DIFF
--- a/mash/services/api/utils/jobs/ec2.py
+++ b/mash/services/api/utils/jobs/ec2.py
@@ -87,6 +87,7 @@ def add_target_ec2_account(
 
     accounts[region_name] = {
         'account': account.name,
+        'partition': account.partition,
         'target_regions': regions,
         'helper_image': helper_image,
         'subnet': subnet

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -176,7 +176,8 @@ class EC2Job(BaseJob):
         for source_region, value in self.target_account_info.items():
             test_regions[source_region] = {
                 'account': value['account'],
-                'subnet': value['subnet']
+                'subnet': value['subnet'],
+                'partition': value['partition']
             }
 
         return test_regions

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -115,6 +115,12 @@ class EC2TestingJob(MashJob):
             account = get_testing_account(info)
             credentials = self.credentials[account]
 
+            if info['partition'] in ('aws-cn', 'aws-us-gov') and \
+                    self.cloud_architecture == 'aarch64':
+                # Skip testing aarch64 images in China and GovCloud.
+                # There are no aarch64 based instance types available.
+                continue
+
             with setup_ec2_networking(
                 credentials['access_key_id'],
                 region,

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -81,7 +81,8 @@ class TestJobCreatorService(object):
                 'account': 'test-aws-gov',
                 'target_regions': ['us-gov-west-1'],
                 'helper_image': 'ami-c2b5d7e1',
-                'subnet': 'subnet-12345'
+                'subnet': 'subnet-12345',
+                'partition': 'aws-us-gov'
             },
             'ap-northeast-1': {
                 'account': 'test-aws',
@@ -89,7 +90,8 @@ class TestJobCreatorService(object):
                     'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3'
                 ],
                 'helper_image': 'ami-383c1956',
-                'subnet': 'subnet-54321'
+                'subnet': 'subnet-54321',
+                'partition': 'aws'
             }
         }
         del job['cloud_accounts']
@@ -154,9 +156,11 @@ class TestJobCreatorService(object):
         for region, info in data['test_regions'].items():
             if region == 'ap-northeast-1':
                 assert info['account'] == 'test-aws'
+                assert info['partition'] == 'aws'
             else:
                 assert region == 'us-gov-west-1'
                 assert info['account'] == 'test-aws-gov'
+                assert info['partition'] == 'aws-us-gov'
 
         # Raw Image Uploader Job Doc
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If account is not in aws public and the image architecture is aarch64 skip testing as there are no instance types available.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
