### PR TITLE
Don't try to remove job from scheduler.

### DIFF
--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -23,7 +23,7 @@ import signal
 from amqpstorm import AMQPError
 
 from apscheduler import events
-from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
+from apscheduler.jobstores.base import ConflictingIdError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
 
@@ -167,13 +167,6 @@ class ListenerService(MashService):
 
         Also attempt to remove any running instances of the job.
         """
-        try:
-            # Remove job from scheduler if it has
-            # not started executing yet.
-            self.scheduler.remove_job(job_id)
-        except JobLookupError:
-            pass
-
         if job_id in self.jobs:
             job = self.jobs[job_id]
             self.log.info(

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -4,7 +4,7 @@ from unittest.mock import call, MagicMock, Mock, patch
 
 from amqpstorm import AMQPError
 
-from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
+from apscheduler.jobstores.base import ConflictingIdError
 
 from mash.services.base_defaults import Defaults
 from mash.services.mash_service import MashService
@@ -238,7 +238,6 @@ class TestListenerService(object):
         job.get_job_id.return_value = {'job_id': '1'}
 
         self.service.jobs['1'] = job
-        self.service.scheduler.remove_job.side_effect = JobLookupError('1')
         self.service._delete_job('1')
 
         self.service.log.info.assert_called_once_with(


### PR DESCRIPTION
This code path cannot be hit successfully. If a job gets scheduled
it will run before this code is hit which causes it to be removed
by scheduler. If the job fails upstream it never gets scheduled.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
