### PR TITLE
Handle error when getting classic sa keys.

### DIFF
--- a/mash/utils/azure.py
+++ b/mash/utils/azure.py
@@ -257,6 +257,14 @@ def get_classic_blob_service(
         storage_account
     )
 
+    if 'error' in keys:
+        try:
+            error = keys['error']['message']
+        except KeyError:
+            error = 'Unable to retrieve storage account keys.'
+
+        raise MashAzureUtilsException(error)
+
     return blob_service_type(
         account_name=storage_account,
         account_key=keys['primaryKey']

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -182,6 +182,15 @@ def test_get_classic_blob_service(
 
     assert service == blob_service
 
+    # Error
+    keys = {'error': {'some': 'data'}}
+    mock_get_classic_storage_account_keys.return_value = keys
+
+    with raises(MashAzureUtilsException):
+        get_classic_blob_service(
+            'test/data/azure_creds.json', 'rg1', 'sa1'
+        )
+
 
 @patch('mash.utils.azure.get_blob_url')
 @patch('mash.utils.azure.get_blob_service_with_account_keys')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If the storage account isn't found an error will be returned instead of the keys dictionary.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
