### PR TITLE
Move migrations and sqlalchemy from API service

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 omit =
     */version.py
     */wsgi.py
+    */migrations/*

--- a/mash/services/api/app.py
+++ b/mash/services/api/app.py
@@ -21,7 +21,7 @@ import logging
 from flask import Flask
 from flask.logging import default_handler
 
-from mash.services.api.extensions import api, db, jwt, migrate
+from mash.services.api.extensions import api, jwt
 
 from mash.log.filter import BaseServiceFilter
 from mash.utils.mash_utils import setup_logfile, setup_rabbitmq_log_handler
@@ -121,8 +121,6 @@ def register_namespaces():
 
 def register_extensions(app):
     """Register Flask extensions."""
-    db.init_app(app)
-    migrate.init_app(app, db)
     jwt.init_app(app)
     api.init_app(app)
 

--- a/mash/services/api/config.py
+++ b/mash/services/api/config.py
@@ -45,10 +45,6 @@ class Config(object):
         return self.config.get_log_file('api')
 
     @property
-    def CREDENTIALS_URL(self):
-        return self.config.get_credentials_url()
-
-    @property
     def CLOUD_DATA(self):
         return self.config.get_cloud_data()
 
@@ -59,14 +55,6 @@ class Config(object):
     @property
     def JWT_SECRET_KEY(self):
         return self.config.get_jwt_secret()
-
-    @property
-    def SQLALCHEMY_TRACK_MODIFICATIONS(self):
-        return False
-
-    @property
-    def SQLALCHEMY_DATABASE_URI(self):
-        return self.config.get_database_uri()
 
     @property
     def EMAIL_WHITELIST(self):

--- a/mash/services/api/extensions.py
+++ b/mash/services/api/extensions.py
@@ -17,8 +17,6 @@
 #
 
 from flask_restplus import Api
-from flask_migrate import Migrate
-from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 
 authorizations = {
@@ -40,6 +38,4 @@ api = Api(
     doc=False,
     authorizations=authorizations
 )
-db = SQLAlchemy()
-migrate = Migrate()
 jwt = JWTManager()

--- a/mash/services/api/utils/accounts/azure.py
+++ b/mash/services/api/utils/accounts/azure.py
@@ -19,7 +19,7 @@
 from flask import current_app
 
 from mash.mash_exceptions import MashDBException
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.api.utils.users import get_user_by_id
 from mash.services.database.models import AzureAccount
 from mash.utils.mash_utils import handle_request

--- a/mash/services/api/utils/accounts/ec2.py
+++ b/mash/services/api/utils/accounts/ec2.py
@@ -19,7 +19,7 @@
 from flask import current_app
 
 from mash.mash_exceptions import MashDBException
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.api.utils.users import get_user_by_id
 from mash.services.database.models import EC2Group, EC2Region, EC2Account
 from mash.utils.mash_utils import handle_request

--- a/mash/services/api/utils/accounts/gce.py
+++ b/mash/services/api/utils/accounts/gce.py
@@ -19,7 +19,7 @@
 from flask import current_app
 
 from mash.mash_exceptions import MashDBException
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.api.utils.users import get_user_by_id
 from mash.services.database.models import GCEAccount
 from mash.utils.mash_utils import handle_request

--- a/mash/services/api/utils/accounts/oci.py
+++ b/mash/services/api/utils/accounts/oci.py
@@ -19,7 +19,7 @@
 from flask import current_app
 
 from mash.mash_exceptions import MashDBException
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.api.utils.users import get_user_by_id
 from mash.services.database.models import OCIAccount
 from mash.utils.mash_utils import handle_request, get_fingerprint_from_private_key

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -21,7 +21,7 @@ import uuid
 
 from flask import current_app
 
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.database.models import Job, User
 from mash.services.api.utils.amqp import publish
 from mash.services.api.utils.users import get_user_by_id

--- a/mash/services/api/utils/tokens.py
+++ b/mash/services/api/utils/tokens.py
@@ -21,7 +21,7 @@ from flask_jwt_extended import decode_token
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.database.models import (
     User,
     Token

--- a/mash/services/api/utils/users.py
+++ b/mash/services/api/utils/users.py
@@ -23,7 +23,7 @@ from secrets import choice
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
-from mash.services.api.extensions import db
+from mash.services.database.extensions import db
 from mash.services.database.models import User
 from mash.services.api.variables import (
     password_change_msg_template,


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

- Omit migrations from coverage check.
- Remove db and sqlalchemy extensions from API. 
- Temporarily import db model from database service to keep unit tests passing.
- Remove sqlalchemy config attrs from API.
- And remove credentials URL which will only be used by database
service.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
