### PR TITLE
Fix pytest 7 compatibility

### DIFF
--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -10,7 +10,7 @@ from mash.mash_exceptions import MashRabbitConnectionException
 class TestBaseService(object):
 
     @patch('mash.services.mash_service.Connection')
-    def setup(self, mock_connection):
+    def setup_method(self, method, mock_connection):
         self.connection = Mock()
         self.channel = Mock()
         self.msg_properties = {

--- a/test/unit/services/cleanup/service_test.py
+++ b/test/unit/services/cleanup/service_test.py
@@ -7,8 +7,8 @@ from mash.services.mash_service import MashService
 class TestCleanupService(object):
 
     @patch.object(MashService, '__init__')
-    def setup(
-        self, mock_base_init
+    def setup_method(
+        self, method, mock_base_init
     ):
         mock_base_init.return_value = None
 

--- a/test/unit/services/credentials/credentials_datastore_test.py
+++ b/test/unit/services/credentials/credentials_datastore_test.py
@@ -14,7 +14,7 @@ class TestCredentialsDatastore(object):
 
     @patch('mash.services.credentials.datastore.BackgroundScheduler')
     @patch('mash.services.credentials.datastore.os')
-    def setup(self, mock_os, mock_scheduler):
+    def setup_method(self, method, mock_os, mock_scheduler):
         self.log_callback = Mock()
         self.scheduler = MagicMock(BackgroundScheduler)
 

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -11,7 +11,7 @@ from mash.utils.json_format import JsonFormat
 class TestJobCreatorService(object):
 
     @patch.object(MashService, '__init__')
-    def setup(self, mock_base_init):
+    def setup_method(self, method, mock_base_init):
         services = [
             'obs', 'upload', 'create', 'test', 'raw_image_upload',
             'replicate', 'publish', 'deprecate'

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -15,8 +15,8 @@ from mash.utils.json_format import JsonFormat
 
 class TestListenerService(object):
     @patch.object(MashService, '__init__')
-    def setup(
-        self, mock_base_init
+    def setup_method(
+        self, method, mock_base_init
     ):
         mock_base_init.return_value = None
         self.config = Mock()

--- a/test/unit/services/logger/service_test.py
+++ b/test/unit/services/logger/service_test.py
@@ -16,8 +16,8 @@ open_name = "__builtin__.open" if sys.version_info.major < 3 \
 class TestLoggerService(object):
 
     @patch.object(MashService, '__init__')
-    def setup(
-        self, mock_base_init
+    def setup_method(
+        self, method, mock_base_init
     ):
         mock_base_init.return_value = None
 

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -13,7 +13,7 @@ from mash.services.obs.build_result import OBSImageBuildResult
 class TestOBSImageBuildResult(object):
     @patch('mash.services.obs.build_result.logging')
     @patch('mash.services.obs.build_result.OBSImageUtil')
-    def setup(self, mock_obs_img_util, mock_logging):
+    def setup_method(self, method, mock_obs_img_util, mock_logging):
         self.logger = MagicMock()
         self.downloader = MagicMock()
         mock_obs_img_util.return_value = self.downloader

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -22,8 +22,8 @@ class TestOBSImageBuildResultService(object):
     @patch('os.listdir')
     @patch('logging.getLogger')
     @patch('atexit.register')
-    def setup(
-        self, mock_register, mock_log, mock_listdir, mock_MashService,
+    def setup_method(
+        self, method, mock_register, mock_log, mock_listdir, mock_MashService,
         mock_restart_jobs, mock_send_job_result_for_upload,
         mock_process_message,
         mock_setup_logfile, mock_makedirs


### PR DESCRIPTION
Setup method is no longer called for every test. Use setup_method
instead.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
