### PR TITLE
Add blob name to notification content

### DIFF
--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -154,6 +154,7 @@ class JobCreatorService(MashService):
                 notification_email,
                 job_doc['status'],
                 job_doc.get('cloud_image_name'),
+                job_doc.get('blob_name'),
                 job_doc['errors']
             )
 
@@ -216,16 +217,21 @@ class JobCreatorService(MashService):
         job_id,
         status,
         image_name,
+        blob_name,
         errors=None
     ):
         """
         Build content string for job notification message.
         """
         msg = [
-            'Job: {job_id}\n'
-            'Image Name: {image_name}\n'
+            f'Job: {job_id}\n'
         ]
         error_msg = ''
+
+        if image_name:
+            msg.append(f'Image Name: {image_name}\n')
+        elif blob_name:
+            msg.append(f'Blob Name: {blob_name}\n')
 
         if status == SUCCESS:
             msg.append('Job finished successfully.')
@@ -234,15 +240,11 @@ class JobCreatorService(MashService):
 
             if errors:
                 error_msg = '\n\n'.join(errors)
-                msg.append(' The following errors were logged: \n\n{error_msg}')
+                msg.append(f' The following errors were logged: \n\n{error_msg}')
 
         msg = ''.join(msg)
 
-        return msg.format(
-            job_id=job_id,
-            image_name=image_name,
-            error_msg=error_msg
-        )
+        return msg
 
     def send_notification(
         self,
@@ -250,6 +252,7 @@ class JobCreatorService(MashService):
         notification_email,
         status,
         image_name,
+        blob_name,
         errors=None
     ):
         """
@@ -259,6 +262,7 @@ class JobCreatorService(MashService):
             job_id,
             status,
             image_name,
+            blob_name,
             errors
         )
         self.notification_class.send_notification(

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -607,7 +607,10 @@ class TestJobCreatorService(object):
     def test_create_notification_content(self):
         # Failed message
         msg = self.jobcreator._create_notification_content(
-            '1', 'failed', 'test_image',
+            '1',
+            'failed',
+            'test_image',
+            'blob123',
             ['Invalid publish permissions!']
         )
 
@@ -615,14 +618,20 @@ class TestJobCreatorService(object):
 
         # Job finished with success
         msg = self.jobcreator._create_notification_content(
-            '1', 'success', 'test_image'
+            '1',
+            'success',
+            'test_image',
+            'blob123'
         )
 
         assert 'Job finished successfully' in msg
 
         # Service with success
         msg = self.jobcreator._create_notification_content(
-            '1', 'success', 'test_image'
+            '1',
+            'success',
+            None,
+            'blob123'
         )
 
     def test_send_email_notification(self):


### PR DESCRIPTION
If image name is provided it is used Else if blob name is provided it is
used. Otherwise neither are included in the content.

This provides useful info for raw upload jobs and prevents any Nonesy
values from being added to content.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
