### PR TITLE
Migrate GCE job routes to database service.

### DIFF
--- a/mash/services/api/routes/jobs/gce.py
+++ b/mash/services/api/routes/jobs/gce.py
@@ -19,7 +19,7 @@
 import json
 
 from flask import jsonify, make_response, request, current_app
-from flask_restplus import marshal, Namespace, Resource
+from flask_restplus import Namespace, Resource
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from mash.mash_exceptions import MashException
@@ -76,7 +76,7 @@ class GCEJob(Resource):
 
         if job:
             return make_response(
-                jsonify(marshal(job, job_response, skip_none=True)),
+                jsonify(job),
                 201
             )
         else:

--- a/mash/services/api/utils/jobs/gce.py
+++ b/mash/services/api/utils/jobs/gce.py
@@ -45,24 +45,24 @@ def validate_gce_job(job_doc):
 
     for attr in attrs:
         if attr not in job_doc:
-            job_doc[attr] = getattr(cloud_account, attr)
+            job_doc[attr] = cloud_account.get(attr)
 
     services = get_services_by_last_service(job_doc['last_service'])
 
     if 'create' in services:
-        if cloud_account.is_publishing_account and not job_doc.get('family'):
+        if cloud_account['is_publishing_account'] and not job_doc.get('family'):
             raise MashJobException(
                 'Jobs using a GCE publishing account require a family.'
             )
 
     if 'test' in services:
-        if cloud_account.is_publishing_account and not job_doc['testing_account']:
+        if cloud_account['is_publishing_account'] and not job_doc.get('testing_account'):
             raise MashJobException(
                 'Jobs using a GCE publishing account require'
                 ' the use of a test account.'
             )
 
-        if cloud_account.is_publishing_account and not job_doc.get('image_project'):
+        if cloud_account['is_publishing_account'] and not job_doc.get('image_project'):
             raise MashJobException(
                 'Jobs using a GCE publishing account require an image_project.'
             )

--- a/test/unit/services/api/routes/jobs/gce_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/gce_job_routes_test.py
@@ -1,32 +1,47 @@
 import json
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from mash.mash_exceptions import MashException
 
 
+@patch('mash.services.api.utils.jobs.get_user_by_id')
 @patch('mash.services.api.routes.jobs.gce.create_job')
-@patch('mash.services.api.routes.jobs.gce.validate_gce_job')
+@patch('mash.services.api.utils.jobs.gce.get_gce_account')
 @patch('mash.services.api.routes.jobs.gce.get_jwt_identity')
 @patch('flask_jwt_extended.view_decorators.verify_jwt_in_request')
 def test_api_add_job_gce(
         mock_jwt_required,
         mock_jwt_identity,
-        mock_validate_gce_job,
+        mock_get_account,
         mock_create_job,
+        mock_get_user,
         test_client
 ):
-    job = Mock()
-    job.job_id = '12345678-1234-1234-1234-123456789012'
-    job.last_service = 'test'
-    job.utctime = 'now'
-    job.image = 'test_image_oem'
-    job.download_url = 'http://download.opensuse.org/repositories/Cloud:Tools/images'
-    job.cloud_architecture = 'x86_64'
-    job.profile = 'Server'
+    job = {
+        'job_id': '12345678-1234-1234-1234-123456789012',
+        'last_service': 'test',
+        'utctime': 'now',
+        'image': 'test_image_oem',
+        'download_url': 'http://download.opensuse.org/repositories/Cloud:Tools/images',
+        'cloud_architecture': 'x86_64',
+        'profile': 'Server',
+        'start_time': '2011-11-11 11:11:11',
+        'state': 'pending',
+        'errors': []
+    }
 
     mock_create_job.return_value = job
     mock_jwt_identity.return_value = 'user1'
+
+    account = {
+        'region': 'us-west1-a',
+        'name': 'test-gce',
+        'is_publishing_account': False
+    }
+    mock_get_account.return_value = account
+
+    mock_get_user.return_value = {'email': 'user1@test.com'}
 
     with open('test/data/gce_job.json', 'r') as job_doc:
         data = json.load(job_doc)
@@ -49,6 +64,8 @@ def test_api_add_job_gce(
     assert response.json['download_url'] == 'http://download.opensuse.org/repositories/Cloud:Tools/images'
     assert response.json['cloud_architecture'] == 'x86_64'
     assert response.json['profile'] == 'Server'
+    assert response.json['state'] == 'pending'
+    assert response.json['start_time'] == '2011-11-11 11:11:11'
 
     # Dry run
     data['dry_run'] = True
@@ -62,7 +79,7 @@ def test_api_add_job_gce(
     assert response.data == b'{"msg":"Job doc is valid!"}\n'
 
     # Exception
-    mock_validate_gce_job.side_effect = Exception('Broken')
+    mock_get_account.side_effect = Exception('Broken')
 
     response = test_client.post(
         '/jobs/gce/',
@@ -73,7 +90,7 @@ def test_api_add_job_gce(
     assert response.data == b'{"msg":"Failed to start job"}\n'
 
     # Mash Exception
-    mock_validate_gce_job.side_effect = MashException('Broken')
+    mock_get_account.side_effect = MashException('Broken')
 
     response = test_client.post(
         '/jobs/gce/',

--- a/test/unit/services/api/utils/jobs/gce_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/gce_job_utils_test.py
@@ -32,12 +32,13 @@ from werkzeug.local import LocalProxy
 def test_update_gce_job_accounts(
     mock_get_gce_account, mock_get_services, mock_get_current_obj
 ):
-    account = Mock()
-    account.name = 'acnt1'
-    account.region = 'us-east1'
-    account.bucket = 'images'
-    account.testing_account = 'acnt2'
-    account.is_publishing_account = True
+    account = {
+        'name': 'acnt1',
+        'region': 'us-east1',
+        'bucket': 'images',
+        'testing_account': 'acnt2',
+        'is_publishing_account': True
+    }
     mock_get_gce_account.return_value = account
 
     app = Mock()
@@ -88,7 +89,7 @@ def test_update_gce_job_accounts(
     # Publishing account has no test account
     del job_doc['testing_account']
     job_doc['family'] = 'sles'
-    account.testing_account = None
+    account['testing_account'] = None
 
     with raises(MashJobException):
         validate_gce_job(job_doc)


### PR DESCRIPTION
Jobs are dicts instead of class objects in API service.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
