### PR TITLE
The default key for token identity is now "sub"

### DIFF
--- a/mash/services/api/v1/utils/tokens.py
+++ b/mash/services/api/v1/utils/tokens.py
@@ -49,7 +49,7 @@ def is_token_revoked(decoded_token):
     Checks if the given token exists.
     """
     jti = decoded_token['jti']
-    user_id = decoded_token['identity']
+    user_id = decoded_token['sub']
     token = get_token_by_jti(jti, user_id)
 
     if token:

--- a/test/unit/services/api/v1/utils/token_utils_test.py
+++ b/test/unit/services/api/v1/utils/token_utils_test.py
@@ -4,7 +4,7 @@ from mash.services.api.app import check_if_token_revoked
 
 @patch('mash.services.api.v1.utils.tokens.get_token_by_jti')
 def test_check_if_token_in_blocklist(mock_get_token):
-    decoded_token = {'jti': '123', 'identity': 'user1'}
+    decoded_token = {'jti': '123', 'sub': 'user1'}
     mock_get_token.return_value = decoded_token
 
     result = check_if_token_revoked(None, decoded_token)


### PR DESCRIPTION
This change comes from flask-jwt-extended >= 4.0.0

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
