### PR TITLE
Change message flow from push to pull.

### DIFF
--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -93,7 +93,7 @@ class ListenerService(MashService):
             self.service_exchange, self.job_document_key, self.service_queue
         )
         self.bind_queue(
-            self.service_exchange, self.listener_msg_key, self.listener_queue
+            self.prev_service, self.listener_msg_key, self.listener_queue
         )
 
         thread_pool_count = self.custom_args.get(
@@ -350,7 +350,7 @@ class ListenerService(MashService):
         Publish message to next service exchange.
         """
         try:
-            self.publish_job_result(self.next_service, message)
+            self.publish_job_result(self.service_exchange, message)
         except AMQPError:
             self.log.warning(
                 'Message not received: {0}'.format(message),

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -81,7 +81,7 @@ class OBSImageBuildResultService(MashService):
 
     def _send_job_result_for_upload(self, job_id, trigger_info):
         self._publish(
-            'upload',
+            self.service_exchange,
             self.listener_msg_key,
             JsonFormat.json_message(trigger_info)
         )
@@ -139,7 +139,7 @@ class OBSImageBuildResultService(MashService):
                 }
             }
             self._publish(
-                'upload',
+                self.service_exchange,
                 self.listener_msg_key,
                 JsonFormat.json_message(message)
             )

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -464,7 +464,7 @@ class TestListenerService(object):
         mock_get_status_message.return_value = self.status_message
         self.service._publish_message('{"test": "message"}', job.id)
         mock_publish.assert_called_once_with(
-            'publish',
+            'replicate',
             '{"test": "message"}'
         )
 

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -87,7 +87,7 @@ class TestOBSImageBuildResultService(object):
         self.obs_result._send_job_result_for_upload('815', {})
         mock_delete_job.assert_called_once_with('815')
         mock_publish.assert_called_once_with(
-            'upload', 'listener_msg', '{}'
+            'obs', 'listener_msg', '{}'
         )
 
     def test_send_control_response_local(self):
@@ -148,7 +148,7 @@ class TestOBSImageBuildResultService(object):
         message.body = '{"job_delete": "4711"}'
         self.obs_result._process_message(message)
         mock_publish.assert_called_once_with(
-            'upload',
+            'obs',
             'listener_msg',
             JsonFormat.json_message(
                 {'obs_result': {'id': '4711', 'status': 'delete'}}


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The listener messages will be published to the service exchange sending the message so a single message can also be pulled/duplicated by the status service.

### How will these changes be tested?

Unit and integration.

### How will this change be deployed? Any special considerations?


### Additional Information
