### PR TITLE
Listener msgs

### DIFF
--- a/mash/services/create/azure_job.py
+++ b/mash/services/create/azure_job.py
@@ -49,8 +49,8 @@ class AzureCreateJob(MashJob):
         self.status = SUCCESS
         self.log_callback.info('Creating image.')
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
-        self.blob_name = self.source_regions['blob_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+        self.blob_name = self.status_msg['blob_name']
 
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]

--- a/mash/services/create/gce_job.py
+++ b/mash/services/create/gce_job.py
@@ -56,8 +56,8 @@ class GCECreateJob(MashJob):
         self.status = SUCCESS
         self.log_callback.info('Creating image.')
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
-        object_name = self.source_regions['object_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+        object_name = self.status_msg['object_name']
 
         timestamp = re.findall(r'\d{8}', self.cloud_image_name)[0]
         self.cloud_image_description = format_string_with_date(

--- a/mash/services/create/oci_job.py
+++ b/mash/services/create/oci_job.py
@@ -78,9 +78,9 @@ class OCICreateJob(MashJob):
             compute_client
         )
 
-        object_name = self.source_regions['object_name']
-        namespace = self.source_regions['namespace']
-        cloud_image_name = self.source_regions['cloud_image_name']
+        object_name = self.status_msg['object_name']
+        namespace = self.status_msg['namespace']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         image_source_details = ImageSourceViaObjectStorageTupleDetails(
             bucket_name=self.bucket,
@@ -93,7 +93,7 @@ class OCICreateJob(MashJob):
 
         image_details = CreateImageDetails(
             compartment_id=self.compartment_id,
-            display_name=cloud_image_name,
+            display_name=self.cloud_image_name,
             image_source_details=image_source_details,
             launch_mode=self.launch_mode
         )
@@ -113,10 +113,7 @@ class OCICreateJob(MashJob):
             waiter_kwargs={'max_wait_seconds': self.max_oci_wait_seconds}
         )
 
-        self.source_regions = {
-            'cloud_image_name': cloud_image_name,
-            'image_id': response.data.id
-        }
+        self.status_msg['image_id'] = response.data.id
         self.log_callback.info(
             'Created image has ID: {0}.'.format(
                 object_name

--- a/mash/services/create_service.py
+++ b/mash/services/create_service.py
@@ -58,8 +58,6 @@ def main():
             service_exchange=service_name,
             config=BaseConfig(),
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/mash/services/deprecate/ec2_job.py
+++ b/mash/services/deprecate/ec2_job.py
@@ -62,7 +62,7 @@ class EC2DeprecateJob(MashJob):
             accounts.append(region_info['account'])
 
         self.request_credentials(accounts)
-        self.cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         for region_info in self.deprecate_regions:
             credential = self.credentials[region_info['account']]

--- a/mash/services/deprecate/gce_job.py
+++ b/mash/services/deprecate/gce_job.py
@@ -66,7 +66,7 @@ class GCEDeprecateJob(MashJob):
         self.request_credentials([self.account])
         credential = self.credentials[self.account]
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         with create_json_file(credential) as auth_file:
             try:

--- a/mash/services/deprecate_service.py
+++ b/mash/services/deprecate_service.py
@@ -57,7 +57,6 @@ def main():
             service_exchange=service_name,
             config=BaseConfig(),
             custom_args={
-                'listener_msg_args': ['source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -145,7 +145,8 @@ class JobCreatorService(MashService):
         """
         self.consume_queue(
             self._handle_service_message,
-            queue_name=self.service_queue
+            self.service_queue,
+            self.service_exchange
         )
         try:
             self.channel.start_consuming()

--- a/mash/services/logger/service.py
+++ b/mash/services/logger/service.py
@@ -82,7 +82,11 @@ class LoggerService(MashService):
         """
         Start logger service.
         """
-        self.consume_queue(self._process_log, 'logging')
+        self.consume_queue(
+            self._process_log,
+            'logging',
+            self.service_exchange
+        )
 
         try:
             self.channel.start_consuming()

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -19,7 +19,7 @@
 import logging
 
 from mash.mash_exceptions import MashJobException
-from mash.services.status_levels import UNKOWN
+from mash.services.status_levels import UNKOWN, SUCCESS
 from mash.utils.mash_utils import handle_request
 
 
@@ -34,12 +34,11 @@ class MashJob(object):
         self._cloud_image_name = None
         self._credentials = None
         self._log_callback = None
-        self._source_regions = {}
         self._job_file = job_config.get('job_file')
 
         self.config = config
         self.iteration_count = 0
-        self.status = UNKOWN
+        self.status_msg = {'status': UNKOWN}
 
         try:
             self.id = job_config['id']
@@ -164,29 +163,35 @@ class MashJob(object):
             {'job_id': self.id}
         )
 
+    def get_status_message(self):
+        """Status message property."""
+        if self.status == SUCCESS:
+            return self.status_msg
+        else:
+            return {
+                'id': self.id,
+                'status': self.status,
+            }
+
+    def set_status_message(self, message):
+        """
+        Setter for status_msg dictionary.
+        """
+        self.status_msg = message
+
     @property
-    def source_regions(self):
-        """Source regions property."""
-        return self._source_regions
+    def status(self):
+        """
+        Returns the status from the status message dictionary.
+        """
+        return self.status_msg['status']
 
-    @source_regions.setter
-    def source_regions(self, regions):
+    @status.setter
+    def status(self, value):
         """
-        Setter for source_regions dictionary.
+        Returns the status from status dictionary.
         """
-        self._source_regions = regions
-
-    @property
-    def image_file(self):
-        """VM image file property."""
-        return self._image_file
-
-    @image_file.setter
-    def image_file(self, system_image_file):
-        """
-        Setter for image_file list.
-        """
-        self._image_file = system_image_file
+        self.status_msg['status'] = value
 
     def post_init(self):
         """

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -178,11 +178,11 @@ class MashService(object):
         if self.connection and self.connection.is_open:
             self.connection.close()
 
-    def consume_queue(self, callback, queue_name):
+    def consume_queue(self, callback, queue_name, exchange):
         """
         Declare and consume queue.
         """
-        queue = self._get_queue_name(self.service_exchange, queue_name)
+        queue = self._get_queue_name(exchange, queue_name)
         self._declare_queue(queue)
         self.channel.basic.consume(
             callback=callback, queue=queue

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -67,7 +67,8 @@ class OBSImageBuildResultService(MashService):
         atexit.register(lambda: os._exit(0))
         self.consume_queue(
             self._process_message,
-            queue_name=self.service_queue
+            self.service_queue,
+            self.service_exchange
         )
 
         try:

--- a/mash/services/publish/azure_job.py
+++ b/mash/services/publish/azure_job.py
@@ -76,8 +76,8 @@ class AzurePublishJob(MashJob):
         self.request_credentials([self.account])
         credential = self.credentials[self.account]
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
-        self.blob_name = self.source_regions['blob_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+        self.blob_name = self.status_msg['blob_name']
 
         with create_json_file(credential) as auth_file:
             self.log_callback.info(

--- a/mash/services/publish/ec2_job.py
+++ b/mash/services/publish/ec2_job.py
@@ -57,7 +57,7 @@ class EC2PublishJob(MashJob):
             accounts.append(region_info['account'])
 
         self.request_credentials(accounts)
-        cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         for region_info in self.publish_regions:
             creds = self.credentials[region_info['account']]
@@ -65,7 +65,7 @@ class EC2PublishJob(MashJob):
             publish = EC2PublishImage(
                 access_key=creds['access_key_id'],
                 allow_copy=self.allow_copy,
-                image_name=cloud_image_name,
+                image_name=self.cloud_image_name,
                 secret_key=creds['secret_access_key'],
                 visibility=self.share_with,
                 log_callback=self.log_callback
@@ -78,6 +78,6 @@ class EC2PublishJob(MashJob):
                 except Exception as error:
                     raise MashPublishException(
                         'An error publishing image {0} in {1}. {2}'.format(
-                            cloud_image_name, region, error
+                            self.cloud_image_name, region, error
                         )
                     )

--- a/mash/services/publish_service.py
+++ b/mash/services/publish_service.py
@@ -59,8 +59,6 @@ def main():
             service_exchange=service_name,
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': job_factory,
                 'thread_pool_count': config.get_publish_thread_pool_count()
             }

--- a/mash/services/raw_image_upload_service.py
+++ b/mash/services/raw_image_upload_service.py
@@ -56,8 +56,6 @@ def main():
             service_exchange=service_name,
             config=UploadConfig(),
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/mash/services/replicate/azure_job.py
+++ b/mash/services/replicate/azure_job.py
@@ -73,8 +73,8 @@ class AzureReplicateJob(MashJob):
         self.request_credentials([self.account])
         credential = self.credentials[self.account]
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
-        self.blob_name = self.source_regions['blob_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+        self.blob_name = self.status_msg['blob_name']
 
         with create_json_file(credential) as auth_file:
             self.log_callback.info(

--- a/mash/services/replicate/ec2_job.py
+++ b/mash/services/replicate/ec2_job.py
@@ -56,7 +56,7 @@ class EC2ReplicateJob(MashJob):
         """
         self.status = SUCCESS
         self.source_region_results = defaultdict(dict)
-        self.cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         # Get all account credentials in one request
         accounts = []
@@ -82,7 +82,7 @@ class EC2ReplicateJob(MashJob):
                     self.source_region_results[target_region]['image_id'] = \
                         self._replicate_to_region(
                             credential,
-                            self.source_regions[source_region],
+                            self.status_msg['source_regions'][source_region],
                             source_region,
                             target_region
                         )  # noqa: E123 Suppress erroneous flake8 warning.

--- a/mash/services/replicate_service.py
+++ b/mash/services/replicate_service.py
@@ -58,8 +58,6 @@ def main():
             service_exchange=service_name,
             config=BaseConfig(),
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/mash/services/test/azure_job.py
+++ b/mash/services/test/azure_job.py
@@ -90,7 +90,7 @@ class AzureTestJob(MashJob):
 
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]
-        self.cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         with create_json_file(credentials) as auth_file:
             try:
@@ -126,7 +126,7 @@ class AzureTestJob(MashJob):
 
     def cleanup_image(self):
         credentials = self.credentials[self.account]
-        blob_name = self.source_regions['blob_name']
+        blob_name = self.status_msg['blob_name']
 
         self.log_callback.info(
             'Cleaning up image: {0} in region: {1}.'.format(

--- a/mash/services/test/ec2_job.py
+++ b/mash/services/test/ec2_job.py
@@ -90,8 +90,6 @@ class EC2TestJob(MashJob):
         if not os.path.exists(self.ssh_private_key_file):
             create_ssh_key_pair(self.ssh_private_key_file)
 
-        self.image_file = None
-
     def run_job(self):
         """
         Tests image with img-proof and update status and results.
@@ -134,7 +132,7 @@ class EC2TestJob(MashJob):
                         cloud=self.cloud,
                         description=self.description,
                         distro=self.distro,
-                        image_id=self.source_regions[region],
+                        image_id=self.status_msg['source_regions'][region],
                         instance_type=self.instance_type,
                         img_proof_timeout=self.img_proof_timeout,
                         region=region,
@@ -177,5 +175,5 @@ class EC2TestJob(MashJob):
                     credentials['secret_access_key'],
                     self.log_callback,
                     region,
-                    self.source_regions[region]
+                    self.status_msg['source_regions'][region]
                 )

--- a/mash/services/test/gce_job.py
+++ b/mash/services/test/gce_job.py
@@ -104,7 +104,7 @@ class GCETestJob(MashJob):
 
         fallback_regions.add(self.region)
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
 
         with create_json_file(credentials) as auth_file:
             for firmware in self.boot_firmware:

--- a/mash/services/test/oci_job.py
+++ b/mash/services/test/oci_job.py
@@ -94,8 +94,8 @@ class OCITestJob(MashJob):
         self.request_credentials([self.account])
         credentials = self.credentials[self.account]
 
-        self.cloud_image_name = self.source_regions['cloud_image_name']
-        image_id = self.source_regions['image_id']
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+        image_id = self.status_msg['image_id']
 
         with create_key_file(credentials['signing_key']) as signing_key_file:
             try:

--- a/mash/services/test_service.py
+++ b/mash/services/test_service.py
@@ -59,8 +59,6 @@ def main():
             service_exchange=service_name,
             config=TestConfig(),
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/mash/services/upload/azure_job.py
+++ b/mash/services/upload/azure_job.py
@@ -59,7 +59,7 @@ class AzureUploadJob(MashJob):
         upload_azure_file(
             blob_name,
             self.container,
-            self.image_file,
+            self.status_msg['image_file'],
             self.config.get_azure_max_retry_attempts(),
             self.config.get_azure_max_workers(),
             self.storage_account,
@@ -68,10 +68,8 @@ class AzureUploadJob(MashJob):
             is_page_blob=True
         )
 
-        self.source_regions = {
-            'cloud_image_name': self.cloud_image_name,
-            'blob_name': blob_name
-        }
+        self.status_msg['cloud_image_name'] = self.cloud_image_name
+        self.status_msg['blob_name'] = blob_name
         self.log_callback.info(
             'Uploaded image: {0}, to the container: {1}'.format(
                 blob_name,

--- a/mash/services/upload/azure_raw_job.py
+++ b/mash/services/upload/azure_raw_job.py
@@ -57,12 +57,16 @@ class AzureRawUploadJob(MashJob):
         self.request_credentials([self.account], 'azure')
         credentials = self.credentials[self.account]
 
-        file_name = self.image_file.rsplit(os.sep, maxsplit=1)[-1]
+        file_name = self.status_msg['image_file'].rsplit(
+            os.sep, maxsplit=1
+        )[-1]
         self.additional_uploads.append('')
 
         for extension in self.additional_uploads:
             upload_file_name = '.'.join(filter(None, [file_name, extension]))
-            file_path = '.'.join(filter(None, [self.image_file, extension]))
+            file_path = '.'.join(
+                filter(None, [self.status_msg['image_file'], extension])
+            )
 
             upload_azure_file(
                 upload_file_name,
@@ -76,10 +80,7 @@ class AzureRawUploadJob(MashJob):
                 expand_image=False
             )
 
-        self.source_regions = {
-            'cloud_image_name': file_name,
-            'blob_name': file_name
-        }
+        self.status_msg['blob_name'] = file_name
         self.log_callback.info(
             'Uploaded image: {0}, to the container: {1}'.format(
                 file_name,

--- a/mash/services/upload/azure_sas_job.py
+++ b/mash/services/upload/azure_sas_job.py
@@ -57,15 +57,15 @@ class AzureSASUploadJob(MashJob):
             )
             self.blob_name = ''.join([self.cloud_image_name, '.vhd'])
         else:
-            self.cloud_image_name = self.source_regions['cloud_image_name']
-            self.blob_name = self.source_regions['blob_name']
+            self.cloud_image_name = self.status_msg['cloud_image_name']
+            self.blob_name = self.status_msg['blob_name']
 
         build = re.search(sas_url_match, self.raw_image_upload_location)
 
         upload_azure_file(
             self.blob_name,
             build.group(2),
-            self.image_file,
+            self.status_msg['image_file'],
             self.config.get_azure_max_retry_attempts(),
             self.config.get_azure_max_workers(),
             build.group(1),

--- a/mash/services/upload/gce_job.py
+++ b/mash/services/upload/gce_job.py
@@ -72,30 +72,16 @@ class GCEUploadJob(MashJob):
             object_name = ''.join([self.cloud_image_name, '.tar.gz'])
             container = storage_driver.get_container(self.bucket)
 
-            with open(self.image_file, 'rb') as image_stream:
+            with open(self.status_msg['image_file'], 'rb') as image_stream:
                 storage_driver.upload_object_via_stream(
                     image_stream, container, object_name
                 )
 
-        self.source_regions = {
-            'cloud_image_name': self.cloud_image_name,
-            'object_name': object_name
-        }
+        self.status_msg['cloud_image_name'] = self.cloud_image_name
+        self.status_msg['object_name'] = object_name
         self.log_callback.info(
             'Uploaded image: {0}, to the bucket named: {1}'.format(
                 object_name,
                 self.bucket
             )
         )
-
-    @property
-    def image_file(self):
-        """System image file property."""
-        return self._image_file
-
-    @image_file.setter
-    def image_file(self, system_image_file):
-        """
-        Setter for image_file list.
-        """
-        self._image_file = system_image_file

--- a/mash/services/upload/oci_job.py
+++ b/mash/services/upload/oci_job.py
@@ -81,9 +81,9 @@ class OCIUploadJob(MashJob):
         )
 
         object_name = ''.join([self.cloud_image_name, '.qcow2'])
-        self._image_size = stat(self.image_file).st_size
+        self._image_size = stat(self.status_msg['image_file']).st_size
 
-        with open(self.image_file, 'rb') as image_stream:
+        with open(self.status_msg['image_file'], 'rb') as image_stream:
             upload_manager.upload_stream(
                 namespace,
                 self.bucket,
@@ -92,11 +92,10 @@ class OCIUploadJob(MashJob):
                 progress_callback=self._progress_callback
             )
 
-        self.source_regions = {
-            'cloud_image_name': self.cloud_image_name,
-            'object_name': object_name,
-            'namespace': namespace
-        }
+        self.status_msg['cloud_image_name'] = self.cloud_image_name
+        self.status_msg['object_name'] = object_name
+        self.status_msg['namespace'] = namespace
+
         self.log_callback.info(
             'Uploaded image: {0}, to the bucket named: {1}'.format(
                 object_name,

--- a/mash/services/upload/s3bucket_job.py
+++ b/mash/services/upload/s3bucket_job.py
@@ -32,7 +32,6 @@ class S3BucketUploadJob(MashJob):
 
     def post_init(self):
         self.cloud = 'ec2'
-        self.image_file = None
         self._image_size = 0
         self._total_bytes_transferred = 0
         self._last_percentage_logged = 0
@@ -80,12 +79,12 @@ class S3BucketUploadJob(MashJob):
         except IndexError:
             bucket_path = ''
 
-        if self.cloud_image_name:
+        if self.status_msg['cloud_image_name']:
             # take suffix from file name, should always consist of two parts
-            suffix = '.'.join(str.split(self.image_file, '.')[-2:])
-            key_name = '.'.join([self.cloud_image_name, suffix])
+            suffix = '.'.join(str.split(self.status_msg['image_file'], '.')[-2:])
+            key_name = '.'.join([self.status_msg['cloud_image_name'], suffix])
         else:
-            key_name = path.basename(self.image_file)
+            key_name = path.basename(self.status_msg['image_file'])
 
         if not bucket_path:
             pass
@@ -95,7 +94,7 @@ class S3BucketUploadJob(MashJob):
             key_name = bucket_path
 
         try:
-            statinfo = stat(self.image_file)
+            statinfo = stat(self.status_msg['image_file'])
             self._image_size = statinfo.st_size
 
             client = get_client(
@@ -104,7 +103,7 @@ class S3BucketUploadJob(MashJob):
             )
 
             client.upload_file(
-                self.image_file,
+                self.status_msg['image_file'],
                 bucket_name,
                 key_name,
                 Callback=self._log_progress

--- a/mash/services/upload_service.py
+++ b/mash/services/upload_service.py
@@ -64,8 +64,6 @@ def main():
             service_exchange=service_name,
             config=UploadConfig(),
             custom_args={
-                'listener_msg_args': ['image_file'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': job_factory
             }
         )

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -102,3 +102,23 @@ class TestMashJob(object):
         job._log_callback = Mock()
         job.process_job()
         mock_run_job.assert_called_once_with()
+
+    def test_get_set_status(self):
+        job = MashJob(self.job_config, self.config)
+        assert job.status is None
+
+        job.status = 'success'
+        assert job.status == 'success'
+
+    def test_get_set_status_message(self):
+        job = MashJob(self.job_config, self.config)
+        status_msg = job.get_status_message()
+
+        assert status_msg['id'] == '1'
+        assert status_msg['status'] is None
+
+        job.set_status_message({'id': '1', 'status': 'success'})
+        status_msg = job.get_status_message()
+
+        assert status_msg['id'] == '1'
+        assert status_msg['status'] == 'success'

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -49,7 +49,7 @@ class TestBaseService(object):
 
     def test_consume_queue(self):
         callback = Mock()
-        self.service.consume_queue(callback, queue_name='service')
+        self.service.consume_queue(callback, 'service', 'obs')
         self.channel.basic.consume.assert_called_once_with(
             callback=callback, queue='obs.service'
         )

--- a/test/unit/services/create/azure_job_test.py
+++ b/test/unit/services/create/azure_job_test.py
@@ -80,10 +80,8 @@ class TestAzureCreateJob(object):
         async_create_image = Mock()
         client.images.create_or_update.return_value = async_create_image
 
-        self.job.source_regions = self.job.source_regions = {
-            'cloud_image_name': 'name',
-            'blob_name': 'name.vhd'
-        }
+        self.job.status_msg['cloud_image_name'] = 'name'
+        self.job.status_msg['blob_name'] = 'name.vhd'
         self.job.run_job()
 
         assert mock_get_client_from_auth_file.call_count == 1

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -43,7 +43,8 @@ class TestAmazonCreateJob(object):
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
-        self.job.image_file = 'file'
+        self.job.status_msg['image_file'] = 'file'
+        self.job.status_msg['source_regions'] = {'us-east-1': 'ami_id'}
         self.job.credentials = self.credentials
 
     def test_post_init_incomplete_arguments(self):
@@ -147,7 +148,6 @@ class TestAmazonCreateJob(object):
         ec2_setup.clean_up.assert_called_once_with()
 
         ec2_upload.create_image.side_effect = ['ami_id', Exception('Failed!')]
-        self.job.source_regions['us-east-1'] = 'ami_id'
         self.job.target_regions['us-east-2'] = {
             'account': 'test',
             'helper_image': 'ami-bc5b48d0',
@@ -199,7 +199,8 @@ class TestAmazonCreateJob(object):
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
-        self.job.image_file = 'file'
+        self.job.status_msg['image_file'] = 'file'
+        self.job.status_msg['source_regions'] = {'us-east-1': 'ami_id'}
         self.job.credentials = self.credentials
 
         open_context = context_manager()

--- a/test/unit/services/create/gce_job_test.py
+++ b/test/unit/services/create/gce_job_test.py
@@ -79,10 +79,8 @@ class TestGCECreateJob(object):
         compute_driver = Mock()
         compute_engine.return_value = compute_driver
 
-        self.job.source_regions = {
-            'cloud_image_name': 'sles-12-sp4-v20180909',
-            'object_name': 'sles-12-sp4-v20180909.tar.gz'
-        }
+        self.job.status_msg['cloud_image_name'] = 'sles-12-sp4-v20180909'
+        self.job.status_msg['object_name'] = 'sles-12-sp4-v20180909.tar.gz'
         self.job.run_job()
 
         compute_driver.ex_create_image.assert_called_once_with(

--- a/test/unit/services/create/main_test.py
+++ b/test/unit/services/create/main_test.py
@@ -20,8 +20,6 @@ class TestCreate(object):
             service_exchange='create',
             config=config,
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/create/oci_job_test.py
+++ b/test/unit/services/create/oci_job_test.py
@@ -70,11 +70,9 @@ class TestOCICreateJob(object):
         compute_composite_client = Mock()
         mock_compute_client_composite.return_value = compute_composite_client
 
-        self.job.source_regions = {
-            'cloud_image_name': 'sles-12-sp4-v20180909',
-            'object_name': 'sles-12-sp4-v20180909.tar.gz',
-            'namespace': 'sles'
-        }
+        self.job.status_msg['cloud_image_name'] = 'sles-12-sp4-v20180909'
+        self.job.status_msg['object_name'] = 'sles-12-sp4-v20180909.tar.gz'
+        self.job.status_msg['namespace'] = 'sles'
         self.job.run_job()
 
         compute_composite_client.create_image_and_wait_for_state.call_count == 1

--- a/test/unit/services/deprecate/ec2_job_test.py
+++ b/test/unit/services/deprecate/ec2_job_test.py
@@ -31,10 +31,8 @@ class TestEC2DeprecateJob(object):
                 'secret_access_key': '654321'
             }
         }
-        self.job.source_regions = {
-            'cloud_image_name': 'image_123',
-            'us-east-2': 'ami-123456'
-        }
+        self.job.status_msg['cloud_image_name'] = 'image_123'
+        self.job.status_msg['source_regions'] = {'us-east-2': 'ami-123456'}
 
     def test_deprecate_ec2_missing_key(self):
         del self.job_config['deprecate_regions']

--- a/test/unit/services/deprecate/gce_job_test.py
+++ b/test/unit/services/deprecate/gce_job_test.py
@@ -26,9 +26,7 @@ class TestGCEDeprecateJob(object):
                 'project_id': '1234567890'
             }
         }
-        self.job.source_regions = {
-            'cloud_image_name': 'image_123'
-        }
+        self.job.status_msg['cloud_image_name'] = 'image_123'
 
     def test_deprecate_gce_missing_key(self):
         del self.job_config['account']

--- a/test/unit/services/deprecate/main_test.py
+++ b/test/unit/services/deprecate/main_test.py
@@ -20,7 +20,6 @@ class TestDeprecateServiceMain(object):
             service_exchange='deprecate',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
                 'job_factory': factory
             }
         )
@@ -48,7 +47,6 @@ class TestDeprecateServiceMain(object):
             service_exchange='deprecate',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -545,7 +545,8 @@ class TestJobCreatorService(object):
 
         mock_consume_queue.assert_called_once_with(
             self.jobcreator._handle_service_message,
-            queue_name='service'
+            'service',
+            'jobcreator'
         )
         mock_stop.assert_called_once_with()
 

--- a/test/unit/services/logger/service_test.py
+++ b/test/unit/services/logger/service_test.py
@@ -111,7 +111,7 @@ class TestLoggerService(object):
         self.logger.start()
         self.channel.start_consuming.assert_called_once_with()
         mock_consume_queue.assert_called_once_with(
-            self.logger._process_log, 'logging'
+            self.logger._process_log, 'logging', 'logger'
         )
         mock_close_connection.assert_called_once_with()
 

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -65,7 +65,7 @@ class TestOBSImageBuildResultService(object):
         )
 
         self.obs_result.consume_queue.assert_called_once_with(
-            mock_process_message, queue_name='service'
+            mock_process_message, 'service', 'obs'
         )
         self.obs_result.channel.start_consuming.assert_called_once_with()
 

--- a/test/unit/services/publish/azure_job_test.py
+++ b/test/unit/services/publish/azure_job_test.py
@@ -48,10 +48,8 @@ class TestAzurePublishJob(object):
                     "https://management.core.windows.net/"
             }
         }
-        self.job.source_regions = {
-            'cloud_image_name': 'New Image',
-            'blob_name': 'New Image.vhd'
-        }
+        self.job.status_msg['cloud_image_name'] = 'New Image'
+        self.job.status_msg['blob_name'] = 'New Image.vhd'
         self.log = MagicMock()
         self.job._log_callback = self.log
 

--- a/test/unit/services/publish/ec2_job_test.py
+++ b/test/unit/services/publish/ec2_job_test.py
@@ -34,10 +34,8 @@ class TestEC2PublishJob(object):
                 'ssh_private_key': 'key123'
             }
         }
-        self.job.source_regions = {
-            'cloud_image_name': 'image_name_123',
-            'us-east-2': 'image-id'
-        }
+        self.job.status_msg['cloud_image_name'] = 'image_name_123'
+        self.job.status_msg['source_regions'] = {'us-east-2': 'image-id'}
         self.job._log_callback = Mock()
 
     def test_publish_ec2_missing_key(self):

--- a/test/unit/services/publish/main_test.py
+++ b/test/unit/services/publish/main_test.py
@@ -23,8 +23,6 @@ class TestPublishServiceMain(object):
             service_exchange='publish',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': factory,
                 'thread_pool_count': 50
             }
@@ -50,8 +48,6 @@ class TestPublishServiceMain(object):
             service_exchange='publish',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': factory,
                 'thread_pool_count': 50
             }

--- a/test/unit/services/raw_image_upload/main_test.py
+++ b/test/unit/services/raw_image_upload/main_test.py
@@ -20,8 +20,6 @@ class TestUpload(object):
             service_exchange='raw_image_upload',
             config=config,
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/replicate/azure_job_test.py
+++ b/test/unit/services/replicate/azure_job_test.py
@@ -47,10 +47,8 @@ class TestAzureReplicateJob(object):
                     "https://management.core.windows.net/"
             }
         }
-        self.job.source_regions = {
-            'cloud_image_name': 'image123',
-            'blob_name': 'image123.vhd'
-        }
+        self.job.status_msg['cloud_image_name'] = 'image123'
+        self.job.status_msg['blob_name'] = 'image123.vhd'
         self.log = Mock()
         self.job._log_callback = self.log
 

--- a/test/unit/services/replicate/ec2_job_test.py
+++ b/test/unit/services/replicate/ec2_job_test.py
@@ -34,10 +34,8 @@ class TestEC2ReplicateJob(object):
             }
         }
 
