### PR TITLE
Includes the endpoint in the API for ec2_container mash job creation

### DIFF
--- a/mash/services/api/app.py
+++ b/mash/services/api/app.py
@@ -43,6 +43,7 @@ from mash.services.api.v1.routes.accounts.aliyun import api as v1_aliyun_account
 
 from mash.services.api.v1.routes.jobs import api as v1_jobs_api
 from mash.services.api.v1.routes.jobs.ec2 import api as v1_ec2_jobs_api
+from mash.services.api.v1.routes.jobs.ec2_container import api as v1_ec2_container_jobs_api
 from mash.services.api.v1.routes.jobs.gce import api as v1_gce_jobs_api
 from mash.services.api.v1.routes.jobs.azure import api as v1_azure_jobs_api
 from mash.services.api.v1.routes.jobs.oci import api as v1_oci_jobs_api
@@ -119,6 +120,7 @@ def register_namespaces():
 
     api.add_namespace(v1_jobs_api, path='/v1/jobs')
     api.add_namespace(v1_ec2_jobs_api, path='/v1/jobs/ec2')
+    api.add_namespace(v1_ec2_container_jobs_api, path='/v1/jobs/ec2_container')
     api.add_namespace(v1_gce_jobs_api, path='/v1/jobs/gce')
     api.add_namespace(v1_azure_jobs_api, path='/v1/jobs/azure')
     api.add_namespace(v1_oci_jobs_api, path='/v1/jobs/oci')

--- a/mash/services/api/v1/routes/jobs/ec2_container.py
+++ b/mash/services/api/v1/routes/jobs/ec2_container.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import json
+
+from flask import jsonify, request, make_response, current_app
+from flask_restx import Namespace, Resource
+from flask_jwt_extended import (
+    jwt_required,
+    get_jwt_identity
+)
+
+from mash.mash_exceptions import MashException
+from mash.services.api.v1.schema import (
+    default_response,
+    validation_error
+)
+from mash.services.api.v1.routes.jobs import job_response
+
+from mash.services.api.v1.schema.jobs.ec2_container import ec2_container_job_message
+from mash.services.api.v1.utils.jobs.ec2_container import validate_ec2_container_job
+from mash.services.api.v1.utils.jobs import create_container_job
+
+
+api = Namespace(
+    'EC2 Container Jobs',
+    description='EC2 Container Job operations'
+)
+ec2_container_job = api.schema_model(
+    'ec2_container_job',
+    ec2_container_job_message
+)
+validation_error_response = api.schema_model(
+    'validation_error', validation_error
+)
+
+
+@api.route('/')
+class EC2ContainerJobCreate(Resource):
+    @api.doc('add_ec2_container_job', security='apiKey')
+    @jwt_required()
+    @api.expect(ec2_container_job)
+    @api.response(201, 'Job added', job_response)
+    @api.response(400, 'Validation error', validation_error_response)
+    @api.response(401, 'Unauthorized', default_response)
+    @api.response(422, 'Not processable', default_response)
+    def post(self):
+        """
+        Add EC2 Container job.
+        """
+        data = json.loads(request.data.decode())
+        data['cloud'] = 'ec2_container'
+        data['requesting_user'] = get_jwt_identity()
+
+        try:
+            data = validate_ec2_container_job(data)
+            job = create_container_job(data)
+        except MashException as error:
+            return make_response(
+                jsonify({'msg': 'Job failed: {0}'.format(error)}),
+                400
+            )
+        except Exception as error:
+            current_app.logger.warning(error)
+            return make_response(
+                jsonify({'msg': 'Failed to start job'}),
+                400
+            )
+
+        if job:
+            return make_response(
+                jsonify(job),
+                201
+            )
+        else:
+            return make_response(
+                jsonify({'msg': 'Job doc is valid!'}),
+                200
+            )
+
+    @api.doc('get_ec2_container_job_doc_schema')
+    @api.response(200, 'Success', ec2_container_job)
+    def get(self):
+        """
+        Get ec2 container job doc schema.
+        """
+        return make_response(jsonify(ec2_container_job_message), 200)

--- a/mash/services/api/v1/schema/jobs/__init__.py
+++ b/mash/services/api/v1/schema/jobs/__init__.py
@@ -73,6 +73,7 @@ utctime = {
     'example': '2019-04-28T06:44:50.142Z',
     'examples': ['now', '2019-04-28T06:44:50.142Z']
 }
