### PR TITLE
Use temporary key pairs for aliyun testing

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -36,4 +36,4 @@ werkzeug<1.0.0
 google-auth
 google-cloud-storage
 google-api-python-client
-aliyun-img-utils
+aliyun-img-utils>=1.3.0

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ $ zypper in mash
 - google-auth
 - google-cloud-storage
 - google-api-python-client
+- aliyun-img-utils>=1.3.0
 
 ## Issues/Enhancements
 

--- a/mash/utils/aliyun.py
+++ b/mash/utils/aliyun.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2021 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from contextlib import contextmanager, suppress
+from aliyun_img_utils.aliyun_utils import (
+    get_compute_client,
+    import_key_pair,
+    delete_key_pair
+)
+from mash.utils.mash_utils import generate_name, get_key_from_file
+
+
+@contextmanager
+def setup_key_pair(
+    access_key,
+    region,
+    access_secret,
+    ssh_private_key_file
+):
+    """
+    Create a temporary key pair in Aliyun.
+    """
+    try:
+        key_name = generate_name()
+        ssh_public_key = get_key_from_file(ssh_private_key_file + '.pub')
+
+        client = get_compute_client(
+            access_key,
+            access_secret,
+            region
+        )
+        import_key_pair(
+            key_name,
+            ssh_public_key,
+            client
+        )
+
+        yield key_name
+    finally:
+        with suppress(Exception):
+            delete_key_pair(key_name, client)

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -55,7 +55,7 @@ BuildRequires:  python3-oci-sdk
 BuildRequires:  python3-google-auth
 BuildRequires:  python3-google-cloud-storage
 BuildRequires:  python3-google-api-python-client
-BuildRequires:  python3-aliyun-img-utils >= 1.0.0
+BuildRequires:  python3-aliyun-img-utils >= 1.3.0
 Requires:       rabbitmq-server
 Requires:       python3-adal
 Requires:       python3-azure-identity
@@ -85,7 +85,7 @@ Requires:       python3-oci-sdk
 Requires:       python3-google-auth
 Requires:       python3-google-cloud-storage
 Requires:       python3-google-api-python-client
-Requires:       python3-aliyun-img-utils >= 1.0.0
+Requires:       python3-aliyun-img-utils >= 1.3.0
 Requires:       apache2
 Requires:       apache2-mod_wsgi-python3
 Requires(pre):  pwdutils

--- a/test/unit/services/test/aliyun_job_test.py
+++ b/test/unit/services/test/aliyun_job_test.py
@@ -30,6 +30,11 @@ class TestAliyunTestJob(object):
         with pytest.raises(MashTestException):
             AliyunTestJob(self.job_config, self.config)
 
+    @patch('mash.utils.aliyun.import_key_pair')
+    @patch('mash.utils.aliyun.delete_key_pair')
+    @patch('mash.utils.aliyun.get_compute_client')
+    @patch('mash.utils.aliyun.get_key_from_file')
+    @patch('mash.utils.aliyun.generate_name')
     @patch.object(AliyunTestJob, 'cleanup_image')
     @patch('mash.services.test.aliyun_job.os')
     @patch('mash.services.test.aliyun_job.create_ssh_key_pair')
@@ -38,7 +43,9 @@ class TestAliyunTestJob(object):
     @patch('mash.services.test.img_proof_helper.test_image')
     def test_aliyun_image_proof(
         self, mock_test_image, mock_temp_file, mock_random,
-        mock_create_ssh_key_pair, mock_os, mock_cleanup_image
+        mock_create_ssh_key_pair, mock_os, mock_cleanup_image,
+        mock_generate_name, mock_get_key_from_file, mock_get_client,
+        mock_import_key_pair, mock_delete_key_pair
     ):
         tmp_file = Mock()
         tmp_file.name = '/tmp/acnt.file'
@@ -67,6 +74,10 @@ class TestAliyunTestJob(object):
         )
         mock_random.choice.return_value = 'ecs.t5-lc1m1.small'
         mock_os.path.exists.return_value = False
+        mock_generate_name.return_value = 'random_name'
+        mock_get_key_from_file.return_value = 'fakekey'
+        client = Mock()
+        mock_get_client.return_value = client
 
         job = AliyunTestJob(self.job_config, self.config)
         job._log_callback = Mock()
@@ -100,7 +111,7 @@ class TestAliyunTestJob(object):
             service_account_file=None,
             signing_key_file=None,
             signing_key_fingerprint=None,
-            ssh_key_name=None,
+            ssh_key_name='random_name',
             ssh_private_key_file='/var/lib/mash/ssh_key',
             ssh_user='ali-user',
             subnet_id=None,


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Using user data to set keys causes the framework to muck with root password.

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