-        self.job.source_regions = {
-            'cloud_image_name': 'My image',
-            'us-east-1': 'ami-12345'
-        }
+        self.job.status_msg['cloud_image_name'] = 'My image'
+        self.job.status_msg['source_regions'] = {'us-east-1': 'ami-12345'}
 
     def test_replicate_ec2_missing_key(self):
         del self.job_config['replicate_source_regions']

--- a/test/unit/services/replicate/main_test.py
+++ b/test/unit/services/replicate/main_test.py
@@ -20,8 +20,6 @@ class TestReplicateServiceMain(object):
             service_exchange='replicate',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': factory
             }
         )
@@ -47,8 +45,6 @@ class TestReplicateServiceMain(object):
             service_exchange='replicate',
             config=config,
             custom_args={
-                'listener_msg_args': ['source_regions'],
-                'status_msg_args': ['source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/test/azure_job_test.py
+++ b/test/unit/services/test/azure_job_test.py
@@ -70,10 +70,8 @@ class TestAzureTestJob(object):
                 'credentials': '321'
             }
         }
-        job.source_regions = {
-            'cloud_image_name': 'name',
-            'blob_name': 'name.vhd'
-        }
+        job.status_msg['cloud_image_name'] = 'name'
+        job.status_msg['blob_name'] = 'name.vhd'
         job.cloud_image_name = 'test_image'
         job._log_callback = Mock()
         job.run_job()

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -83,7 +83,7 @@ class TestEC2TestJob(object):
                 'secret_access_key': '321'
             }
         }
