### PR TITLE
Add no_expiry option to login

### DIFF
--- a/mash/services/api/v1/routes/auth.py
+++ b/mash/services/api/v1/routes/auth.py
@@ -109,7 +109,12 @@ class Login(Resource):
 
         if user:
             access_token = create_access_token(identity=user['id'])
-            refresh_token = create_refresh_token(identity=user['id'])
+
+            expires = data['no_expiry'] if data.get('no_expiry') else None
+            refresh_token = create_refresh_token(
+                identity=user['id'],
+                expires_delta=expires
+            )
 
             add_token_to_database(access_token, user['id'])
             add_token_to_database(refresh_token, user['id'])

--- a/mash/services/api/v1/schema/__init__.py
+++ b/mash/services/api/v1/schema/__init__.py
@@ -87,7 +87,15 @@ login_request_model = {
     'type': 'object',
     'properties': {
         'email': email,
-        'password': string_with_example('secretpassword123')
+        'password': string_with_example('secretpassword123'),
+        'no_expiry': {
+            'type': 'boolean',
+            'description': 'If True the refresh token will be created with '
+                           'no expiration date. To invalidate the token it '
+                           'requires manual deletion. The default expiry '
+                           'is 30 days.'
+        }
+
     },
     'additionalProperties': False,
     'required': [


### PR DESCRIPTION
This allows the creation of a refresh token with no expiration. By default the expiry delta is 30 days. The token with no expiration is removed by manual deletion.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
