### PR TITLE
Override cloud name when retrieving credentials

### DIFF
--- a/mash/services/publish/ec2_mp_job.py
+++ b/mash/services/publish/ec2_mp_job.py
@@ -66,7 +66,7 @@ class EC2MPPublishJob(MashJob):
         self.status = SUCCESS
 
         # Get all account credentials in one request
-        self.request_credentials(list(self.publish_regions.keys()))
+        self.request_credentials(list(self.publish_regions.keys()), cloud='ec2')
         self.cloud_image_name = self.status_msg['cloud_image_name']
 
         timestamp = re.findall(r'\d{8}', self.cloud_image_name)[0]


### PR DESCRIPTION
Credentials for ec2 only exist in ec2 namespace not ec2_mp.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
