### PR TITLE
Cleanup s3 raw image upload.

### DIFF
--- a/test/unit/services/upload/s3bucket_job_test.py
+++ b/test/unit/services/upload/s3bucket_job_test.py
@@ -90,6 +90,31 @@ class TestS3BucketUploadJob(object):
             Callback=self.job._log_progress
         )
 
+        # Test bucket only location
+        mock_client.upload_file.reset_mock()
+        self.job.location = 'my-bucket'
+        self.job.run_job()
+
+        mock_client.upload_file.assert_called_once_with(
+            'file.raw.gz',
+            'my-bucket',
+            'name.raw.gz',
+            Callback=self.job._log_progress
+        )
+
+        # Test bucket and full name
+        mock_client.upload_file.reset_mock()
+        self.job.location = 'my-bucket/some-prefix/image.raw.gz'
+        self.job.cloud_image_name = None
+        self.job.run_job()
+
+        mock_client.upload_file.assert_called_once_with(
+            'file.raw.gz',
+            'my-bucket',
+            'some-prefix/image.raw.gz',
+            Callback=self.job._log_progress
+        )
+
         mock_client.upload_file.side_effect = Exception
 
         with raises(MashUploadException):


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The cloud_image_name may not always be set. Handle both
cloud_image_name and image_file name. Also, handle different
location paths. Location can be bucket, bucket/path/to/put/file/
and bucket/path/to/file.xz. If a file name is part of the location
string it is used in place of cloud_image_name and image_file.

### How will these changes be tested?

Unit and integration.

### How will this change be deployed? Any special considerations?


### Additional Information