-        job.source_regions = {'us-east-1': 'ami-123'}
+        job.status_msg['source_regions'] = {'us-east-1': 'ami-123'}
         job.run_job()
 
         client.import_key_pair.assert_called_once_with(
@@ -172,5 +172,5 @@ class TestEC2TestJob(object):
                 'secret_access_key': '321'
             }
         }
-        job.source_regions = {'cn-east-1': 'ami-123'}
+        job.status_msg['source_regions'] = {'cn-east-1': 'ami-123'}
         job.run_job()

--- a/test/unit/services/test/gce_job_test.py
+++ b/test/unit/services/test/gce_job_test.py
@@ -83,7 +83,7 @@ class TestGCETestJob(object):
                 'credentials': '321'
             }
         }
-        job.source_regions = {'cloud_image_name': 'ami-123'}
+        job.status_msg['cloud_image_name'] = 'ami-123'
         job.run_job()
 
         mock_test_image.assert_has_calls([
@@ -162,7 +162,7 @@ class TestGCETestJob(object):
                 'credentials': '321'
             }
         }
-        job.source_regions = {'cloud_image_name': 'ami-123'}
+        job.status_msg['cloud_image_name'] = 'ami-123'
         job.run_job()
 
         mock_test_image.assert_has_calls([

--- a/test/unit/services/test/main_test.py
+++ b/test/unit/services/test/main_test.py
@@ -20,8 +20,6 @@ class TestImgProofTestServiceMain(object):
             service_exchange='test',
             config=config,
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': factory
             }
         )
