### PR TITLE
Add option to set boot firmware mode in EC2

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,7 +18,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0
 amqpstorm
-ec2imgutils>=9.0.1
+ec2imgutils>=9.0.3
 img-proof>=7.0.0
 lxml
 requests

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -68,6 +68,14 @@ class EC2CreateJob(MashJob):
         self.use_build_time = self.job_config.get('use_build_time')
         self.force_replace_image = self.job_config.get('force_replace_image')
         self.tpm_support = self.job_config.get('tpm_support')
+        self.boot_firmware = self.job_config.get('boot_firmware', ['bios'])
+
+        # EC2 images only support one firmware
+        self.boot_firmware = self.boot_firmware[0]
+
+        if self.boot_firmware == 'bios':
+            # Translate to EC2 lingo
+            self.boot_firmware = 'legacy-bios'
 
         if self.arch == 'aarch64':
             self.arch = 'arm64'
@@ -118,7 +126,8 @@ class EC2CreateJob(MashJob):
             'running_id': None,
             'secret_key': None,
             'billing_codes': None,
-            'log_callback': self.log_callback
+            'log_callback': self.log_callback,
+            'boot_mode': self.boot_firmware
         }
 
         if self.tpm_support:

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -239,7 +239,8 @@ class EC2Job(BaseJob):
                 'use_build_time': self.use_build_time,
                 'target_regions': self.get_create_regions(),
                 'force_replace_image': self.force_replace_image,
-                'tpm_support': self.tpm_support
+                'tpm_support': self.tpm_support,
+                'boot_firmware': self.boot_firmware
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -35,7 +35,7 @@ BuildRequires:  python3-PyJWT
 BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
-BuildRequires:  python3-ec2imgutils >= 9.0.1
+BuildRequires:  python3-ec2imgutils >= 9.0.3
 BuildRequires:  python3-img-proof >= 7.0.0
 BuildRequires:  python3-img-proof-tests >= 7.0.0
 BuildRequires:  python3-lxml
@@ -61,7 +61,7 @@ Requires:       python3-PyJWT
 Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
-Requires:       python3-ec2imgutils >= 9.0.1
+Requires:       python3-ec2imgutils >= 9.0.3
 Requires:       python3-img-proof >= 7.0.0
 Requires:       python3-img-proof-tests >= 7.0.0
 Requires:       python3-lxml

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -154,7 +154,8 @@ class TestAmazonCreateJob(object):
             vpc_subnet_id='subnet-123456789',
             wait_count=3,
             log_callback=self.job._log_callback,
-            tpm_support='v2.0'
+            tpm_support='v2.0',
+            boot_mode='legacy-bios'
         )
         open_context.file_mock.write.assert_called_once_with('pkey')
         ec2_client.create_key_pair.assert_called_once_with(KeyName='mash-xxxx')


### PR DESCRIPTION
The image can only "support" one firmware.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
