### PR TITLE
Add use_build_time job flag.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -29,7 +29,7 @@ img-proof>=6.2.0
 lxml
 requests
 urllib3
-obs-img-utils<0.3.0,>=0.2.0
+obs-img-utils>=0.3.0
 oci
 werkzeug<1.0.0
 google-auth

--- a/mash/services/api/schema/jobs/__init__.py
+++ b/mash/services/api/schema/jobs/__init__.py
@@ -266,6 +266,16 @@ base_job_message = {
             'example': True,
             'description': 'Only validate the job document and return. '
                            'Do not create the job.'
+        },
+        'use_build_time': {
+            'type': 'boolean',
+            'example': True,
+            'description': 'If True and the image build time is available '
+                           'it will be used when formatting the cloud image '
+                           'name. A {date} format is required in the cloud '
+                           'image name for the timestamp to be used. If True '
+                           'and build time is not available the job will '
+                           'fail.'
         }
     },
     'additionalProperties': False,

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -100,6 +100,14 @@ def validate_job(data):
     Validate job doc.
     """
     data = normalize_dictionary(data)
+
+    if data.get('use_build_time') and \
+            '{date}' not in data['cloud_image_name']:
+        raise MashJobException(
+            'When use_build_time flag is True the {date} '
+            'format string is required in cloud_image_name.'
+        )
+
     validate_last_service(data)
     services_run = get_services_by_last_service(data['last_service'])
 

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -186,7 +186,8 @@ class AzureJob(BaseJob):
                 'storage_account': self.source_storage_account,
                 'raw_image_upload_type': self.raw_image_upload_type,
                 'raw_image_upload_account': self.raw_image_upload_account,
-                'raw_image_upload_location': self.raw_image_upload_location
+                'raw_image_upload_location': self.raw_image_upload_location,
+                'use_build_time': self.use_build_time
             }
         }
 

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -66,6 +66,7 @@ class BaseJob(object):
         self.additional_uploads = kwargs.get('additional_uploads')
         self.cloud_image_name = kwargs.get('cloud_image_name')
         self.image_description = kwargs.get('image_description')
+        self.use_build_time = kwargs.get('use_build_time')
         self.kwargs = kwargs
 
         if self.raw_image_upload_type and self.last_service == 'upload':

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -186,6 +186,7 @@ class EC2Job(BaseJob):
                 'cloud_image_name': self.cloud_image_name,
                 'cloud': self.cloud,
                 'image_description': self.image_description,
+                'use_build_time': self.use_build_time,
                 'target_regions': self.get_create_regions()
             }
         }

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -145,7 +145,8 @@ class GCEJob(BaseJob):
                 'region': self.region,
                 'raw_image_upload_type': self.raw_image_upload_type,
                 'raw_image_upload_account': self.raw_image_upload_account,
-                'raw_image_upload_location': self.raw_image_upload_location
+                'raw_image_upload_location': self.raw_image_upload_location,
+                'use_build_time': self.use_build_time
             }
         }
         upload_message['upload_job'].update(self.base_message)

--- a/mash/services/jobcreator/oci_job.py
+++ b/mash/services/jobcreator/oci_job.py
@@ -144,7 +144,8 @@ class OCIJob(BaseJob):
                 'tenancy': self.tenancy,
                 'raw_image_upload_type': self.raw_image_upload_type,
                 'raw_image_upload_account': self.raw_image_upload_account,
-                'raw_image_upload_location': self.raw_image_upload_location
+                'raw_image_upload_location': self.raw_image_upload_location,
+                'use_build_time': self.use_build_time
             }
         }
         upload_message['upload_job'].update(self.base_message)

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -208,7 +208,9 @@ class OBSImageBuildResult(object):
                         'status': self.job_status,
                         'errors': self.errors,
                         'notification_email': self.notification_email,
-                        'last_service': self.last_service
+                        'last_service': self.last_service,
+                        'build_time':
+                            self.downloader.image_status['buildtime'],
                     }
                 }
             )

--- a/mash/services/upload/azure_job.py
+++ b/mash/services/upload/azure_job.py
@@ -19,7 +19,10 @@
 # project
 from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
-from mash.utils.mash_utils import format_string_with_date
+from mash.utils.mash_utils import (
+    format_string_with_date,
+    timestamp_from_epoch
+)
 from mash.services.status_levels import SUCCESS
 from mash.utils.azure import upload_azure_file
 
@@ -33,9 +36,6 @@ class AzureUploadJob(MashJob):
             self.container = self.job_config['container']
             self.storage_account = self.job_config['storage_account']
             self.base_cloud_image_name = self.job_config['cloud_image_name']
-            self.account = self.job_config.get('account')
-            self.region = self.job_config.get('region')
-            self.resource_group = self.job_config.get('resource_group')
         except KeyError as error:
             raise MashUploadException(
                 'Azure upload jobs require a(n) {0} '
@@ -44,12 +44,28 @@ class AzureUploadJob(MashJob):
                 )
             )
 
+        self.account = self.job_config.get('account')
+        self.region = self.job_config.get('region')
+        self.resource_group = self.job_config.get('resource_group')
+        self.use_build_time = self.job_config.get('use_build_time')
+
     def run_job(self):
         self.status = SUCCESS
         self.log_callback.info('Uploading image.')
 
+        timestamp = None
+        build_time = self.status_msg.get('build_time', 'unknown')
+
+        if self.use_build_time and (build_time != 'unknown'):
+            timestamp = timestamp_from_epoch(build_time)
+        elif self.use_build_time and (build_time == 'unknown'):
+            raise MashUploadException(
+                'use_build_time set for job but build time is unknown.'
+            )
+
         self.cloud_image_name = format_string_with_date(
-            self.base_cloud_image_name
+            self.base_cloud_image_name,
+            timestamp=timestamp
         )
         blob_name = ''.join([self.cloud_image_name, '.vhd'])
 

--- a/mash/utils/mash_utils.py
+++ b/mash/utils/mash_utils.py
@@ -122,6 +122,14 @@ def format_string_with_date(value, timestamp=None, date_format='%Y%m%d'):
     return value
 
 
+def timestamp_from_epoch(epoch, date_format='%Y%m%d'):
+    timestamp = datetime.datetime.fromtimestamp(
+        int(epoch),
+        datetime.timezone.utc
+    )
+    return timestamp.strftime(date_format)
+
+
 def remove_file(file_path):
     """
     Remove file from disk if it exists.

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -50,8 +50,7 @@ BuildRequires:  python3-Flask-SQLAlchemy
 BuildRequires:  python3-Flask-Migrate
 BuildRequires:  python3-flask-jwt-extended
 BuildRequires:  python3-requests