@@ -46,8 +44,6 @@ class TestImgProofTestServiceMain(object):
             service_exchange='test',
             config=config,
             custom_args={
-                'listener_msg_args': ['image_file', 'source_regions'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/test/oci_job_test.py
+++ b/test/unit/services/test/oci_job_test.py
@@ -71,10 +71,8 @@ class TestOCITestJob(object):
                 'fingerprint': 'fake fingerprint'
             }
         }
-        job.source_regions = {
-            'cloud_image_name': 'name.qcow2',
-            'image_id': 'ocid1.image.oc1..'
-        }
+        job.status_msg['cloud_image_name'] = 'name.qcow2'
+        job.status_msg['image_id'] = 'ocid1.image.oc1..'
         job.run_job()
 
         mock_test_image.assert_called_once_with(

--- a/test/unit/services/upload/azure_job_test.py
+++ b/test/unit/services/upload/azure_job_test.py
@@ -50,7 +50,7 @@ class TestAzureUploadJob(object):
         )
 
         self.job = AzureUploadJob(job_doc, self.config)
-        self.job.image_file = 'file.vhdfixed.xz'
+        self.job.status_msg['image_file'] = 'file.vhdfixed.xz'
         self.job.credentials = self.credentials
         self.job._log_callback = MagicMock()
 

