### PR TITLE
Fixes issue with concurrent mp_changes in EC2 affecting same resource

### DIFF
--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -189,3 +189,9 @@ class MashGCEUtilsException(MashException):
     """
     Exception raised if an error occurs in GCE Utils.
     """
+
+
+class MashEc2UtilsException(MashException):
+    """
+    Exception raised if an error occurs in EC2 Utils.
+    """


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

When mash tries to create concurrently change_sets that affect the same resources, boto3 raises ResourceInUseException and we have to resubmit.

This change includes a waiter that allows the second change_set to wait for the first to be completed and tries to apply the change_set again. 

### How will these changes be tested?

Unit tests are included to provide 100% code coverage.
The new branch is only run in case ResourceInUseException is raised by boto3

### How will this change be deployed? Any special considerations?


### Additional Information

- Found out about `botocore.stub` to mock aws responses, I'll try to improve test coverage in some other repos...
- Number of reattempts and period default values might require tunning, as I wasn't sure about typical mp change_set completion times...
- Found out that utils/ec2.py was raising `MashGCEUtilsException`, will fix in another PR.
