### PR TITLE
Reorder job validation.

### DIFF
--- a/mash/services/api/routes/jobs/azure.py
+++ b/mash/services/api/routes/jobs/azure.py
@@ -30,7 +30,7 @@ from mash.services.api.schema import (
 from mash.services.api.routes.jobs import job_response
 from mash.services.api.schema.jobs.azure import azure_job_message
 from mash.services.api.utils.jobs import create_job
-from mash.services.api.utils.jobs.azure import update_azure_job_accounts
+from mash.services.api.utils.jobs.azure import validate_azure_job
 
 api = Namespace(
     'Azure Jobs',
@@ -60,7 +60,7 @@ class AzureJobCreate(Resource):
         data['requesting_user'] = get_jwt_identity()
 
         try:
-            data = update_azure_job_accounts(data)
+            data = validate_azure_job(data)
             job = create_job(data)
         except MashException as error:
             return make_response(
@@ -74,10 +74,16 @@ class AzureJobCreate(Resource):
                 400
             )
 
-        return make_response(
-            jsonify(marshal(job, job_response, skip_none=True)),
-            201
-        )
+        if job:
+            return make_response(
+                jsonify(marshal(job, job_response, skip_none=True)),
+                201
+            )
+        else:
+            return make_response(
+                jsonify({'msg': 'Job doc is valid!'}),
+                200
+            )
 
     @api.doc('get_azure_job_doc_schema')
     @api.response(200, 'Success', azure_job)

--- a/mash/services/api/routes/jobs/ec2.py
+++ b/mash/services/api/routes/jobs/ec2.py
@@ -30,7 +30,7 @@ from mash.services.api.schema import (
 from mash.services.api.routes.jobs import job_response
 
 from mash.services.api.schema.jobs.ec2 import ec2_job_message
-from mash.services.api.utils.jobs.ec2 import update_ec2_job_accounts
+from mash.services.api.utils.jobs.ec2 import validate_ec2_job
 from mash.services.api.utils.jobs import create_job
 
 api = Namespace(
@@ -61,7 +61,7 @@ class EC2JobCreate(Resource):
         data['requesting_user'] = get_jwt_identity()
 
         try:
-            data = update_ec2_job_accounts(data)
+            data = validate_ec2_job(data)
             job = create_job(data)
         except MashException as error:
             return make_response(
@@ -75,10 +75,16 @@ class EC2JobCreate(Resource):
                 400
             )
 
-        return make_response(
-            jsonify(marshal(job, job_response, skip_none=True)),
-            201
-        )
+        if job:
+            return make_response(
+                jsonify(marshal(job, job_response, skip_none=True)),
+                201
+            )
+        else:
+            return make_response(
+                jsonify({'msg': 'Job doc is valid!'}),
+                200
+            )
 
     @api.doc('get_ec2_job_doc_schema')
     @api.response(200, 'Success', ec2_job)

--- a/mash/services/api/routes/jobs/gce.py
+++ b/mash/services/api/routes/jobs/gce.py
@@ -30,7 +30,7 @@ from mash.services.api.schema import (
 from mash.services.api.routes.jobs import job_response
 from mash.services.api.schema.jobs.gce import gce_job_message
 from mash.services.api.utils.jobs import create_job
-from mash.services.api.utils.jobs.gce import update_gce_job_accounts
+from mash.services.api.utils.jobs.gce import validate_gce_job
 
 api = Namespace(
     'GCE Jobs',
@@ -60,7 +60,7 @@ class GCEJob(Resource):
         data['requesting_user'] = get_jwt_identity()
 
         try:
-            data = update_gce_job_accounts(data)
+            data = validate_gce_job(data)
             job = create_job(data)
         except MashException as error:
             return make_response(
@@ -74,10 +74,16 @@ class GCEJob(Resource):
                 400
             )
 
-        return make_response(
-            jsonify(marshal(job, job_response, skip_none=True)),
-            201
-        )
+        if job:
+            return make_response(
+                jsonify(marshal(job, job_response, skip_none=True)),
+                201
+            )
+        else:
+            return make_response(
+                jsonify({'msg': 'Job doc is valid!'}),
+                200
+            )
 
     @api.doc('get_gce_job_doc_schema')
     @api.response(200, 'Success', gce_job)

--- a/mash/services/api/routes/jobs/oci.py
+++ b/mash/services/api/routes/jobs/oci.py
@@ -30,7 +30,7 @@ from mash.services.api.schema import (
 from mash.services.api.routes.jobs import job_response
 from mash.services.api.schema.jobs.oci import oci_job_message
 from mash.services.api.utils.jobs import create_job
-from mash.services.api.utils.jobs.oci import update_oci_job_accounts
+from mash.services.api.utils.jobs.oci import validate_oci_job
 
 api = Namespace(
     'OCI Jobs',
@@ -60,7 +60,7 @@ class OCIJobCreate(Resource):
         data['requesting_user'] = get_jwt_identity()
 
         try:
-            data = update_oci_job_accounts(data)
+            data = validate_oci_job(data)
             job = create_job(data)
         except MashException as error:
             return make_response(
@@ -74,10 +74,16 @@ class OCIJobCreate(Resource):
                 400
             )
 
-        return make_response(
-            jsonify(marshal(job, job_response, skip_none=True)),
-            201
-        )
+        if job:
+            return make_response(
+                jsonify(marshal(job, job_response, skip_none=True)),
+                201
+            )
+        else:
+            return make_response(
+                jsonify({'msg': 'Job doc is valid!'}),
+                200
+            )
 
     @api.doc('get_oci_job_doc_schema')
     @api.response(200, 'Success', oci_job)

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -267,6 +267,12 @@ base_job_message = {
                            'image tarball. This allows the checksum and/or '
                            'signature to also be uploaded for image '
                            'verification.'
+        },
+        'dry_run': {
+            'type': 'boolean',
+            'example': True,
+            'description': 'Only validate the job document and return. '
+                           'Do not create the job.'
         }
     },
     'additionalProperties': False,

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -36,7 +36,9 @@ def create_job(data):
     """
     Create a new job for user.
     """
-    validate_job(data)
+    if data.get('dry_run'):
+        return None
+
     job_id = get_new_job_id()
     data['job_id'] = job_id
 

--- a/mash/services/api/utils/jobs/azure.py
+++ b/mash/services/api/utils/jobs/azure.py
@@ -18,13 +18,20 @@
 
 from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.accounts.azure import get_azure_account
-from mash.services.api.utils.jobs import get_services_by_last_service
+from mash.services.api.utils.jobs import (
+    get_services_by_last_service,
+    validate_job
+)
 
 
-def update_azure_job_accounts(job_doc):
+def validate_azure_job(job_doc):
     """
-    Update target_account_info for given job doc.
+    Validate job.
+
+    And update target_account_info for given job doc.
     """
+    validate_job(job_doc)
+
     cloud_account = get_azure_account(
         job_doc['cloud_account'],
         job_doc['requesting_user']

--- a/mash/services/api/utils/jobs/ec2.py
+++ b/mash/services/api/utils/jobs/ec2.py
@@ -22,6 +22,7 @@ from flask import current_app
 
 from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.accounts.ec2 import get_ec2_group, get_ec2_account
+from mash.services.api.utils.jobs import validate_job
 
 
 def get_ec2_regions_by_partition(partition):
@@ -106,13 +107,17 @@ def convert_account_dict(accounts):
     return cloud_accounts
 
 
-def update_ec2_job_accounts(job_doc):
+def validate_ec2_job(job_doc):
     """
+    Validate job.
+
     Update target_account_info for given job doc.
 
     Once accounts dictionary is built remove cloud_groups
     and cloud_accounts keys from job_doc.
     """
+    validate_job(job_doc)
+
     user_id = job_doc['requesting_user']
 
     helper_images = get_ec2_helper_images()

--- a/mash/services/api/utils/jobs/gce.py
+++ b/mash/services/api/utils/jobs/gce.py
@@ -18,13 +18,20 @@
 
 from mash.mash_exceptions import MashJobException
 from mash.services.api.utils.accounts.gce import get_gce_account
-from mash.services.api.utils.jobs import get_services_by_last_service
+from mash.services.api.utils.jobs import (
+    get_services_by_last_service,
+    validate_job
+)
 
 
-def update_gce_job_accounts(job_doc):
+def validate_gce_job(job_doc):
     """
-    Update target_account_info for given job doc.
+    Validate job.
+
+    And update target_account_info for given job doc.
     """
+    validate_job(job_doc)
+
     cloud_account = get_gce_account(
         job_doc['cloud_account'],
         job_doc['requesting_user']

--- a/mash/services/api/utils/jobs/oci.py
+++ b/mash/services/api/utils/jobs/oci.py
@@ -17,14 +17,19 @@
 #
 
 from mash.services.api.utils.accounts.oci import get_oci_account
-from mash.services.api.utils.jobs import get_services_by_last_service
+from mash.services.api.utils.jobs import (
+    get_services_by_last_service,
+    validate_job
+)
 from mash.mash_exceptions import MashJobException
 
 
-def update_oci_job_accounts(job_doc):
+def validate_oci_job(job_doc):
     """
     Update target_account_info for given job doc.
     """
+    validate_job(job_doc)
+
     user_id = job_doc['requesting_user']
     cloud_account = get_oci_account(job_doc['cloud_account'], user_id)
 

--- a/test/unit/services/api/routes/jobs/azure_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/azure_job_routes_test.py
@@ -6,13 +6,13 @@ from mash.mash_exceptions import MashException
 
 
 @patch('mash.services.api.routes.jobs.azure.create_job')
-@patch('mash.services.api.routes.jobs.azure.update_azure_job_accounts')
+@patch('mash.services.api.routes.jobs.azure.validate_azure_job')
 @patch('mash.services.api.routes.jobs.azure.get_jwt_identity')
 @patch('flask_jwt_extended.view_decorators.verify_jwt_in_request')
 def test_api_add_job_gce(
         mock_jwt_required,
         mock_jwt_identity,
-        mock_update_azure_job_accounts,
+        mock_validate_azure_job,
         mock_create_job,
         test_client
 ):
@@ -50,8 +50,19 @@ def test_api_add_job_gce(
     assert response.json['cloud_architecture'] == 'x86_64'
     assert response.json['profile'] == 'Server'
 
+    # Dry run
+    data['dry_run'] = True
+    mock_create_job.return_value = None
+    response = test_client.post(
+        '/jobs/azure/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"msg":"Job doc is valid!"}\n'
+
     # Exception
-    mock_update_azure_job_accounts.side_effect = Exception('Broken')
+    mock_validate_azure_job.side_effect = Exception('Broken')
 
     response = test_client.post(
         '/jobs/azure/',
@@ -62,7 +73,7 @@ def test_api_add_job_gce(
     assert response.data == b'{"msg":"Failed to start job"}\n'
 
     # Mash Exception
-    mock_update_azure_job_accounts.side_effect = MashException('Broken')
+    mock_validate_azure_job.side_effect = MashException('Broken')
 
     response = test_client.post(
         '/jobs/azure/',

--- a/test/unit/services/api/routes/jobs/gce_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/gce_job_routes_test.py
@@ -6,13 +6,13 @@ from mash.mash_exceptions import MashException
 
 
 @patch('mash.services.api.routes.jobs.gce.create_job')
-@patch('mash.services.api.routes.jobs.gce.update_gce_job_accounts')
+@patch('mash.services.api.routes.jobs.gce.validate_gce_job')
 @patch('mash.services.api.routes.jobs.gce.get_jwt_identity')
 @patch('flask_jwt_extended.view_decorators.verify_jwt_in_request')
 def test_api_add_job_gce(
         mock_jwt_required,
         mock_jwt_identity,
-        mock_update_gce_job_accounts,
+        mock_validate_gce_job,
         mock_create_job,
         test_client
 ):
@@ -50,8 +50,19 @@ def test_api_add_job_gce(
     assert response.json['cloud_architecture'] == 'x86_64'
     assert response.json['profile'] == 'Server'
 
+    # Dry run
+    data['dry_run'] = True
+    mock_create_job.return_value = None
+    response = test_client.post(
+        '/jobs/gce/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"msg":"Job doc is valid!"}\n'
+
     # Exception
-    mock_update_gce_job_accounts.side_effect = Exception('Broken')
+    mock_validate_gce_job.side_effect = Exception('Broken')
 
     response = test_client.post(
         '/jobs/gce/',
@@ -62,7 +73,7 @@ def test_api_add_job_gce(
     assert response.data == b'{"msg":"Failed to start job"}\n'
 
     # Mash Exception
-    mock_update_gce_job_accounts.side_effect = MashException('Broken')
+    mock_validate_gce_job.side_effect = MashException('Broken')
 
     response = test_client.post(
         '/jobs/gce/',

--- a/test/unit/services/api/routes/jobs/oci_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/oci_job_routes_test.py
@@ -6,13 +6,13 @@ from mash.mash_exceptions import MashException
 
 
 @patch('mash.services.api.routes.jobs.oci.create_job')
-@patch('mash.services.api.routes.jobs.oci.update_oci_job_accounts')
+@patch('mash.services.api.routes.jobs.oci.validate_oci_job')
 @patch('mash.services.api.routes.jobs.oci.get_jwt_identity')
 @patch('flask_jwt_extended.view_decorators.verify_jwt_in_request')
 def test_api_add_job_oci(
         mock_jwt_required,
         mock_jwt_identity,
-        mock_update_oci_job_accounts,
+        mock_validate_oci_job,
         mock_create_job,
         test_client
 ):
@@ -52,8 +52,19 @@ def test_api_add_job_oci(
     assert response.json['cloud_architecture'] == 'x86_64'
     assert response.json['profile'] == 'Server'
 
+    # Dry run
+    data['dry_run'] = True
+    mock_create_job.return_value = None
+    response = test_client.post(
+        '/jobs/oci/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"msg":"Job doc is valid!"}\n'
+
     # Exception
-    mock_update_oci_job_accounts.side_effect = Exception('Broken')
+    mock_validate_oci_job.side_effect = Exception('Broken')
 
     response = test_client.post(
         '/jobs/oci/',
@@ -64,7 +75,7 @@ def test_api_add_job_oci(
     assert response.data == b'{"msg":"Failed to start job"}\n'
 
     # Mash Exception
-    mock_update_oci_job_accounts.side_effect = MashException('Broken')
+    mock_validate_oci_job.side_effect = MashException('Broken')
 
     response = test_client.post(
         '/jobs/oci/',


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Base job validation should happen before cloud framework specific validation.

Add option to do a dry run which only validates the job doc and does not create a job.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