--- a/test/unit/services/upload/azure_raw_job_test.py
+++ b/test/unit/services/upload/azure_raw_job_test.py
@@ -52,7 +52,7 @@ class TestAzureRawUploadJob(object):
         )
 
         self.job = AzureRawUploadJob(job_doc, self.config)
-        self.job.image_file = 'file.vhdfixed.xz'
+        self.job.status_msg['image_file'] = 'file.vhdfixed.xz'
         self.job.credentials = self.credentials
         self.job._log_callback = MagicMock()
 

--- a/test/unit/services/upload/azure_sas_job_test.py
+++ b/test/unit/services/upload/azure_sas_job_test.py
@@ -26,7 +26,7 @@ class TestAzureSASUploadJob(object):
         )
 
         self.job = AzureSASUploadJob(job_doc, self.config)
-        self.job.image_file = 'file.vhdfixed.xz'
+        self.job.status_msg = {'image_file': 'file.vhdfixed.xz'}
         self.job._log_callback = MagicMock()
 
     def test_post_init_incomplete_arguments(self):
@@ -71,10 +71,8 @@ class TestAzureSASUploadJob(object):
         open_handle.__enter__.return_value = open_handle
         mock_open.return_value = open_handle
 
-        self.job.source_regions = self.job.source_regions = {
-            'cloud_image_name': 'name',
-            'blob_name': 'name.vhd'
-        }
+        self.job.status_msg['cloud_image_name'] = 'name'
+        self.job.status_msg['blob_name'] = 'name.vhd'
         self.job.cloud_image_name = ''
 
         self.job.run_job()

