### PR TITLE
Move notification email to job creator.

### DIFF
--- a/examples/messages/azure_job.json
+++ b/examples/messages/azure_job.json
@@ -31,7 +31,7 @@
   "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
-  "notification_type": "single",
+  "notify": true,
   "publish_offer": true,
   "cleanup_images": true,
   "additional_uploads": ["sha256"]

--- a/examples/messages/credentials_job.json
+++ b/examples/messages/credentials_job.json
@@ -7,6 +7,6 @@
         "last_service": "deprecation",
         "utctime": "now",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/deprecation_job.json
+++ b/examples/messages/deprecation_job.json
@@ -16,6 +16,6 @@
             }
         ],
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/gce_job.json
+++ b/examples/messages/gce_job.json
@@ -21,7 +21,7 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_type": "single",
+  "notify": true,
   "guest_os_features": ["UEFI_COMPATIBLE"],
   "image_project": "test"
 }

--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -22,7 +22,7 @@
   "distro": "sles",
   "instance_type": "t2.micro",
   "tests": ["test_stuff"],
-  "notification_type": "single",
+  "notify": true,
   "conditions_wait_time": 500,
   "disallow_licenses": ["MIT"],
   "disallow_packages": ["*-mini"]

--- a/examples/messages/obs_job.json
+++ b/examples/messages/obs_job.json
@@ -16,6 +16,6 @@
         ],
         "cloud_architecture": "x86_64",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/obs_now_job.json
+++ b/examples/messages/obs_now_job.json
@@ -6,6 +6,6 @@
         "last_service": "testing",
         "utctime": "now",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/publisher_job.json
+++ b/examples/messages/publisher_job.json
@@ -19,6 +19,6 @@
             }
         ],
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/replication_job.json
+++ b/examples/messages/replication_job.json
@@ -16,6 +16,6 @@
             }
         },
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/testing_job.json
+++ b/examples/messages/testing_job.json
@@ -12,6 +12,6 @@
             "cn-north-1": "test-aws-cn"
         },
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/examples/messages/upload_job.json
+++ b/examples/messages/upload_job.json
@@ -17,6 +17,6 @@
             }
         },
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -181,14 +181,10 @@ base_job_message = {
                            'default architecture is x86_64.'
         },
         'notification_email': email,