-BuildRequires:  python3-obs-img-utils >= 0.2.0
-BuildRequires:  python3-obs-img-utils < 0.3.0
+BuildRequires:  python3-obs-img-utils >= 0.3.0
 BuildRequires:  python3-oci-sdk
 BuildRequires:  python3-google-auth
 BuildRequires:  python3-google-cloud-storage
@@ -80,8 +79,7 @@ Requires:       python3-Flask-SQLAlchemy
 Requires:       python3-Flask-Migrate
 Requires:       python3-flask-jwt-extended
 Requires:       python3-requests
-Requires:       python3-obs-img-utils >= 0.2.0
-Requires:       python3-obs-img-utils < 0.3.0
+Requires:       python3-obs-img-utils >= 0.3.0
 Requires:       python3-oci-sdk
 Requires:       python3-google-auth
 Requires:       python3-google-cloud-storage

--- a/test/unit/services/api/utils/jobs/base_job_utils_test.py
+++ b/test/unit/services/api/utils/jobs/base_job_utils_test.py
@@ -8,7 +8,8 @@ from mash.services.api.utils.jobs import (
     delete_job,
     validate_last_service,
     validate_create_args,
-    validate_deprecate_args
+    validate_deprecate_args,
+    validate_job
 )
 from mash.mash_exceptions import MashJobException
 
@@ -162,3 +163,15 @@ def test_validate_create_args():
 def test_validate_deprecate_args():
     with raises(MashJobException):
         validate_deprecate_args({})
+
+
+def test_validate_job():
+    # use_build_time missing {date}
+    job = {
+        'last_service': 'test',
+        'use_build_time': True,
+        'cloud_image_name': 'Fake image'
+    }
+
+    with raises(Exception):
+        validate_job(job)

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -38,12 +38,14 @@ class TestAmazonCreateJob(object):
                     'subnet': 'subnet-123456789'
                 }
             },
-            'cloud_image_name': 'name',
-            'image_description': 'description'
+            'cloud_image_name': 'name v{date}',
+            'image_description': 'description',
+            'use_build_time': True
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
         self.job.status_msg['image_file'] = 'file'
+        self.job.status_msg['build_time'] = '1601061355'
         self.job.status_msg['source_regions'] = {'us-east-1': 'ami_id'}
         self.job.credentials = self.credentials
 
@@ -66,6 +68,12 @@ class TestAmazonCreateJob(object):
         job_doc['cloud_image_name'] = 'name'
         with raises(MashUploadException):
             EC2CreateJob(job_doc, self.config)
