### PR TITLE
Remove notification emails option.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -24,7 +24,6 @@
   "distro": "sles",
   "instance_type": "Basic_A2",
   "tests": ["test_stuff"],
-  "emails": "jdoe@fake.com",
   "offer_id": "sles",
   "publisher_id": "suse",
   "label": "New Image 123",

--- a/mash/services/api/schema/jobs/azure.py
+++ b/mash/services/api/schema/jobs/azure.py
@@ -22,12 +22,6 @@ from mash.services.api.schema import string_with_example
 from mash.services.api.schema.jobs import base_job_message
 
 azure_job_message = copy.deepcopy(base_job_message)
-azure_job_message['properties']['emails'] = string_with_example(
-    'test@fake.com',
-    description='A comma-separated list of email addresses to recieve '
-                'notifications from the Azure partner portal about the '
-                'progress of the publishing operation.'
-)
 azure_job_message['properties']['label'] = string_with_example(
     'openSUSE Leap 15',
     description='The title to be displayed in the marketplace.'

--- a/mash/services/api/utils/jobs/azure.py
+++ b/mash/services/api/utils/jobs/azure.py
@@ -39,7 +39,6 @@ def update_azure_job_accounts(job_doc):
         'destination_storage_account'
     )
     publisher_args = (
-        'emails',
         'label',
         'offer_id',
         'publisher_id',

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -48,7 +48,6 @@ class AzureJob(BaseJob):
         self.destination_container = self.kwargs.get('destination_container')
         self.destination_resource_group = self.kwargs.get('destination_resource_group')
         self.destination_storage_account = self.kwargs.get('destination_storage_account')
-        self.emails = self.kwargs.get('emails')
         self.label = self.kwargs.get('label')
         self.offer_id = self.kwargs.get('offer_id')
         self.publisher_id = self.kwargs.get('publisher_id')
@@ -77,7 +76,6 @@ class AzureJob(BaseJob):
         """
         publisher_message = {
             'publisher_job': {
-                'emails': self.emails,
                 'image_description': self.image_description,
                 'label': self.label,
                 'offer_id': self.offer_id,

--- a/mash/services/publisher/azure_job.py
+++ b/mash/services/publisher/azure_job.py
@@ -42,7 +42,6 @@ class AzurePublisherJob(MashJob):
         Post initialization method.
         """
         try:
-            self.emails = self.job_config['emails']
             self.image_description = self.job_config['image_description']
             self.label = self.job_config['label']
             self.offer_id = self.job_config['offer_id']
@@ -134,7 +133,6 @@ class AzurePublisherJob(MashJob):
                 if self.publish_offer:
                     operation = publish_cloud_partner_offer(
                         credential,
-                        self.emails,
                         self.offer_id,
                         self.publisher_id
                     )

--- a/mash/utils/azure.py
+++ b/mash/utils/azure.py
@@ -430,7 +430,7 @@ def put_cloud_partner_offer_doc(credentials, doc, offer_id, publisher_id):
 
 
 def publish_cloud_partner_offer(
-    credentials, emails, offer_id, publisher_id
+    credentials, offer_id, publisher_id
 ):
     """
     Publish the cloud partner offer and return the operation location.
@@ -448,7 +448,6 @@ def publish_cloud_partner_offer(
     response = process_request(
         endpoint,
         headers,
-        data={'metadata': {'notification-emails': emails}},
         method='post',
         json_response=False
     )

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -24,7 +24,6 @@
   "distro": "sles",
   "instance_type": "Basic_A2",
   "tests": ["test_stuff"],
-  "emails": "jdoe@fake.com",
   "offer_id": "sles",
   "publisher_id": "suse",
   "label": "New Image 123",

--- a/test/unit/services/api/utils/jobs/azure_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/azure_job_utils_test.py
@@ -42,7 +42,6 @@ def test_update_azure_job_accounts(
         'destination_resource_group': 'rg-2',
         'destination_container': 'container2',
         'destination_storage_account': 'sa2',
-        'emails': 'jdoe@fake.com',
         'label': 'New Image 123',
         'offer_id': 'sles',
         'publisher_id': 'suse'

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -310,7 +310,7 @@ def test_publish_cloud_partner_offer(
         credentials = json.load(f)
 
     response = publish_cloud_partner_offer(
-        credentials, 'jdoe@fake.com', 'sles', 'suse'
+        credentials, 'sles', 'suse'
     )
 
     assert response == '/api/endpoint/url'

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -47,7 +47,6 @@ def test_azure_job_cleanup(mock_init):
     })
     job.kwargs = {
         'cloud_account': 'acnt1',
-        'emails': 'test@test.com',
         'label': 'Great Image',
         'offer_id': 'sles',
         'publisher_id': 'suse',

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -317,7 +317,6 @@ class TestJobCreatorService(object):
 
         data = json.loads(mock_publish.mock_calls[6][1][2])['publisher_job']
         check_base_attrs(data)
-        assert data['emails'] == 'jdoe@fake.com'
         assert data['image_description'] == 'New Image #123'
         assert data['label'] == 'New Image 123'
         assert data['offer_id'] == 'sles'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

For Azure publishing jobs. This is no longer used by the new partner center.

### How will these changes be tested?

Unit tests.

### How will this change be deployed? Any special considerations?


### Additional Information

https://docs.microsoft.com/en-us/azure/marketplace/cloud-partner-portal-migration-faq#will-the-cloud-partner-portal-rest-apis-be-supported-post-migration

> For migrated offers, we'll no longer send notifications to the list of emails specified in the requests. Instead, the API service will align with the notification email process in Partner Center to send emails. Specifically, notifications will be sent to the email address set in the Seller contact info section of your Account settings in Partner Center, to notify you of operation progress.