-        'notification_type': {
-            'type': 'string',
-            'enum': ['periodic', 'single'],
-            'example': 'single',
-            'description': 'The single notification option sends an email '
-                           'with job status when the job finishes or fails. '
-                           'The periodic option will send an email after the '
-                           'job finishes each service with the job status.'
+        'notify': {
+            'type': 'boolean',
+            'example': True,
+            'description': 'If True Send email notification when job finishes.'
         },
         'profile': string_with_example('Proxy'),
         'conditions_wait_time': {

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -109,7 +109,7 @@ def validate_job(data):
     if 'deprecate' in services_run:
         validate_deprecate_args(data)
 
-    if 'notification_type' in data and not data.get('notification_email'):
+    if data.get('notify') and not data.get('notification_email'):
         user_id = data['requesting_user']
         user = get_user_by_id(user_id)
         data['notification_email'] = user['email']

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -53,8 +53,8 @@ class BaseJob(object):
         self.cleanup_images = kwargs.get('cleanup_images')
         self.cloud_architecture = kwargs.get('cloud_architecture', 'x86_64')
         self.conditions_wait_time = kwargs.get('conditions_wait_time')
+        self.notify = kwargs.get('notify')
         self.notification_email = kwargs.get('notification_email')
-        self.notification_type = kwargs.get('notification_type', 'single')
         self.profile = kwargs.get('profile')
         self.raw_image_upload_type = kwargs.get('raw_image_upload_type')
         self.raw_image_upload_location = kwargs.get('raw_image_upload_location')
@@ -78,9 +78,8 @@ class BaseJob(object):
             'requesting_user': self.requesting_user
         }
 
-        if self.notification_email:
+        if self.notify:
             self.base_message['notification_email'] = self.notification_email
-            self.base_message['notification_type'] = self.notification_type
 
         self.post_init()
 

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -135,6 +135,8 @@ class JobCreatorService(MashService):
         """
         job_doc['current_service'] = self._get_next_service(service)
         job_doc['prev_service'] = service
+        last_service = job_doc.pop('last_service')
+        notification_email = job_doc.pop('notification_email')
 
         try:
             handle_request(
@@ -146,10 +148,10 @@ class JobCreatorService(MashService):
         except Exception as error:
             self.log.error('Job status update failed: {}'.format(error))
 
-        if job_doc.get('notification_email') and (job_doc['last_service'] == service):
+        if notification_email and (last_service == service):
             self.send_notification(
                 job_doc['id'],
-                job_doc['notification_email'],
+                notification_email,
                 job_doc['status'],
                 job_doc.get('cloud_image_name'),
                 job_doc['errors']

--- a/mash/services/listener_service.py
+++ b/mash/services/listener_service.py
@@ -290,17 +290,6 @@ class ListenerService(MashService):
 
         message = self._get_status_message(job)
         self._publish_message(message, job.id)
-
-        self.send_notification(
-            job.id,
-            job.notification_email,
-            job.notification_type,
-            job.status,
-            job.last_service,
-            job.cloud_image_name,
-            event.exception
-        )
-
         job.listener_msg.ack()
 
     def _process_job_missed(self, event):

--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -52,9 +52,6 @@ class MashJob(object):
                 )
             )
 
-        self.notification_email = job_config.get('notification_email')
-        self.notification_type = job_config.get('notification_type', 'single')
-
         self.post_init()
 
     def get_job_id(self):

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -22,10 +22,8 @@ from amqpstorm import Connection
 
 # project
 from mash.log.filter import BaseServiceFilter
-from mash.services.status_levels import SUCCESS
 from mash.mash_exceptions import MashRabbitConnectionException
 from mash.utils.mash_utils import setup_rabbitmq_log_handler
-from mash.utils.email_notification import EmailNotification
 
 
 class MashService(object):
@@ -69,16 +67,6 @@ class MashService(object):
         )
         self.log.addHandler(rabbit_handler)
         self.log.addFilter(BaseServiceFilter())
-
-        # notification settings
-        self.notification_class = EmailNotification(
-            self.config.get_smtp_host(),
-            self.config.get_smtp_port(),
-            self.config.get_smtp_user(),
-            self.config.get_smtp_pass(),
-            self.config.get_smtp_ssl(),
-            log_callback=self.log
-        )
 
         self.post_init()
 
@@ -196,89 +184,3 @@ class MashService(object):
         self.channel.queue.unbind(
             queue=queue, exchange=exchange, routing_key=routing_key
         )
-
-    def _should_notify(
-        self,
-        notification_email,
-        notification_type,
-        status,
-        last_service
-    ):
-        """
-        Return True if a notification should be sent based on job info.
-        """
-        if not notification_email:
-            return False
-        elif status != SUCCESS:
-            return True
-        elif notification_type == 'periodic':
-            return True
-        elif last_service == self.service_exchange:
-            return True
-
-        return False
-
-    def _create_notification_content(
-        self, job_id, status, last_service, image_name,
-        error=None
-    ):
-        """
-        Build content string for job notification message.
-        """
-        msg = [
-            'Job: {job_id}\n'
-            'Image Name: {image_name}\n'
-            'Service: {service}\n'
-            'Log: {job_log}\n\n'
-        ]
-
-        if status == SUCCESS:
-            if self.service_exchange == last_service:
-                msg.append('Job finished successfully.')
-            else:
-                msg.append(
-                    'Job finished through the {service} service.'
-                )
-        else:
-            msg.append('Job failed.')
-
-            if error:
-                msg.append(' The following error was logged: \n\n{error}')
-
-        msg = ''.join(msg)
-
-        return msg.format(
-            job_id=job_id,
-            service=self.service_exchange,
-            job_log=self.config.get_job_log_file(job_id),
-            image_name=image_name,
-            error=error
-        )
-
-    def send_notification(
-        self, job_id, notification_email, notification_type, status,
-        last_service, image_name, error=None
-    ):
-        """
-        Send job notification based on result of _should_notify.
-        """
-        notify = self._should_notify(
-            notification_email,
-            notification_type,
-            status,
-            last_service
-        )
-
-        if notify:
-            content = self._create_notification_content(
-                job_id,
-                status,
-                last_service,
-                image_name,
-                error
-            )
-            self.notification_class.send_notification(
-                content,
-                self.config.get_notification_subject(),
-                notification_email
-            )

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -77,9 +77,6 @@ class OBSImageBuildResult(object):
     * :attr:`notification_email`
       Email to send job notifications.
 
-    * :attr:`notification_type`
-      The frequency of notification emails.
-
     * :attr:`profile`
       The multibuild profile name for the image.
 
@@ -96,7 +93,7 @@ class OBSImageBuildResult(object):
         self, job_id, job_file, download_url, image_name, last_service,
         log_callback, conditions=None, arch='x86_64',
         download_directory=Defaults.get_download_dir(),
-        notification_email=None, notification_type='single',
+        notification_email=None,
         profile=None, conditions_wait_time=900, disallow_licenses=None,
         disallow_packages=None
     ):
@@ -115,7 +112,6 @@ class OBSImageBuildResult(object):
         self.log_callback = None
         self.result_callback = None
         self.notification_email = notification_email
-        self.notification_type = notification_type
         self.profile = profile
         self.job_status = 'prepared'
         self.progress_log = {}
@@ -212,7 +208,6 @@ class OBSImageBuildResult(object):
                         'status': self.job_status,
                         'errors': self.errors,
                         'notification_email': self.notification_email,
-                        'notification_type': self.notification_type,
                         'last_service': self.last_service
                     }
                 }

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -29,7 +29,6 @@ from obs_img_utils.api import OBSImageUtil
 
 # project
 from mash.services.obs.defaults import Defaults
-from mash.services.status_levels import FAILED, SUCCESS
 
 
 class OBSImageBuildResult(object):
@@ -115,7 +114,6 @@ class OBSImageBuildResult(object):
         self.job_deleted = False
         self.log_callback = None
         self.result_callback = None
-        self.notification_callback = None
         self.notification_email = notification_email
         self.notification_type = notification_type
         self.profile = profile
@@ -200,9 +198,6 @@ class OBSImageBuildResult(object):
     def set_result_handler(self, function):
         self.result_callback = function
 
-    def set_notification_handler(self, function):
-        self.notification_callback = function
-
     def call_result_handler(self):
         self._result_callback()
 
@@ -215,23 +210,12 @@ class OBSImageBuildResult(object):
                         'image_file':
                             self.downloader.image_status['image_source'],
                         'status': self.job_status,
-                        'errors': self.errors
+                        'errors': self.errors,
+                        'notification_email': self.notification_email,
+                        'notification_type': self.notification_type,
+                        'last_service': self.last_service
                     }
                 }
-            )
-
-    def _notification_callback(
-        self, status, error=None
-    ):
-        if self.notification_callback:
-            self.notification_callback(
-                self.job_id,
-                self.notification_email,
-                self.notification_type,
-                status,
-                self.last_service,
-                self.image_name,
-                error
             )
 
     def _job_submit_event(self, event):
@@ -268,7 +252,6 @@ class OBSImageBuildResult(object):
                 'Job status: {0}'.format(self.job_status)
             )
             self._result_callback()
-            self._notification_callback(SUCCESS)
             self.log_callback.info('Job done')
         except Exception as issue:
             msg = '{0}: {1}'.format(type(issue).__name__, issue)
@@ -276,7 +259,6 @@ class OBSImageBuildResult(object):
             self.job_status = 'failed'
             self.errors.append(msg)
             self.log_callback.error(msg)
-            self._notification_callback(FAILED, msg)
             self._result_callback()
 
     def progress_callback(self, block_num, read_size, total_size, done=False):

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -248,7 +248,6 @@ class OBSImageBuildResultService(MashService):
 
         job_worker = OBSImageBuildResult(**kwargs)
         job_worker.set_result_handler(self._send_job_result_for_upload)
-        job_worker.set_notification_handler(self.send_notification)
         job_worker.start_watchdog(isotime=time)
         self.jobs[job_id] = job_worker
         return {

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -154,7 +154,7 @@ class OBSImageBuildResultService(MashService):
                   {"version": "8.13.21"}
               ],
               "notification_email": "test@fake.com",
-              "notification_type": "single",
+              "notify": True,
               "conditions_wait_time": 900
           }
         }
@@ -235,7 +235,6 @@ class OBSImageBuildResultService(MashService):
 
         if 'notification_email' in job:
             kwargs['notification_email'] = job['notification_email']
-            kwargs['notification_type'] = job['notification_type']
 
         if 'conditions_wait_time' in job:
             kwargs['conditions_wait_time'] = job['conditions_wait_time']

--- a/test/data/azure_job.json
+++ b/test/data/azure_job.json
@@ -31,7 +31,7 @@
   "generation_id": "image-gen2",
   "cloud_image_name_generation_suffix": "gen2",
   "vm_images_key": "key123",
-  "notification_type": "single",
+  "notify": true,
   "publish_offer": true,
   "cleanup_images": true,
   "raw_image_upload_type": "s3bucket",

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -21,7 +21,7 @@
   "instance_type": "n1-standard-1",
   "family": "sles-15",
   "tests": ["test_stuff"],
-  "notification_type": "single",
+  "notify": true,
   "guest_os_features": ["UEFI_COMPATIBLE"],
   "raw_image_upload_type": "s3bucket",
   "raw_image_upload_account": "account",

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -24,7 +24,7 @@
   "tests": ["test_stuff"],
   "cleanup_images": true,
   "cloud_architecture": "aarch64",
-  "notification_type": "single",
+  "notify": true,
   "profile": "Proxy",
   "conditions_wait_time": 500,
   "raw_image_upload_type": "s3bucket",

--- a/test/data/job1.json
+++ b/test/data/job1.json
@@ -9,6 +9,6 @@
       {"version": "8.13.21"}
     ],
     "notification_email": "test@fake.com",
-    "notification_type": "single"
+    "notify": true
   }
 }

--- a/test/data/job2.json
+++ b/test/data/job2.json
@@ -5,6 +5,6 @@
     "image": "test-image-oem",
     "utctime": "always",
     "notification_email": "test@fake.com",
-    "notification_type": "single"
+    "notify": true
   }
 }

--- a/test/data/job3.json
+++ b/test/data/job3.json
@@ -5,6 +5,6 @@
     "image": "test-image-oem",
     "utctime": "Wed Oct 11 17:50:26 UTC 2017",
     "notification_email": "test@fake.com",
-    "notification_type": "single"
+    "notify": true
   }
 }

--- a/test/data/upload_job1.json
+++ b/test/data/upload_job1.json
@@ -9,6 +9,6 @@
         "id": "123",
         "utctime": "now",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/test/data/upload_job2.json
+++ b/test/data/upload_job2.json
@@ -6,6 +6,6 @@
         "id": "123",
         "utctime": "now",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/test/data/upload_job3.json
+++ b/test/data/upload_job3.json
@@ -6,6 +6,6 @@
         "id": "123",
         "utctime": "Wed Oct 11 17:50:26 UTC 2017",
         "notification_email": "test@fake.com",
-        "notification_type": "single"
+        "notify": true
     }
 }

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -335,12 +335,11 @@ class TestListenerService(object):
         )
 
     @patch.object(ListenerService, '_get_status_message')
-    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_service_process_job_result(
         self, mock_publish_message, mock_delete_job,
-        mock_send_email_notification, mock_get_status_msg
+        mock_get_status_msg
     ):
         event = Mock()
         event.job_id = '1'
@@ -372,12 +371,11 @@ class TestListenerService(object):
         msg.ack.assert_called_once_with()
 
     @patch.object(ListenerService, '_get_status_message')
-    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_service_process_job_result_exception(
         self, mock_publish_message, mock_delete_job,
-        mock_send_email_notification, mock_get_status_msg
+        mock_get_status_msg
     ):
         event = Mock()
         event.job_id = '1'
@@ -405,12 +403,10 @@ class TestListenerService(object):
             '1'
         )
 
-    @patch.object(ListenerService, 'send_notification')
     @patch.object(ListenerService, '_delete_job')
     @patch.object(ListenerService, '_publish_message')
     def test_publishing_process_job_result_fail(
-        self, mock_publish_message, mock_delete_job,
-        mock_send_email_notification
+        self, mock_publish_message, mock_delete_job
     ):
         event = Mock()
         event.job_id = '1'

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -34,11 +34,6 @@ class TestOBSImageBuildResult(object):
         self.obs_result.set_result_handler(function)
         assert self.obs_result.result_callback == function
 
-    def test_set_notification_handler(self):
-        function = Mock()
-        self.obs_result.set_notification_handler(function)
-        assert self.obs_result.notification_callback == function
-
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_call_result_handler(self, mock_result_callback):
         self.obs_result.call_result_handler()
@@ -55,19 +50,12 @@ class TestOBSImageBuildResult(object):
                     'id': '815',
                     'image_file': 'image',
                     'status': 'success',
-                    'errors': []
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'notification_type': 'single',
+                    'last_service': 'publish'
                 }
             }
-        )
-
-    def test_notification_callback(self):
-        self.obs_result.notification_callback = Mock()
-        self.obs_result._notification_callback(
-            'success', 'error!'
-        )
-        self.obs_result.notification_callback.assert_called_once_with(
-            '815', 'test@fake.com', 'single', 'success',
-            'publish', 'obs_package', 'error!'
         )
 
     @patch('mash.services.obs.build_result.BackgroundScheduler')
@@ -126,22 +114,18 @@ class TestOBSImageBuildResult(object):
         osc_result_thread.join.assert_called_once_with()
         mock_image_status.assert_called_once_with()
 
-    @patch.object(OBSImageBuildResult, '_notification_callback')
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_update_image_status(
         self,
-        mock_result_callback,
-        mock_notification_callback
+        mock_result_callback
     ):
         self.downloader.get_image.return_value = 'new-image.xz'
         self.obs_result._update_image_status()
         mock_result_callback.assert_called_once_with()
-        mock_notification_callback.assert_called_once_with('success')
 
-    @patch.object(OBSImageBuildResult, '_notification_callback')
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_update_image_status_raises(
-        self, mock_result_callback, mock_notification_callback
+        self, mock_result_callback
     ):
         self.downloader.get_image.side_effect = Exception(
             'request error'

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -24,7 +24,7 @@ class TestOBSImageBuildResult(object):
         self.obs_result = OBSImageBuildResult(
             '815', 'job_file', 'obs_project', 'obs_package', 'publish',
             self.logger,
-            notification_email='test@fake.com', notification_type='single',
+            notification_email='test@fake.com',
             profile='Proxy', disallow_licenses=["MIT"],
             disallow_packages=["fake"]
         )
@@ -52,7 +52,6 @@ class TestOBSImageBuildResult(object):
                     'status': 'success',
                     'errors': [],
                     'notification_email': 'test@fake.com',
-                    'notification_type': 'single',
                     'last_service': 'publish'
                 }
             }

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -242,7 +242,7 @@ class TestOBSImageBuildResultService(object):
             ],
             "cloud_architecture": "aarch64",
             "notification_email": "test@fake.com",
-            "notification_type": "single",
+            "notify": True,
             "profile": "Proxy",
             "conditions_wait_time": 500,
             "disallow_licenses": ["MIT"],


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The job creator is handling the job status and is the best spot to handle email notifs.

- Remove periodic email notification. This is not needed with status API. Only send an email when job finishes. No need to have the option of sending an email after each service finishes.
- Pop extra data from status message. Pop notification email and last service from status message before saving to DB. This is not helpful in the data section of job.

### How will these changes be tested?

Unit and integration tests.

### How will this change be deployed? Any special considerations?


### Additional Information
