### PR TITLE
- Switch the default root volume for EC2 images from gp2

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -24,7 +24,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0,<2.8.1
 amqpstorm
-ec2imgutils>=8.1.2
+ec2imgutils>=9.0.1
 img-proof>=6.2.0
 lxml
 requests

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -113,7 +113,7 @@ class EC2CreateJob(MashJob):
             'sriov_type': 'simple',
             'access_key': None,
             'ena_support': True,
-            'backing_store': 'ssd',
+            'backing_store': 'gp3',
             'running_id': None,
             'secret_key': None,
             'billing_codes': None,

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -40,7 +40,7 @@ BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
 BuildRequires:  python3-python-dateutil < 2.8.1
-BuildRequires:  python3-ec2imgutils >= 8.1.2
+BuildRequires:  python3-ec2imgutils >= 9.0.1
 BuildRequires:  python3-img-proof >= 6.2.0
 BuildRequires:  python3-img-proof-tests >= 6.2.0
 BuildRequires:  python3-lxml
@@ -69,7 +69,7 @@ Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 2.8.1
-Requires:       python3-ec2imgutils >= 8.1.2
+Requires:       python3-ec2imgutils >= 9.0.1
 Requires:       python3-img-proof >= 6.2.0
 Requires:       python3-img-proof-tests >= 6.2.0
 Requires:       python3-lxml

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -129,7 +129,7 @@ class TestAmazonCreateJob(object):
         )
         mock_EC2ImageUploader.assert_called_once_with(
             access_key='access-key',
-            backing_store='ssd',
+            backing_store='gp3',
             billing_codes=None,
             bootkernel=None,
             ena_support=True,


### PR DESCRIPTION
  (ssd) to   the new gp3 volume type. This affords users a 20% cost saving
  with no penalties. Requires ec2imgutils 9.0.1 or greater.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