+
+    def test_missing_date_format_exception(self):
+        self.job.status_msg['build_time'] = 'unknown'
+
+        with raises(MashUploadException):
+            self.job.run_job()
 
     @patch('mash.services.create.ec2_job.cleanup_ec2_image')
     @patch('mash.services.create.ec2_job.get_vpc_id_from_subnet')
@@ -121,7 +129,7 @@ class TestAmazonCreateJob(object):
             ena_support=True,
             image_arch='arm64',
             image_description='description',
-            image_name='name',
+            image_name='name v20200925',
             image_virt_type='hvm',
             inst_user_name='ec2-user',
             launch_ami='ami-bc5b48d0',

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -42,7 +42,10 @@ class TestOBSImageBuildResult(object):
     def test_result_callback(self):
         self.obs_result.result_callback = Mock()
         self.obs_result.job_status = 'success'
-        self.downloader.image_status = {'image_source': 'image'}
+        self.downloader.image_status = {
+            'image_source': 'image',
+            'buildtime': '1601061355'
+        }
         self.obs_result._result_callback()
         self.obs_result.result_callback.assert_called_once_with(
             '815', {
@@ -52,7 +55,8 @@ class TestOBSImageBuildResult(object):
                     'status': 'success',
                     'errors': [],
                     'notification_email': 'test@fake.com',
-                    'last_service': 'publish'
+                    'last_service': 'publish',
+                    'build_time': '1601061355'
                 }
             }
         )

--- a/test/unit/services/upload/azure_job_test.py
+++ b/test/unit/services/upload/azure_job_test.py
@@ -42,7 +42,8 @@ class TestAzureUploadJob(object):
             'container': 'container',
             'storage_account': 'storage',
             'region': 'region',
-            'cloud_image_name': 'name'
+            'cloud_image_name': 'name v{date}',
+            'use_build_time': True
         }
 
         self.config = UploadConfig(
@@ -51,6 +52,7 @@ class TestAzureUploadJob(object):
 
         self.job = AzureUploadJob(job_doc, self.config)
         self.job.status_msg['image_file'] = 'file.vhdfixed.xz'
+        self.job.status_msg['build_time'] = '1601061355'
         self.job.credentials = self.credentials
         self.job._log_callback = MagicMock()
 
@@ -67,6 +69,12 @@ class TestAzureUploadJob(object):
         with raises(MashUploadException):
             AzureUploadJob(job_doc, self.config)
 
+    def test_missing_date_format_exception(self):
+        self.job.status_msg['build_time'] = 'unknown'
+
+        with raises(MashUploadException):
+            self.job.run_job()
+
     @patch('mash.services.upload.azure_job.upload_azure_file')
     @patch('builtins.open')
     def test_upload(
@@ -79,7 +87,7 @@ class TestAzureUploadJob(object):
         self.job.run_job()
 
         mock_upload_azure_file.assert_called_once_with(
-            'name.vhd',
+            'name v20200925.vhd',
             'container',
             'file.vhdfixed.xz',
             5,

--- a/test/unit/services/upload/gce_job_test.py
+++ b/test/unit/services/upload/gce_job_test.py
@@ -43,12 +43,14 @@ class TestGCEUploadJob(object):
             'region': 'us-west1-a',
             'account': 'test',
             'bucket': 'images',
-            'cloud_image_name': 'sles-12-sp4-v20180909',
-            'image_description': 'description 20180909'
+            'cloud_image_name': 'sles-12-sp4-v{date}',
+            'image_description': 'description 20180909',
+            'use_build_time': True
         }
 
         self.job = GCEUploadJob(job_doc, self.config)
         self.job.status_msg['image_file'] = 'sles-12-sp4-v20180909.tar.gz'
+        self.job.status_msg['build_time'] = '1601061355'
         self.job.credentials = self.credentials
         self.job._log_callback = Mock()
 
@@ -63,6 +65,12 @@ class TestGCEUploadJob(object):
 
         with raises(MashUploadException):
             GCEUploadJob(job_doc, self.config)
+
+    def test_missing_date_format_exception(self):
+        self.job.status_msg['build_time'] = 'unknown'
+
+        with raises(MashUploadException):
+            self.job.run_job()
 
     def test_post_init_sles_11(self):
         job_doc = {


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If set the image build time will be used to format the cloud_image_name. If set and the build time is not available or the cloud_image_name does not have {date} format string an exception is raised.

### How will these changes be tested?

Unit + E2E

### How will this change be deployed? Any special considerations?

Carefully

### Additional Information
