### PR TITLE
Modifies s3bucket upload service to allow raw image upload to a S3 bucket

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy<=3.0.0
+flask-sqlalchemy<3.0.0
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -29,3 +29,4 @@ google-cloud-storage
 google-api-python-client
 aliyun-img-utils>=1.4.0
 azure-img-utils>=0.4.1
+Sqlalchemy<2.0.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy
+flask-sqlalchemy=2.4.4
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy<=2.4.4
+flask-sqlalchemy<=3.0.0
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy=2.4.4
+flask-sqlalchemy==2.4.4
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy==2.4.4
+flask-sqlalchemy<=2.4.4
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,7 +7,7 @@
 
 Flask
 flask-restx
-flask-sqlalchemy<3.0.0
+flask-sqlalchemy
 flask-migrate
 flask-jwt-extended>=4.0.0
 setuptools>=40.3.0

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -279,7 +279,8 @@ class EC2Job(BaseJob):
                 'cloud': self.cloud,
                 'raw_image_upload_type': self.raw_image_upload_type,
                 'raw_image_upload_account': self.raw_image_upload_account,
-                'raw_image_upload_location': self.raw_image_upload_location
+                'raw_image_upload_location': self.raw_image_upload_location,
+                'use_build_time': self.use_build_time
             }
         }
         upload_message['upload_job'].update(self.base_message)

--- a/mash/services/upload/s3bucket_job.py
+++ b/mash/services/upload/s3bucket_job.py
@@ -91,11 +91,7 @@ class S3BucketUploadJob(MashJob):
         except IndexError:
             bucket_path = ''
 
-        if (
-            'cloud_image_name' in self.status_msg and self.status_msg[
-                'cloud_image_name']
-        ):
-
+        if self.status_msg.get('cloud_image_name'):
             # take suffix from file name, should always consist of two parts
             suffix = '.'.join(
                 str.split(self.status_msg['image_file'], '.')[-2:]

--- a/mash/services/upload/s3bucket_job.py
+++ b/mash/services/upload/s3bucket_job.py
@@ -23,6 +23,10 @@ from mash.services.mash_job import MashJob
 from mash.mash_exceptions import MashUploadException
 from mash.utils.ec2 import get_client
 from mash.services.status_levels import SUCCESS
+from mash.utils.mash_utils import (
+    format_string_with_date,
+    timestamp_from_epoch
+)
 
 
 class S3BucketUploadJob(MashJob):
@@ -37,6 +41,8 @@ class S3BucketUploadJob(MashJob):
         self._last_percentage_logged = 0
         self._percentage_log_step = 20
 
+        self.use_build_time = self.job_config.get('use_build_time', False)
+
         try:
             self.account = self.job_config['raw_image_upload_account']
             self.location = self.job_config['raw_image_upload_location']
@@ -46,6 +52,12 @@ class S3BucketUploadJob(MashJob):
                 'key in the job doc.'.format(
                     error
                 )
+            )
+
+        if self.use_build_time and '{date}' not in self.location:
+            raise MashUploadException(
+                'When use_build_time flag is True the {date} '
+                'format string is required in raw_image_upload_location.'
             )
 
     def _log_progress(self, bytes_transferred):
@@ -79,9 +91,11 @@ class S3BucketUploadJob(MashJob):
         except IndexError:
             bucket_path = ''
 
-        if self.status_msg['cloud_image_name']:
+        if 'cloud_image_name' in self.status_msg:
             # take suffix from file name, should always consist of two parts
-            suffix = '.'.join(str.split(self.status_msg['image_file'], '.')[-2:])
+            suffix = '.'.join(
+                str.split(self.status_msg['image_file'], '.')[-2:]
+            )
             key_name = '.'.join([self.status_msg['cloud_image_name'], suffix])
         else:
             key_name = path.basename(self.status_msg['image_file'])
@@ -92,6 +106,21 @@ class S3BucketUploadJob(MashJob):
             key_name = ''.join([bucket_path, key_name])
         else:
             key_name = bucket_path
+
+        # replacing key_name {date}
+        build_time = self.status_msg.get('build_time', 'unknown')
+
+        if self.use_build_time and (build_time != 'unknown'):
+            timestamp = timestamp_from_epoch(build_time)
+        elif self.use_build_time and (build_time == 'unknown'):
+            raise MashUploadException(
+                'use_build_time set for job but build time is unknown.'
+            )
+
+        key_name = format_string_with_date(
+            key_name,
+            timestamp=timestamp
+        )
 
         try:
             statinfo = stat(self.status_msg['image_file'])
@@ -108,6 +137,9 @@ class S3BucketUploadJob(MashJob):
                 key_name,
                 Callback=self._log_progress
             )
