### PR TITLE
Fixed spec file requirement

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -23,7 +23,7 @@ cryptography
 PyYAML
 PyJWT
 APScheduler
-python-dateutil>=2.6.0,<2.8.1
+python-dateutil>=2.6.0
 amqpstorm
 ec2imgutils>=9.0.1
 img-proof>=7.0.0

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -40,7 +40,6 @@ BuildRequires:  python3-PyJWT
 BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
-BuildRequires:  python3-python-dateutil < 2.8.1
 BuildRequires:  python3-ec2imgutils >= 9.0.1
 BuildRequires:  python3-img-proof >= 7.0.0
 BuildRequires:  python3-img-proof-tests >= 7.0.0
@@ -71,7 +70,6 @@ Requires:       python3-PyJWT
 Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
-Requires:       python3-python-dateutil < 2.8.1
 Requires:       python3-ec2imgutils >= 9.0.1
 Requires:       python3-img-proof >= 7.0.0
 Requires:       python3-img-proof-tests >= 7.0.0


### PR DESCRIPTION
Mash sets a max version in the spec file for the dateutil
module. However, the implementation doesn't require this
constraint as it works with any modern version of dateutil.
In an effort to make mash being able to build and work in
a variety of linux versions such max version constraints
will be roadblocks in moving forward and should be deleted
if possible.