+
 base_job_message = {
     'type': 'object',
     'properties': {
@@ -297,5 +298,30 @@ base_job_message = {
         'utctime',
         'image',
         'download_url'
+    ]
+}
+
+base_container_job_message = {
+    'type': 'object',
+    'properties': {
+        'last_service': {
+            'type': 'string',
+            'example': 'create',
+            'description': 'The last service in the pipeline to be executed. '
+                           'All services except the OBS service are valid '
+                           'values.'
+        },
+        'utctime': utctime,
+        'dry_run': {
+            'type': 'boolean',
+            'example': True,
+            'description': 'Only validate the job document and return. '
+                           'Do not create the job.'
+        }
+    },
+    'additionalProperties': False,
+    'required': [
+        'last_service',
+        'utctime'
     ]
 }

--- a/mash/services/api/v1/schema/jobs/ec2_container.py
+++ b/mash/services/api/v1/schema/jobs/ec2_container.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import copy
+
+from mash.services.api.v1.schema.jobs import base_container_job_message
+
+
+ec2_container_job_message = copy.deepcopy(base_container_job_message)

--- a/mash/services/api/v1/utils/jobs/__init__.py
+++ b/mash/services/api/v1/utils/jobs/__init__.py
@@ -34,6 +34,36 @@ def get_new_job_id():
     return str(uuid.uuid4())
 
 
+def create_container_job(data):
+    """
+    Create a new container job for user.
+    """
+    if data.get('dry_run'):
+        return None
+
+    job_id = get_new_job_id()
+    data['job_id'] = job_id
+
+    user_id = data['requesting_user']
+
+    kwargs = {
+        'job_id': job_id,
+        'last_service': data['last_service'],
+        'utctime': data['utctime'],
+        'user_id': user_id,
+        'state': RUNNING,
+    }
+
+    if data['utctime'] != 'now':
+        kwargs['start_time'] = parser.parse(data['utctime'])
+
+    # Store job in database
+
+    # Publish data in job_document of jobcreator
+
+    return data
+
+
 def create_job(data):
     """
     Create a new job for user.
@@ -93,6 +123,14 @@ def create_job(data):
         raise MashJobException('Failed to initialize job.')
 
     return response.json()
+
+
+def validate_container_job(data):
+    """
+    Validate container job doc.
+    """
+    data = normalize_dictionary(data)
+    return data
 
 
 def validate_job(data):

--- a/mash/services/api/v1/utils/jobs/ec2_container.py
+++ b/mash/services/api/v1/utils/jobs/ec2_container.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.services.api.v1.utils.jobs import validate_container_job
+
+
+def validate_ec2_container_job(job_doc):
+    """
+    Validate container job.
+
+    """
+    job_doc = validate_container_job(job_doc)
+    return job_doc

--- a/test/data/container_job.json
+++ b/test/data/container_job.json
@@ -1,0 +1,5 @@
+{
+  "requesting_user": "user1",
+  "last_service": "deprecate",
+  "utctime": "now"
+}

--- a/test/unit/services/api/v1/routes/jobs/ec2_container_job_routes_test.py
+++ b/test/unit/services/api/v1/routes/jobs/ec2_container_job_routes_test.py
@@ -1,0 +1,84 @@
+import json
+
+from unittest.mock import patch
+
+from mash.mash_exceptions import MashException
+
+
+@patch('mash.services.api.v1.routes.jobs.ec2_container.create_container_job')
+@patch('mash.services.api.v1.routes.jobs.ec2_container.get_jwt_identity')
+@patch('flask_jwt_extended.view_decorators.verify_jwt_in_request')
+def test_api_add_job_ec2_container(
+    mock_jwt_required,
+    mock_jwt_identity,
+    mock_create_container_job,
+    test_client
+):
+    job = {
+        'job_id': '12345678-1234-1234-1234-123456789012',
+        'last_service': 'test',
+        'utctime': 'now',
+        'errors': []
+    }
+    mock_create_container_job.return_value = job
+    mock_jwt_identity.return_value = 'user1'
+
+    with open('test/data/container_job.json', 'r') as job_doc:
+        data = json.load(job_doc)
+
+    del data['requesting_user']
+    # del data['job_id']
+    # del data['cloud']
+
+    response = test_client.post(
+        '/v1/jobs/ec2_container/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    print(f"{response.status_code}")
+    print(f"{response.data}")
+
+    assert response.status_code == 201
+    assert response.json['job_id'] == '12345678-1234-1234-1234-123456789012'
+    assert response.json['last_service'] == 'test'
+    assert response.json['utctime'] == 'now'
+
+    # Dry run
+    data['dry_run'] = True
+    mock_create_container_job.return_value = None
+    response = test_client.post(
+        '/v1/jobs/ec2_container/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 200
+    assert response.data == b'{"msg":"Job doc is valid!"}\n'
+
+    # Exception
+    mock_create_container_job.side_effect = Exception('Broken')
+
+    response = test_client.post(
+        '/v1/jobs/ec2_container/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 400
+    assert response.data == b'{"msg":"Failed to start job"}\n'
+
+    # Mash Exception
+    mock_create_container_job.side_effect = MashException('Broken')
+
+    response = test_client.post(
+        '/v1/jobs/ec2_container/',
+        content_type='application/json',
+        data=json.dumps(data, sort_keys=True)
+    )
+    assert response.status_code == 400
+    assert response.data == b'{"msg":"Job failed: Broken"}\n'
+
+
+def test_api_get_ec2_container_job_schema(test_client):
+    response = test_client.get('/v1/jobs/ec2_container/')
+    assert response.status_code == 200
+    data = json.loads(response.data)  # assert json loads
+    assert data['additionalProperties'] is False


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
This PR includes an endpoint in the mash API to generate jobs for container publication in ec2 cloud.
For now the job is not created in the database nor published in the message broker.

### How will these changes be tested?
Unit tests have been included in the PR and changes have been tested locally.

### How will this change be deployed? Any special considerations?
Nope

### Additional Information
I'll complete additional PRs to this `feature_container_automation` branch to progress in extending mash functionality into container publication automation.
