### PR TITLE
Move required arg validation to utils

### DIFF
--- a/mash/services/api/config.py
+++ b/mash/services/api/config.py
@@ -115,3 +115,7 @@ class Config(object):
     @property
     def SMTP_SSL(self):
         return self.config.get_smtp_ssl()
+
+    @property
+    def SERVICE_NAMES(self):
+        return self.config.get_service_names()

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -81,15 +81,6 @@ base_job_message = {
     'properties': {
         'last_service': {
             'type': 'string',
-            'enum': [
-                'uploader',
-                'create',
-                'testing',
-                'raw_image_uploader',
-                'replication',
-                'publisher',
-                'deprecation'
-            ],
             'example': 'create',
             'description': 'The last service in the pipeline to be executed. '
                            'All services except the OBS service are valid '
@@ -283,8 +274,6 @@ base_job_message = {
         'last_service',
         'utctime',
         'image',
-        'cloud_image_name',
-        'image_description',
         'download_url'
     ]
 }

--- a/mash/services/api/schema/jobs/oci.py
+++ b/mash/services/api/schema/jobs/oci.py
@@ -81,5 +81,3 @@ oci_job_message['properties']['image_description']['example'] = \
 oci_job_message['properties']['instance_type']['example'] = 'VM.Standard2.1'
 
 oci_job_message['required'].append('cloud_account')
-oci_job_message['required'].append('operating_system')
-oci_job_message['required'].append('operating_system_version')

--- a/mash/services/api/utils/jobs/azure.py
+++ b/mash/services/api/utils/jobs/azure.py
@@ -18,6 +18,7 @@
 
 from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.accounts.azure import get_azure_account
+from mash.services.api.utils.jobs import get_services_by_last_service
 
 
 def update_azure_job_accounts(job_doc):
@@ -49,7 +50,8 @@ def update_azure_job_accounts(job_doc):
         if attr not in job_doc:
             job_doc[attr] = getattr(cloud_account, attr)
 
-    if job_doc['last_service'] in ('publisher', 'deprecation'):
+    services = get_services_by_last_service(job_doc['last_service'])
+    if 'publisher' in services:
         for arg in publisher_args:
             if arg not in job_doc:
                 raise MashJobException(

--- a/mash/services/api/utils/jobs/gce.py
+++ b/mash/services/api/utils/jobs/gce.py
@@ -18,6 +18,7 @@
 
 from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.accounts.gce import get_gce_account
+from mash.services.api.utils.jobs import get_services_by_last_service
 
 
 def update_gce_job_accounts(job_doc):
@@ -39,20 +40,24 @@ def update_gce_job_accounts(job_doc):
         if attr not in job_doc:
             job_doc[attr] = getattr(cloud_account, attr)
 
-    if cloud_account.is_publishing_account and not job_doc.get('family'):
-        raise MashJobException(
-            'Jobs using a GCE publishing account require a family.'
-        )
+    services = get_services_by_last_service(job_doc['last_service'])
 
-    if cloud_account.is_publishing_account and not job_doc['testing_account']:
-        raise MashJobException(
-            'Jobs using a GCE publishing account require'
-            ' the use of a testing account.'
-        )
+    if 'create' in services:
+        if cloud_account.is_publishing_account and not job_doc.get('family'):
+            raise MashJobException(
+                'Jobs using a GCE publishing account require a family.'
+            )
 
-    if cloud_account.is_publishing_account and not job_doc.get('image_project'):
-        raise MashJobException(
-            'Jobs using a GCE publishing account require an image_project.'
-        )
+    if 'testing' in services:
+        if cloud_account.is_publishing_account and not job_doc['testing_account']:
+            raise MashJobException(
+                'Jobs using a GCE publishing account require'
+                ' the use of a testing account.'
+            )
+
+        if cloud_account.is_publishing_account and not job_doc.get('image_project'):
+            raise MashJobException(
+                'Jobs using a GCE publishing account require an image_project.'
+            )
 
     return job_doc

--- a/mash/services/api/utils/jobs/oci.py
+++ b/mash/services/api/utils/jobs/oci.py
@@ -17,6 +17,8 @@
 #
 
 from mash.services.api.utils.accounts.oci import get_oci_account
+from mash.services.api.utils.jobs import get_services_by_last_service
+from mash.mash_exceptions import MashJobException
 
 
 def update_oci_job_accounts(job_doc):
@@ -34,9 +36,25 @@ def update_oci_job_accounts(job_doc):
         'oci_user_id',
         'tenancy',
     ]
+    create_args = [
+        'operating_system',
+        'operating_system_version'
+    ]
 
     for attr in attrs:
         if attr not in job_doc:
             job_doc[attr] = getattr(cloud_account, attr)
+
+    services = get_services_by_last_service(job_doc['last_service'])
+
+    if 'create' in services:
+        for arg in create_args:
+            if arg not in job_doc:
+                raise MashJobException(
+                    'OCI jobs that create an image require an '
+                    ' {arg} argument in the job document.'.format(
+                        arg=arg
+                    )
+                )
 
     return job_doc

--- a/mash/services/jobcreator/oci_job.py
+++ b/mash/services/jobcreator/oci_job.py
@@ -38,8 +38,6 @@ class OCIJob(BaseJob):
             self.compartment_id = self.kwargs['compartment_id']
             self.oci_user_id = self.kwargs['oci_user_id']
             self.tenancy = self.kwargs['tenancy']
-            self.operating_system = self.kwargs['operating_system']
-            self.operating_system_version = self.kwargs['operating_system_version']
         except KeyError as error:
             raise MashJobCreatorException(
                 'OCI jobs require a(n) {0} key in the job doc.'.format(
@@ -49,6 +47,10 @@ class OCIJob(BaseJob):
 
         self.image_type = self.kwargs.get('image_type')
         self.launch_mode = self.kwargs.get('launch_mode')
+        self.operating_system = self.kwargs.get('operating_system')
+        self.operating_system_version = self.kwargs.get(
+            'operating_system_version'
+        )
 
     def get_deprecation_message(self):
         """

--- a/test/unit/services/api/utils/jobs/azure_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/azure_job_utils_test.py
@@ -23,14 +23,26 @@ from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.jobs.azure import update_azure_job_accounts
 
 
+@patch('mash.services.api.utils.jobs.azure.get_services_by_last_service')
 @patch('mash.services.api.utils.jobs.azure.get_azure_account')
 def test_update_azure_job_accounts(
-    mock_get_azure_account
+    mock_get_azure_account, mock_get_services
 ):
     account = Mock()
     account.region = 'southcentralus'
     account.name = 'acnt1'
     mock_get_azure_account.return_value = account
+
+    mock_get_services.return_value = [
+        'obs',
+        'uploader',
+        'create',
+        'testing',
+        'raw_image_uploader',
+        'replication',
+        'publisher',
+        'deprecation'
+    ]
 
     job_doc = {
         'last_service': 'deprecation',

--- a/test/unit/services/api/utils/jobs/gce_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/gce_job_utils_test.py
@@ -24,9 +24,10 @@ from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.jobs.gce import update_gce_job_accounts
 
 
+@patch('mash.services.api.utils.jobs.gce.get_services_by_last_service')
 @patch('mash.services.api.utils.jobs.gce.get_gce_account')
 def test_update_gce_job_accounts(
-    mock_get_gce_account
+    mock_get_gce_account, mock_get_services
 ):
     account = Mock()
     account.name = 'acnt1'
@@ -36,7 +37,15 @@ def test_update_gce_job_accounts(
     account.is_publishing_account = True
     mock_get_gce_account.return_value = account
 
+    mock_get_services.return_value = [
+        'obs',
+        'uploader',
+        'create',
+        'testing'
+    ]
+
     job_doc = {
+        'last_service': 'testing',
         'requesting_user': '1',
         'cloud_account': 'acnt1',
         'bucket': 'images2',


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Validate base job, gce job and oci job attrs by last service.
- Validate last_service based on dynamic list of services instead of static list in schema. 
- Update Azure publisher arg validation.

### How will these changes be tested?

Unit and integration.

### How will this change be deployed? Any special considerations?


### Additional Information
