### PR TITLE
Update ec2imgutils version requirement.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -25,7 +25,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0,<2.8.1
 amqpstorm
-ec2imgutils>=8.1.1
+ec2imgutils>=8.1.2
 img-proof>=5.2.0
 lxml
 requests

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -41,7 +41,7 @@ BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
 BuildRequires:  python3-python-dateutil < 2.8.1
-BuildRequires:  python3-ec2imgutils>=8.1.1
+BuildRequires:  python3-ec2imgutils>=8.1.2
 BuildRequires:  python3-img-proof >= 5.2.0
 BuildRequires:  python3-img-proof-tests >= 5.2.0
 BuildRequires:  python3-lxml
@@ -69,7 +69,7 @@ Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 2.8.1
-Requires:       python3-ec2imgutils>=8.1.1
+Requires:       python3-ec2imgutils>=8.1.2
 Requires:       python3-img-proof >= 5.2.0
 Requires:       python3-img-proof-tests >= 5.2.0
 Requires:       python3-lxml


### PR DESCRIPTION
8.1.2 has a bug fix for image deprecation logging.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