+
+            self.status_msg['key_name'] = key_name
+            self.status_msg['bucket_name'] = bucket_name
 
         except Exception as e:
             raise MashUploadException(

--- a/mash/services/upload/s3bucket_job.py
+++ b/mash/services/upload/s3bucket_job.py
@@ -91,7 +91,10 @@ class S3BucketUploadJob(MashJob):
         except IndexError:
             bucket_path = ''
 
-        if 'cloud_image_name' in self.status_msg:
+        if (
+            'cloud_image_name' in self.status_msg and
+            self.status_msg['cloud_image_name']
+        ):
             # take suffix from file name, should always consist of two parts
             suffix = '.'.join(
                 str.split(self.status_msg['image_file'], '.')[-2:]
@@ -112,15 +115,14 @@ class S3BucketUploadJob(MashJob):
 
         if self.use_build_time and (build_time != 'unknown'):
             timestamp = timestamp_from_epoch(build_time)
+            key_name = format_string_with_date(
+                key_name,
+                timestamp=timestamp
+            )
         elif self.use_build_time and (build_time == 'unknown'):
             raise MashUploadException(
                 'use_build_time set for job but build time is unknown.'
             )
-
-        key_name = format_string_with_date(
-            key_name,
-            timestamp=timestamp
-        )
 
         try:
             statinfo = stat(self.status_msg['image_file'])

--- a/mash/services/upload/s3bucket_job.py
+++ b/mash/services/upload/s3bucket_job.py
@@ -92,9 +92,10 @@ class S3BucketUploadJob(MashJob):
             bucket_path = ''
 
         if (
-            'cloud_image_name' in self.status_msg and
-            self.status_msg['cloud_image_name']
+            'cloud_image_name' in self.status_msg and self.status_msg[
+                'cloud_image_name']
         ):
+
             # take suffix from file name, should always consist of two parts
             suffix = '.'.join(
                 str.split(self.status_msg['image_file'], '.')[-2:]

--- a/test/unit/services/upload/s3bucket_job_test.py
+++ b/test/unit/services/upload/s3bucket_job_test.py
@@ -164,4 +164,3 @@ class TestS3BucketUploadJob(object):
         self.job._log_callback.info.assert_called_once_with(
             'Raw image 100% uploaded.'
         )
-

--- a/test/unit/services/upload/s3bucket_job_test.py
+++ b/test/unit/services/upload/s3bucket_job_test.py
@@ -42,7 +42,10 @@ class TestS3BucketUploadJob(object):
             'image_description': 'description',
             'raw_image_upload_type': 's3bucket',
             'raw_image_upload_location': 'my-bucket/some-prefix/',
-            'raw_image_upload_account': 'test'
+            'raw_image_upload_account': 'test',
+            'status_msg': {
+                'build_time': '1677149451'
+            }
         }
         self.job = S3BucketUploadJob(job_doc, self.config)
         self.job.status_msg = {
@@ -58,15 +61,21 @@ class TestS3BucketUploadJob(object):
             'last_service': 'upload',
             'requesting_user': 'user1',
             'cloud': 'ec2',
-            'utctime': 'now'
+            'utctime': 'now',
+            'raw_image_upload_account': "account1",
         }
 
-        with raises(MashUploadException):
+        with raises(MashUploadException) as e:
             S3BucketUploadJob(job_doc, self.config)
+        assert "S3 bucket upload jobs require a(n)" in str(e)
+        assert "raw_image_upload_location" in str(e)
 
-        job_doc['cloud_image_name'] = 'name'
-        with raises(MashUploadException):
+        job_doc['use_build_time'] = True
+        job_doc['raw_image_upload_location'] = 'bucket1'
+
+        with raises(MashUploadException) as e:
             S3BucketUploadJob(job_doc, self.config)
+        assert "When use_build_time flag is True the {date}" in str(e)
 
     @patch('mash.services.upload.s3bucket_job.stat')
     @patch('mash.services.upload.s3bucket_job.get_client')
@@ -104,10 +113,35 @@ class TestS3BucketUploadJob(object):
             Callback=self.job._log_progress
         )
 
+        # test use_build_time in location
+        mock_client.upload_file.reset_mock()
+        self.job.location = 'my-bucket/filename_v{date}.tar.gz'
+        self.job.account = 'test'
+        self.job.use_build_time = True
+        self.job.status_msg['build_time'] = '1677149451'
+        self.job.status_msg['image_file'] = 'file.raw.gz'
+        self.job.run_job()
+        mock_client.upload_file.assert_called_once_with(
+            'file.raw.gz',
+            'my-bucket',
+            'filename_v20230223.tar.gz',
+            Callback=self.job._log_progress
+        )
+        assert self.job.status_msg['key_name'] == 'filename_v20230223.tar.gz'
+        assert self.job.status_msg['bucket_name'] == 'my-bucket'
+
+        # Test exception in use_build_time
+        mock_client.upload_file.reset_mock()
+        del self.job.status_msg['build_time']
+        with raises(MashUploadException) as e:
+            self.job.run_job()
+        assert "use_build_time set for job but build time is unknown" in str(e)
+
         # Test bucket and full name
         mock_client.upload_file.reset_mock()
         self.job.location = 'my-bucket/some-prefix/image.raw.gz'
         self.job.status_msg['cloud_image_name'] = None
+        self.job.use_build_time = False
         self.job.run_job()
 
         mock_client.upload_file.assert_called_once_with(
@@ -117,8 +151,10 @@ class TestS3BucketUploadJob(object):
             Callback=self.job._log_progress
         )
 
+        # Test upload exception
         mock_client.upload_file.side_effect = Exception
 
+        self.job.use_build_time = False
         with raises(MashUploadException):
             self.job.run_job()
 
@@ -128,3 +164,4 @@ class TestS3BucketUploadJob(object):
         self.job._log_callback.info.assert_called_once_with(
             'Raw image 100% uploaded.'
         )
+


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

We need to have to have the possibility of just uploading raw images to a s3 bucket (without image publication)

These changes:
- Allows to use the s3upload service without `cloud_image_name` parameter (and without image publication)
- Includes the option to `use_build_time` in the `raw_image_upload_location` parameter

### How will these changes be tested?

The changes have been tested.

### How will this change be deployed? Any special considerations?

Usual procedure without special considerations.

### Additional Information
 None