### PR TITLE
Add paging for list job route.

### DIFF
--- a/mash/services/api/routes/jobs/__init__.py
+++ b/mash/services/api/routes/jobs/__init__.py
@@ -16,13 +16,16 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from flask import jsonify, make_response, current_app
+import json
+
+from flask import request, jsonify, make_response, current_app
 from flask_restplus import Namespace, Resource
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from mash.services.api.schema import (
     default_response,
-    validation_error
+    validation_error,
+    job_list
 )
 from mash.services.api.utils.jobs import delete_job, get_job, get_jobs
 from mash.services.database.routes.jobs import job_response, job_data
@@ -35,6 +38,10 @@ api = Namespace(
 
 api.models['job_data'] = job_data
 api.models['job_response'] = job_response
+
+job_list_request = api.schema_model(
+    'job_list_request', job_list
+)
 
 validation_error_response = api.schema_model(
     'validation_error', validation_error
@@ -52,12 +59,28 @@ class JobList(Resource):
 
     @api.doc('get_jobs')
     @jwt_required
+    @api.expect(job_list_request)
     @api.response(200, 'Success', job_response)
     def get(self):
         """
-        Get all jobs.
+        Get paginated jobs.
         """
-        jobs = get_jobs(get_jwt_identity())
+        try:
+            data = json.loads(request.data.decode())
+        except json.decoder.JSONDecodeError:  # pragma: no cover
+            data = {}  # pragma: no cover
+
+        page = data.get('page')
+        per_page = data.get('per_page')
+
+        kwargs = {}
+        if page:
+            kwargs['page'] = page
+
+        if per_page:
+            kwargs['per_page'] = per_page
+
+        jobs = get_jobs(get_jwt_identity(), **kwargs)
         return make_response(jsonify(jobs), 200)
 
 

--- a/mash/services/api/schema/__init__.py
+++ b/mash/services/api/schema/__init__.py
@@ -139,3 +139,12 @@ oauth2_login_model = {
         'redirect_port'
     ]
 }
+
+job_list = {
+    'type': 'object',
+    'properties': {
+        'page': integer_with_example(1),
+        'per_page': integer_with_example(10)
+    },
+    'additionalProperties': False
+}

--- a/mash/services/api/utils/jobs/__init__.py
+++ b/mash/services/api/utils/jobs/__init__.py
@@ -188,14 +188,15 @@ def get_job(job_id, user_id):
     return response.json()
 
 
-def get_jobs(user_id):
+def get_jobs(user_id, page=None, per_page=None):
     """
     Retrieve all jobs for user.
     """
     response = handle_request(
         current_app.config['DATABASE_API_URL'],
         'jobs/list/{user}'.format(user=user_id),
-        'get'
+        'get',
+        job_data={'page': page, 'per_page': per_page}
     )
 
     return response.json()

--- a/mash/services/database/routes/jobs.py
+++ b/mash/services/database/routes/jobs.py
@@ -118,7 +118,18 @@ def get_job():
 
 @blueprint.route('/list/<string:user>', methods=['GET'])
 def get_job_list(user):
-    jobs = get_jobs(user)
+    data = json.loads(request.data.decode())
+    page = data.get('page')
+    per_page = data.get('per_page')
+
+    kwargs = {}
+    if page:
+        kwargs['page'] = page
+
+    if per_page:
+        kwargs['per_page'] = per_page
+
+    jobs = get_jobs(user, **kwargs)
     jobs = [marshal(job, job_response, skip_none=True) for job in jobs]
     return make_response(jsonify(jobs), 200)
 

--- a/mash/services/database/utils/jobs.py
+++ b/mash/services/database/utils/jobs.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from mash.services.database.extensions import db
 from mash.services.database.models import Job
 from mash.services.status_levels import FAILED, EXCEPTION, RUNNING, FINISHED
-from mash.services.database.utils.users import get_user_by_id
 
 
 def create_new_job(data):
@@ -59,12 +58,17 @@ def get_job_by_user(job_id, user_id):
     return job
 
 
-def get_jobs(user_id):
+def get_jobs(user_id, page=1, per_page=10):
     """
     Retrieve all jobs for user.
     """
-    user = get_user_by_id(user_id)
-    return user.jobs
+    job_query = Job.query.filter_by(user_id=user_id).paginate(
+        page,
+        per_page,
+        error_out=False,  # Return empty set if no results
+        max_per_page=20
+    )
+    return job_query.items
 
 
 def delete_job_for_user(job_id, user_id):

--- a/test/unit/services/api/routes/jobs/base_job_routes_test.py
+++ b/test/unit/services/api/routes/jobs/base_job_routes_test.py
@@ -1,3 +1,5 @@
+import json
+
 from datetime import datetime
 from unittest.mock import patch, Mock
 
@@ -119,7 +121,11 @@ def test_api_get_job_list(
 
     mock_jwt_identity.return_value = 'user1'
 
-    result = test_client.get('/jobs/')
+    result = test_client.get(
+        '/jobs/',
+        content_type='application/json',
+        data=json.dumps({'page': 1, 'per_page': 10})
+    )
 
     assert result.status_code == 200
     assert result.json[0]['job_id'] == '12345678-1234-1234-1234-123456789012'

--- a/test/unit/services/database/routes/db_job_routes_test.py
+++ b/test/unit/services/database/routes/db_job_routes_test.py
@@ -164,8 +164,8 @@ def test_get_job(mock_job, test_client):
     assert response.json['msg'] == msg
 
 
-@patch('mash.services.database.utils.jobs.get_user_by_id')
-def test_get_job_list(mock_get_user, test_client):
+@patch('mash.services.database.utils.jobs.Job')
+def test_get_job_list(mock_job, test_client):
     job = Mock()
     job.job_id = '12345678-1234-1234-1234-123456789012'
     job.last_service = 'test'
@@ -178,11 +178,17 @@ def test_get_job_list(mock_get_user, test_client):
     job.finish_time = datetime.now()
     job.errors = []
 
-    user = Mock
-    user.jobs = [job]
-    mock_get_user.return_value = user
+    queryset1 = Mock()
+    queryset2 = Mock()
+    queryset2.items = [job]
+    queryset1.paginate.return_value = queryset2
+    mock_job.query.filter_by.return_value = queryset1
 
-    response = test_client.get('/jobs/list/user1')
+    response = test_client.get(
+        '/jobs/list/user1',
+        content_type='application/json',
+        data=json.dumps({'page': 1, 'per_page': 10})
+    )
 
     assert response.status_code == 200
     assert response.json[0]['job_id'] == '12345678-1234-1234-1234-123456789012'


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

By default display first page and 10 jobs per page.

### How will these changes be tested?

Unit and integration.

### How will this change be deployed? Any special considerations?

Mash client can be updated independently as the changes handle client call with and without paging data.

### Additional Information

Fixes #742