### PR TITLE
Add upgrade instructions to aws mp schema

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -157,6 +157,11 @@ ec2_job_message['properties']['usage_instructions'] = string_with_example(
     'Instructions on image usage...',
     description='Instructions for using the marketplace image.'
 )
+ec2_job_message['properties']['upgrade_instructions'] = string_with_example(
+    'Upgrade instructions for the image...',
+    description='Information on how a customer can upgrade from one version '
+                'of the product to another.'
+)
 ec2_job_message['properties']['recommended_instance_type'] = string_with_example(
     't3.medium',
     description='The instance type that is recommended to run the service '

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -119,6 +119,7 @@ def validate_mp_fields(job_doc):
         'os_name',
         'os_version',
         'usage_instructions',
+        'upgrade_instructions',
         'recommended_instance_type'
     ]
     missing_mp_fields = []

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -43,6 +43,7 @@ class EC2Job(BaseJob):
         self.os_name = self.kwargs.get('os_name')
         self.os_version = self.kwargs.get('os_version')
         self.usage_instructions = self.kwargs.get('usage_instructions')
+        self.upgrade_instructions = self.kwargs.get('upgrade_instructions')
         self.recommended_instance_type = self.kwargs.get(
             'recommended_instance_type'
         )
@@ -102,6 +103,7 @@ class EC2Job(BaseJob):
                     'os_name': self.os_name,
                     'os_version': self.os_version,
                     'usage_instructions': self.usage_instructions,
+                    'upgrade_instructions': self.upgrade_instructions,
                     'recommended_instance_type': self.recommended_instance_type,
                     'allow_copy': self.allow_copy,
                     'share_with': self.share_with,

--- a/mash/services/publish/ec2_mp_job.py
+++ b/mash/services/publish/ec2_mp_job.py
@@ -45,6 +45,7 @@ class EC2MPPublishJob(MashJob):
             self.os_name = self.job_config['os_name']
             self.os_version = self.job_config['os_version']
             self.usage_instructions = self.job_config['usage_instructions']
+            self.upgrade_instructions = self.job_config['upgrade_instructions']
             self.recommended_instance_type = \
                 self.job_config['recommended_instance_type']
         except KeyError as error:
@@ -102,6 +103,7 @@ class EC2MPPublishJob(MashJob):
                 self.os_name,
                 self.os_version,
                 self.usage_instructions,
+                self.upgrade_instructions,
                 self.recommended_instance_type,
                 self.ssh_user
             )

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -224,6 +224,7 @@ def start_mp_change_set(
     os_name,
     os_version,
     usage_instructions,
+    upgrade_instructions,
     recommended_instance_type,
     ssh_user
 ):
@@ -244,6 +245,7 @@ def start_mp_change_set(
             'Details': {
                 'AmiDeliveryOptionDetails': {
                     'UsageInstructions': usage_instructions,
+                    'UpgradeInstructions': upgrade_instructions,
                     'RecommendedInstanceType': recommended_instance_type,
                     'AmiSource': {
                         'AmiId': ami_id,

--- a/test/unit/services/publish/ec2_mp_job_test.py
+++ b/test/unit/services/publish/ec2_mp_job_test.py
@@ -19,6 +19,7 @@ class TestEC2MPPublishJob(object):
             'os_name': 'OTHERLINUX',
             'os_version': '15.3',
             'usage_instructions': 'Login using SSH...',
+            'upgrade_instructions': 'Upgrade using zypper...',
             'recommended_instance_type': 't3.medium',
             'publish_regions': {'test-aws': 'us-east-2'},
             'share_with': '123456789',

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -133,6 +133,7 @@ def test_start_mp_change_set():
         os_name='OTHERLINUX',
         os_version='15.3',
         usage_instructions='Login with SSH...',
+        upgrade_instructions='Upgrade with zypper...',
         recommended_instance_type='t3.medium',
         ssh_user='ec2-user'
     )


### PR DESCRIPTION
Upgrade instructions are required by the MP for every version.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information

WIP (do not merge): waiting for information from AWS MP team as upgrade instructions is required in dashboard but the argument is not in the change set documentation.
