### PR TITLE
Provide log callback to img-proof.

### DIFF
--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -105,7 +105,8 @@ class AzureTestingJob(MashJob):
                     service_account_file=auth_file,
                     ssh_private_key_file=self.ssh_private_key_file,
                     ssh_user=self.ssh_user,
-                    tests=self.tests
+                    tests=self.tests,
+                    log_callback=self.log_callback
                 )
             except Exception:
                 result = {

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -144,7 +144,8 @@ class EC2TestingJob(MashJob):
                         ssh_private_key_file=self.ssh_private_key_file,
                         ssh_user=self.ssh_user,
                         subnet_id=network_details['subnet_id'],
-                        tests=self.tests
+                        tests=self.tests,
+                        log_callback=self.log_callback
                     )
                 except Exception:
                     result = {

--- a/mash/services/testing/gce_job.py
+++ b/mash/services/testing/gce_job.py
@@ -133,7 +133,8 @@ class GCETestingJob(MashJob):
                             ssh_user=self.ssh_user,
                             tests=self.tests,
                             boot_firmware=firmware,
-                            image_project=self.image_project
+                            image_project=self.image_project,
+                            log_callback=self.log_callback
                         )
                     except IpaRetryableError as error:
                         result = {

--- a/mash/services/testing/img_proof_helper.py
+++ b/mash/services/testing/img_proof_helper.py
@@ -30,7 +30,7 @@ def img_proof_test(
     ssh_key_name=None, ssh_private_key_file=None, ssh_user=None, subnet_id=None,
     tests=None, availability_domain=None, compartment_id=None, tenancy=None,
     oci_user_id=None, signing_key_file=None, signing_key_fingerprint=None,
-    boot_firmware=None, image_project=None
+    boot_firmware=None, image_project=None, log_callback=None
 ):
     if boot_firmware and boot_firmware == 'uefi':
         enable_secure_boot = True
@@ -63,7 +63,8 @@ def img_proof_test(
         tests=tests,
         timeout=img_proof_timeout,
         enable_secure_boot=enable_secure_boot,
-        image_project=image_project
+        image_project=image_project,
+        log_callback=log_callback
     )
 
     status = SUCCESS if status == 0 else FAILED

--- a/mash/services/testing/oci_job.py
+++ b/mash/services/testing/oci_job.py
@@ -115,7 +115,8 @@ class OCITestingJob(MashJob):
                     ssh_private_key_file=self.ssh_private_key_file,
                     ssh_user=self.ssh_user,
                     tenancy=self.tenancy,
-                    tests=self.tests
+                    tests=self.tests,
+                    log_callback=self.log_callback
                 )
             except Exception:
                 result = {

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -104,7 +104,8 @@ class TestAzureTestingJob(object):
             tests=['test_stuff'],
             timeout=None,
             enable_secure_boot=False,
-            image_project=None
+            image_project=None,
+            log_callback=job._log_callback
         )
         job._log_callback.info.reset_mock()
 

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -115,7 +115,8 @@ class TestEC2TestingJob(object):
             tests=['test_stuff'],
             timeout=None,
             enable_secure_boot=False,
-            image_project=None
+            image_project=None,
+            log_callback=job._log_callback
         )
         client.delete_key_pair.assert_called_once_with(KeyName='random_name')
         mock_cleanup_image.assert_called_once_with(

--- a/test/unit/services/testing/gce_job_test.py
+++ b/test/unit/services/testing/gce_job_test.py
@@ -113,7 +113,8 @@ class TestGCETestingJob(object):
                 tests=['test_stuff'],
                 timeout=None,
                 enable_secure_boot=True,
-                image_project=None
+                image_project=None,
+                log_callback=job._log_callback
             )
         ])
         job._log_callback.warning.reset_mock()
@@ -191,7 +192,8 @@ class TestGCETestingJob(object):
                 tests=['test_stuff'],
                 timeout=None,
                 enable_secure_boot=True,
-                image_project=None
+                image_project=None,
+                log_callback=job._log_callback
             ),
             call(
                 'gce',
@@ -219,7 +221,8 @@ class TestGCETestingJob(object):
                 tests=['test_stuff'],
                 timeout=None,
                 enable_secure_boot=True,
-                image_project=None
+                image_project=None,
+                log_callback=job._log_callback
             )
         ])
 

--- a/test/unit/services/testing/oci_job_test.py
+++ b/test/unit/services/testing/oci_job_test.py
@@ -103,7 +103,8 @@ class TestOCITestingJob(object):
             tests=['test_stuff'],
             timeout=600,
             enable_secure_boot=False,
-            image_project=None
+            image_project=None,
+            log_callback=job._log_callback
         )
         job._log_callback.info.reset_mock()
 


### PR DESCRIPTION
When running tests provide job based logger to aggregate log output in mash log files.

### What does this PR do? Why are we making this change?


### How will these changes be tested?

Unit and integration tests.

### How will this change be deployed? Any special considerations?


### Additional Information

Relies on https://github.com/SUSE-Enceladus/img-proof/pull/250.