### PR TITLE
Use user email for notifications.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -31,7 +31,7 @@
   "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "publish_offer": true,
   "cleanup_images": true,
   "additional_uploads": ["sha256"]

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -21,7 +21,7 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "guest_os_features": ["UEFI_COMPATIBLE"],
   "image_project": "test"
 }

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -22,7 +22,7 @@
   "distro": "sles",
   "instance_type": "t2.micro",
   "tests": ["test_stuff"],
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "conditions_wait_time": 500,
   "disallow_licenses": ["MIT"],
   "disallow_packages": ["*-mini"]

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -17,7 +17,6 @@
 #
 
 from mash.services.api.schema import (
-    email,
     non_empty_string,
     string_with_example
 )
@@ -183,7 +182,6 @@ base_job_message = {
                            'Valid options are x86_64 and aarch64 and the '
                            'default architecture is x86_64.'
         },
-        'notification_email': email,
         'notification_type': {
             'type': 'string',
             'enum': ['periodic', 'single'],

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -17,6 +17,7 @@
 #
 
 from mash.services.api.schema import (
+    email,
     non_empty_string,
     string_with_example
 )
@@ -182,6 +183,7 @@ base_job_message = {
                            'Valid options are x86_64 and aarch64 and the '
                            'default architecture is x86_64.'
         },
+        'notification_email': email,
         'notification_type': {
             'type': 'string',
             'enum': ['periodic', 'single'],

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -89,7 +89,7 @@ def validate_job(data):
     if 'deprecate' in services_run:
         validate_deprecate_args(data)
 
-    if 'notification_type' in data:
+    if 'notification_type' in data and not data.get('notification_email'):
         user_id = data['requesting_user']
         user = get_user_by_id(user_id)
         data['notification_email'] = user.email

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -89,6 +89,11 @@ def validate_job(data):
     if 'deprecate' in services_run:
         validate_deprecate_args(data)
 
+    if 'notification_type' in data:
+        user_id = data['requesting_user']
+        user = get_user_by_id(user_id)
+        data['notification_email'] = user.email
+
     return data
 
 

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -31,7 +31,7 @@
   "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "publish_offer": true,
   "cleanup_images": true,
   "raw_image_upload_type": "s3bucket",

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -21,7 +21,7 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "guest_os_features": ["UEFI_COMPATIBLE"],
   "raw_image_upload_type": "s3bucket",
   "raw_image_upload_account": "account",

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -24,7 +24,7 @@
   "tests": ["test_stuff"],
   "cleanup_images": true,
   "cloud_architecture": "aarch64",
-  "notification_email": "test@fake.com",
+  "notification_type": "single",
   "profile": "Proxy",
   "conditions_wait_time": 500,
   "raw_image_upload_type": "s3bucket",

--- a/test/unit/services/api/utils/jobs/base_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/base_job_utils_test.py
@@ -10,7 +10,8 @@ from mash.services.api.utils.jobs import (
     get_jobs,
     validate_last_service,
     validate_create_args,
-    validate_deprecate_args
+    validate_deprecate_args,
+    validate_job
 )
 from mash.mash_exceptions import MashJobException
 
@@ -161,3 +162,32 @@ def test_validate_create_args():
 def test_validate_deprecate_args():
     with raises(MashJobException):
         validate_deprecate_args({})
+
+
+@patch('mash.services.api.utils.jobs.get_user_by_id')
+@patch('mash.services.api.utils.jobs.get_services_by_last_service')
+@patch('mash.services.api.utils.jobs.validate_last_service')
+def test_validate_job(
+    mock_validate_last_srv,
+    mock_get_services,
+    mock_get_user
+):
+    user = Mock()
+    user.email = 'test@fake.com'
+
+    mock_get_user.return_value = user
+    mock_get_services.return_value = ['obs', 'upload']
+
+    data = {
+        'last_service': 'upload',
+        'utctime': 'now',
+        'image': 'test_oem_image',
+        'download_url': 'http://download.opensuse.org/repositories/Cloud:Tools/images',
+        'requesting_user': '1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'notification_type': 'single'
+    }
+
+    data = validate_job(data)
+    assert data['notification_email'] == 'test@fake.com'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -96,6 +96,7 @@ class TestJobCreatorService(object):
         }
         del job['cloud_accounts']
         del job['cloud_groups']
+        job['notification_email'] = 'test@fake.com'
 
         message = MagicMock()
         message.body = JsonFormat.json_message(job)
@@ -237,6 +238,7 @@ class TestJobCreatorService(object):
         with open('test/data/azure_job.json', 'r') as job_doc:
             job = json.load(job_doc)
 
+        job['notification_email'] = 'test@fake.com'
         message = MagicMock()
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
@@ -350,6 +352,7 @@ class TestJobCreatorService(object):
         with open('test/data/gce_job.json', 'r') as job_doc:
             job = json.load(job_doc)
 
+        job['notification_email'] = 'test@fake.com'
         message = MagicMock()
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Instead of requiring the email as job arg. To enable notification emails notification_type now is required.

### How will these changes be tested?

Unit tests.

### How will this change be deployed? Any special considerations?


### Additional Information
