### PR TITLE
Add tpm_support option for EC2 images

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -162,6 +162,10 @@ ec2_job_message['properties']['recommended_instance_type'] = string_with_example
     description='The instance type that is recommended to run the service '
                 'with the marketplace image.'
 )
+ec2_job_message['properties']['tpm_support'] = string_with_example(
+    'v2.0',
+    description='The NitroTPM version supported by the image.'
+)
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -150,6 +150,13 @@ def validate_ec2_job(job_doc):
         job_doc['skip_replication'] = True  # No replication for MP images
         validate_mp_fields(job_doc)
 
+    boot_firmware = job_doc.get('boot_firmware', [])
+    if job_doc.get('tpm_support') and 'uefi' not in boot_firmware:
+        raise MashJobException(
+            'NitroTPM support requires a UEFI compatible image. '
+            'Ensure "uefi" is included in "boot_firmware" list.'
+        )
+
     job_doc = validate_job(job_doc)
 
     user_id = job_doc['requesting_user']

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -67,6 +67,7 @@ class EC2CreateJob(MashJob):
         self.arch = self.job_config.get('cloud_architecture', 'x86_64')
         self.use_build_time = self.job_config.get('use_build_time')
         self.force_replace_image = self.job_config.get('force_replace_image')
+        self.tpm_support = self.job_config.get('tpm_support')
 
         if self.arch == 'aarch64':
             self.arch = 'arm64'
@@ -119,6 +120,9 @@ class EC2CreateJob(MashJob):
             'billing_codes': None,
             'log_callback': self.log_callback
         }
+
+        if self.tpm_support:
+            self.ec2_upload_parameters['tpm_support'] = self.tpm_support
 
         # Get all account credentials in one request
         accounts = []

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -35,6 +35,7 @@ class EC2Job(BaseJob):
         self.allow_copy = self.kwargs.get('allow_copy', 'none')
         self.billing_codes = self.kwargs.get('billing_codes')
         self.use_root_swap = self.kwargs.get('use_root_swap', False)
+        self.tpm_support = self.kwargs.get('tpm_support')
         self.entity_id = self.kwargs.get('entity_id')
         self.version_title = self.kwargs.get('version_title')
         self.release_notes = self.kwargs.get('release_notes')
@@ -237,7 +238,8 @@ class EC2Job(BaseJob):
                 'image_description': self.image_description,
                 'use_build_time': self.use_build_time,
                 'target_regions': self.get_create_regions(),
-                'force_replace_image': self.force_replace_image
+                'force_replace_image': self.force_replace_image,
+                'tpm_support': self.tpm_support
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -230,6 +230,18 @@ def test_validate_ec2_job(
 
     assert 'cloud_account' not in result
 
+    # Test doc with TPM and no uefi
+    job_doc = {
+        'last_service': 'testing',
+        'requesting_user': '1',
+        'cloud_groups': ['group1'],
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'tpm_support': 'v2.0'
+    }
+    with raises(MashJobException):
+        validate_ec2_job(job_doc)
+
 
 @patch.object(LocalProxy, '_get_current_object')
 def test_validate_mp_fields(mock_get_current_obj):

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -41,7 +41,8 @@ class TestAmazonCreateJob(object):
             },
             'cloud_image_name': 'name v{date}',
             'image_description': 'description',
-            'use_build_time': True
+            'use_build_time': True,
+            'tpm_support': 'v2.0'
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
@@ -152,7 +153,8 @@ class TestAmazonCreateJob(object):
             use_private_ip=False,
             vpc_subnet_id='subnet-123456789',
             wait_count=3,
-            log_callback=self.job._log_callback
+            log_callback=self.job._log_callback,
+            tpm_support='v2.0'
         )
         open_context.file_mock.write.assert_called_once_with('pkey')
         ec2_client.create_key_pair.assert_called_once_with(KeyName='mash-xxxx')


### PR DESCRIPTION
NitroTPM support requires a UEFI compatible image.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
