### PR TITLE
Always pass in jwt algorithms for decoding

### DIFF
--- a/mash/services/api/v1/utils/jwt.py
+++ b/mash/services/api/v1/utils/jwt.py
@@ -44,7 +44,9 @@ def decode_token(provider_url, token, audience):
             format=serialization.PublicFormat.SubjectPublicKeyInfo
         )
         try:
-            token_json = jwt.decode(token, pem, audience=audience)
+            token_json = jwt.decode(
+                token, pem, audience=audience, algorithms=['HS256']
+            )
             return token_json
         except Exception as e:
             last_exception = e


### PR DESCRIPTION
Starting with versions >= 2.0.0 of pyjwt the setting of the
decoding algorithms became mandatory.


