### PR TITLE
Fix vswitch_id arg name in img-proof helper

### DIFF
--- a/mash/services/test/img_proof_helper.py
+++ b/mash/services/test/img_proof_helper.py
@@ -70,7 +70,7 @@ def img_proof_test(
         sev_capable=sev_capable,
         access_key=access_key,
         access_secret=access_secret,
-        vswitch_id=vswitch_id
+        v_switch_id=vswitch_id
     )
 
     status = SUCCESS if status == 0 else FAILED

--- a/test/unit/services/test/aliyun_job_test.py
+++ b/test/unit/services/test/aliyun_job_test.py
@@ -113,7 +113,7 @@ class TestAliyunTestJob(object):
             sev_capable=None,
             access_key='123456789',
             access_secret='987654321',
-            vswitch_id='vs1'
+            v_switch_id='vs1'
         )
         job._log_callback.info.reset_mock()
 

--- a/test/unit/services/test/azure_job_test.py
+++ b/test/unit/services/test/azure_job_test.py
@@ -118,7 +118,7 @@ class TestAzureTestJob(object):
             sev_capable=None,
             access_key=None,
             access_secret=None,
-            vswitch_id=None
+            v_switch_id=None
         )
         job._log_callback.info.reset_mock()
 

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -131,7 +131,7 @@ class TestEC2TestJob(object):
             sev_capable=None,
             access_key=None,
             access_secret=None,
-            vswitch_id=None
+            v_switch_id=None
         )
         client.delete_key_pair.assert_called_once_with(KeyName='random_name')
         mock_cleanup_image.assert_called_once_with(

--- a/test/unit/services/test/gce_job_test.py
+++ b/test/unit/services/test/gce_job_test.py
@@ -135,7 +135,7 @@ class TestGCETestJob(object):
                 sev_capable=False,
                 access_key=None,
                 access_secret=None,
-                vswitch_id=None
+                v_switch_id=None
             )
         ])
         job._log_callback.warning.reset_mock()
@@ -225,7 +225,7 @@ class TestGCETestJob(object):
                 sev_capable=False,
                 access_key=None,
                 access_secret=None,
-                vswitch_id=None
+                v_switch_id=None
             ),
             call(
                 'gce',
@@ -259,7 +259,7 @@ class TestGCETestJob(object):
                 sev_capable=False,
                 access_key=None,
                 access_secret=None,
-                vswitch_id=None
+                v_switch_id=None
             )
         ])
 

--- a/test/unit/services/test/oci_job_test.py
+++ b/test/unit/services/test/oci_job_test.py
@@ -117,7 +117,7 @@ class TestOCITestJob(object):
             sev_capable=None,
             access_key=None,
             access_secret=None,
-            vswitch_id=None
+            v_switch_id=None
         )
         job._log_callback.info.reset_mock()
 


### PR DESCRIPTION
img-proof arg is v_switch_id.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
