### PR TITLE
Raise exception if offer doc not updated.

### DIFF
--- a/mash/utils/azure.py
+++ b/mash/utils/azure.py
@@ -520,8 +520,22 @@ def update_cloud_partner_offer_doc(
 
                         plan[vm_images_key][release] = generation_version
                         break
+                else:
+                    raise MashAzureUtilsException(
+                        'No Match found for Generation ID: {gen}. '
+                        'Offer doc not updated properly.'.format(
+                            gen=generation_id
+                        )
+                    )
 
             break
+    else:
+        raise MashAzureUtilsException(
+            'No Match found for SKU: {sku}. '
+            'Offer doc not updated properly.'.format(
+                sku=sku
+            )
+        )
 
     return doc
 

--- a/test/unit/services/base/azure_utils_test.py
+++ b/test/unit/services/base/azure_utils_test.py
@@ -341,6 +341,30 @@ def test_update_cloud_partner_offer_doc():
     assert plan['diskGenerations'][0][vm_images_key][release]['mediaName'] == \
         'new-image-gen2'
 
+    with raises(MashAzureUtilsException):
+        update_cloud_partner_offer_doc(
+            doc,
+            'blob/url/.vhd',
+            'New image for v123',
+            'new-image',
+            'New Image 123',
+            'gen2',
+            generation_id='image-gen2',
+            cloud_image_name_generation_suffix='gen2'
+        )
+
+    with raises(MashAzureUtilsException):
+        update_cloud_partner_offer_doc(
+            doc,
+            'blob/url/.vhd',
+            'New image for v123',
+            'new-image',
+            'New Image 123',
+            'gen1',
+            generation_id='image-gen3',
+            cloud_image_name_generation_suffix='gen2'
+        )
+
 
 def test_update_cloud_partner_offer_doc_existing_date():
     vm_images_key = 'microsoft-azure-corevm.vmImagesPublicAzure'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

If there's a typo in generation id or sku the offer doc won't be updated so raise exception instead of letting job pass.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information

Closes #734 