### PR TITLE
Add a slow rollout policy to new GCE images.

### DIFF
--- a/mash/services/create/gce_job.py
+++ b/mash/services/create/gce_job.py
@@ -26,6 +26,7 @@ from mash.services.status_levels import SUCCESS
 from mash.utils.gce import (
     get_gce_image,
     create_gce_image,
+    create_gce_rollout,
     delete_gce_image,
     get_gce_compute_driver
 )

--- a/mash/services/create/gce_job.py
+++ b/mash/services/create/gce_job.py
@@ -72,7 +72,7 @@ class GCECreateJob(MashJob):
         credentials = self.credentials[self.account]
 
         project = credentials.get('project_id')
-        compute_driver = get_gce_compute_driver(credentials)
+        compute_driver = get_gce_compute_driver(credentials, version='alpha')
 
         uri = ''.join([
             'https://www.googleapis.com/storage/v1/b/',
@@ -91,6 +91,8 @@ class GCECreateJob(MashJob):
                 self.cloud_image_name
             )
 
+        rollout = create_gce_rollout(compute_driver, project)
+
         create_gce_image(
             compute_driver,
             project,
@@ -98,7 +100,8 @@ class GCECreateJob(MashJob):
             self.cloud_image_description,
             uri,
             family=self.family,
-            guest_os_features=self.guest_os_features
+            guest_os_features=self.guest_os_features,
+            rollout=rollout
         )
 
         self.log_callback.info(

--- a/mash/services/deprecate/gce_job.py
+++ b/mash/services/deprecate/gce_job.py
@@ -63,7 +63,7 @@ class GCEDeprecateJob(MashJob):
 
         try:
             project = credential.get('project_id')
-            compute_driver = get_gce_compute_driver(credential)
+            compute_driver = get_gce_compute_driver(credential, version='alpha')
 
             deprecate_gce_image(
                 compute_driver,

--- a/mash/utils/gce.py
+++ b/mash/utils/gce.py
@@ -87,8 +87,13 @@ def get_zones(compute_driver, project):
         region = zone.get('region')
         name = zone.get('name')
         zones_map.setdefault(region, []).append(name)
+    # Create a list of lists. Each sublist is the zone names in a different
+    # region.
     zones = list(zones_map.values())
+    # Permute the sublists so the region ordering is random, but the zone
+    # ordering is deterministic and sorted.
     random.shuffle(zones)
+    # Interleave varying sized lists of zones adding a 'zones/' prefix.
     return [
         'zones/%s' % zone for zone in itertools.chain(
             *itertools.zip_longest(*zones)) if zone is not None]
@@ -100,7 +105,7 @@ def create_gce_rollout(compute_driver, project):
     """
     format_str = '%Y-%m-%dT%H:%M:%SZ'
     now = datetime.datetime.now()
-    zones = zones = get_zones(compute_driver, project)
+    zones = get_zones(compute_driver, project)
     policies = {}
     for num, zone in enumerate(zones):
         rollout_time = now + datetime.timedelta(hours=num)

--- a/mash/utils/gce.py
+++ b/mash/utils/gce.py
@@ -78,24 +78,36 @@ def get_region_list(compute_driver, project):
 
 def get_zones(compute_driver, project):
     """
-    Returns a list of zones for a project.
+    Returns a list of zone names for a project.
     """
+    # The Compute API response is a dictionary containing the key 'items'.
     zones = compute_driver.zones().list(project=project).execute()
+    # The value of items is a list of dictionary objects, one per each zone.
+    # Each zone dictionary contains the key 'name' and 'region', representing
+    # the zone name and the region where the zone lives.
     zones = sorted(zones.get('items'), key=lambda zone: zone.get('name'))
+    # Create a dictionary mapping a region name to a sorted list of zone names.
+    # For example:
+    # {'r1': ['r1-a', 'r1-b', 'r1-c'], 'r2': ['r2-a'], 'r3': ['r3-a', 'r3-d']}
     zones_map = {}
     for zone in zones:
         region = zone.get('region')
         name = zone.get('name')
         zones_map.setdefault(region, []).append(name)
     # Create a list of lists. Each sublist is the zone names in a different
-    # region.
+    # region. For example:
+    # [['r1-a', 'r1-b', 'r1-c'], ['r2-a'], ['r3-a', 'r3-d']]
     zones = list(zones_map.values())
     # Permute the sublists so the region ordering is random, but the zone
-    # ordering is deterministic and sorted.
+    # ordering is deterministic and sorted. For example:
+    # [['r3-a', 'r3-d'], ['r2-a'], ['r1-a', 'r1-b', 'r1-c']]
     random.shuffle(zones)
     # Interleave varying sized lists of zones adding a 'zones/' prefix.
+    # The final result should look like the following:
+    # ['zones/r3-a', 'zones/r2-a', 'zones/r1-a', 'zones/r3-d', 'zones/r1-b',
+    # 'zones/r1-c']
     return [
-        'zones/%s' % zone for zone in itertools.chain(
+        'zones/{name}'.format(name=zone) for zone in itertools.chain(
             *itertools.zip_longest(*zones)) if zone is not None]
 
 

--- a/test/unit/services/create/gce_job_test.py
+++ b/test/unit/services/create/gce_job_test.py
@@ -65,6 +65,7 @@ class TestGCECreateJob(object):
 
     @patch('mash.services.create.gce_job.get_gce_image')
     @patch('mash.services.create.gce_job.create_gce_image')
+    @patch('mash.services.create.gce_job.create_gce_rollout')
     @patch('mash.services.create.gce_job.delete_gce_image')
     @patch('mash.services.create.gce_job.get_gce_compute_driver')
     @patch('builtins.open')
@@ -73,6 +74,7 @@ class TestGCECreateJob(object):
         mock_open,
         mock_get_driver,
         mock_delete_image,
+        mock_create_rollout,
         mock_create_image,
         mock_get_image
     ):
@@ -83,6 +85,9 @@ class TestGCECreateJob(object):
         compute_driver = Mock()
         mock_get_driver.return_value = compute_driver
 
+        rollout = {'defaultRolloutTime': '2021-01-01T00:00:00Z'}
+        mock_create_rollout.return_value = rollout
+
         self.job.status_msg['cloud_image_name'] = 'sles-12-sp4-v20180909'
         self.job.status_msg['object_name'] = 'sles-12-sp4-v20180909.tar.gz'
         self.job.run_job()
@@ -92,6 +97,10 @@ class TestGCECreateJob(object):
             'projectid',
             'sles-12-sp4-v20180909'
         )
+        mock_create_rollout.assert_called_once_with(
+            compute_driver,
+            'projectid'
+        )
         mock_create_image.assert_called_once_with(
             compute_driver,
             'projectid',
@@ -99,5 +108,6 @@ class TestGCECreateJob(object):
             'description 20180909',
             'https://www.googleapis.com/storage/v1/b/images/o/sles-12-sp4-v20180909.tar.gz',
             family='sles-12',
-            guest_os_features=['UEFI_COMPATIBLE']
+            guest_os_features=['UEFI_COMPATIBLE'],
+            rollout=rollout
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
Introduce slow rollout policy for new GCE image publication and deprecation.

### How will these changes be tested?
TBD (Please help me figure out how to test these changes work in your build environment).

### How will this change be deployed? Any special considerations?
These changes should be used whenever publishing new images in GCE. No action should be required to use these new changes.

### Additional Information
Existing usage of the API should behave as normal and without change.