--- a/test/unit/services/upload/gce_job_test.py
+++ b/test/unit/services/upload/gce_job_test.py
@@ -48,7 +48,7 @@ class TestGCEUploadJob(object):
         }
 
         self.job = GCEUploadJob(job_doc, self.config)
-        self.job.image_file = ['sles-12-sp4-v20180909.tar.gz']
+        self.job.status_msg['image_file'] = 'sles-12-sp4-v20180909.tar.gz'
         self.job.credentials = self.credentials
         self.job._log_callback = Mock()
 

--- a/test/unit/services/upload/main_test.py
+++ b/test/unit/services/upload/main_test.py
@@ -20,8 +20,6 @@ class TestUpload(object):
             service_exchange='upload',
             config=config,
             custom_args={
-                'listener_msg_args': ['image_file'],
-                'status_msg_args': ['image_file', 'source_regions'],
                 'job_factory': factory
             }
         )

--- a/test/unit/services/upload/oci_job_test.py
+++ b/test/unit/services/upload/oci_job_test.py
@@ -37,7 +37,7 @@ class TestOCIUploadJob(object):
         }
 
         self.job = OCIUploadJob(job_doc, self.config)
-        self.job.image_file = ['sles-12-sp4-v20180909.qcow2']
+        self.job.status_msg = {'image_file': 'sles-12-sp4-v20180909.qcow2'}
         self.job.credentials = credentials
         self.job._log_callback = Mock()
 

