### PR TITLE
Drop jwt error routing workaround.

### DIFF
--- a/mash/services/api/app.py
+++ b/mash/services/api/app.py
@@ -129,6 +129,3 @@ def register_extensions(app):
     """Register Flask extensions."""
     jwt.init_app(app)
     api.init_app(app)
-
-    # Required for flask-restplus to play nicely with flask-jwt-extended
-    jwt._set_error_handler_callbacks(api)

--- a/mash/services/api/extensions.py
+++ b/mash/services/api/extensions.py
@@ -16,6 +16,8 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from jwt.exceptions import PyJWTError
+
 from flask_restx import Api
 from flask_jwt_extended import JWTManager
 
@@ -38,4 +40,15 @@ api = Api(
     doc=False,
     authorizations=authorizations
 )
+
+
+@api.errorhandler(PyJWTError)
+def handle_jwt_exception(error):
+    err = '. '.join([
+        str(error),
+        'Log in again with "mash auth login" or "mash auth oidc".'
+    ])
+    return {"msg": err}, 401
+
+
 jwt = JWTManager()

--- a/test/unit/services/api/api_error_handling_test.py
+++ b/test/unit/services/api/api_error_handling_test.py
@@ -1,0 +1,15 @@
+from jwt.exceptions import ExpiredSignatureError
+
+from mash.services.api.extensions import handle_jwt_exception
+
+
+def test_jwt_exception_handling():
+    msg = (
+        'Signature has expired. Log in again with "mash auth login" '
+        'or "mash auth oidc".'
+    )
+    err = ExpiredSignatureError('Signature has expired')
+    resp, code = handle_jwt_exception(err)
+
+    assert code == 401
+    assert resp['msg'] == msg


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Restx no longer eats the unhandled exceptions. Instead provide
a handler to process JWT exceptions and return a useful message
with 401 status code.

### How will these changes be tested?

E2E

### How will this change be deployed? Any special considerations?


### Additional Information

Fixes #775 Resolves #772