### PR TITLE
Add a 5 minute wait before checking on images

### DIFF
--- a/mash/services/replicate/aliyun_job.py
+++ b/mash/services/replicate/aliyun_job.py
@@ -16,6 +16,8 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import time
+
 from aliyun_img_utils.aliyun_image import AliyunImage
 
 from mash.mash_exceptions import MashReplicateException
@@ -67,6 +69,9 @@ class AliyunReplicateJob(MashJob):
         )
 
         images = aliyun_image.replicate_image(self.cloud_image_name)
+
+        # Replication can take time so give it 5 minutes before checking
+        time.sleep(300)
 
         for region, image_id in images.items():
             if image_id:

--- a/test/unit/services/replicate/aliyun_job_test.py
+++ b/test/unit/services/replicate/aliyun_job_test.py
@@ -39,8 +39,9 @@ class TestAliyunReplicateJob(object):
         with raises(MashReplicateException):
             AliyunReplicateJob(self.job_config, self.config)
 
+    @patch('mash.services.replicate.aliyun_job.time')
     @patch('mash.services.replicate.aliyun_job.AliyunImage')
-    def test_replicate(self, mock_aliyun_image):
+    def test_replicate(self, mock_aliyun_image, mock_time):
         aliyun_image = Mock()
         mock_aliyun_image.return_value = aliyun_image
         aliyun_image.replicate_image.return_value = {'cn-shanghai': None}
@@ -55,8 +56,9 @@ class TestAliyunReplicateJob(object):
         )
         assert self.job.status == FAILED
 
+    @patch('mash.services.replicate.aliyun_job.time')
     @patch('mash.services.replicate.aliyun_job.AliyunImage')
-    def test_replicate_fail(self, mock_aliyun_image):
+    def test_replicate_fail(self, mock_aliyun_image, mock_time):
         aliyun_image = Mock()
         mock_aliyun_image.return_value = aliyun_image
         aliyun_image.replicate_image.return_value = {'cn-shanghai': 'i-8765'}


### PR DESCRIPTION
Replication can take time to finish in all the regions. This
prevents unnecessary API calls while the images process.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