--- a/test/unit/services/upload/s3bucket_job_test.py
+++ b/test/unit/services/upload/s3bucket_job_test.py
@@ -45,8 +45,10 @@ class TestS3BucketUploadJob(object):
             'raw_image_upload_account': 'test'
         }
         self.job = S3BucketUploadJob(job_doc, self.config)
-        self.job.image_file = 'file.raw.gz'
-        self.job.cloud_image_name = 'name'
+        self.job.status_msg = {
+            'image_file': 'file.raw.gz',
+            'cloud_image_name': 'name'
+        }
         self.job.credentials = self.credentials
         self.job._log_callback = Mock()
 
@@ -105,7 +107,7 @@ class TestS3BucketUploadJob(object):
         # Test bucket and full name
         mock_client.upload_file.reset_mock()
         self.job.location = 'my-bucket/some-prefix/image.raw.gz'
-        self.job.cloud_image_name = None
+        self.job.status_msg['cloud_image_name'] = None
         self.job.run_job()
 
         mock_client.upload_file.assert_called_once_with(


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Move knowledge of specific listener message args to job classes.
- Instead of setting attrs in listener_service this allows the args to be different between cloud frameworks.
- This is useful for providing status based on cloud.
- It also decouples the specifics of job classes from the service itself.
- Rename the attr from source_regions which made sense only for EC2 to status_msg. This dictionary will hold all listener msg info as a hash and can be different per cloud framework.
- Consume_queue method now requires exchange name as arg.

### How will these changes be tested?

Unit and integration testing.

### How will this change be deployed? Any special considerations?


### Additional Information
