### PR TITLE
Encapsulating 'test_image' call into a function for EC2 image tests

### DIFF
--- a/mash/services/test/ec2_job.py
+++ b/mash/services/test/ec2_job.py
@@ -145,70 +145,31 @@ class EC2TestJob(MashJob):
                     # There are no aarch64 based instance types available.
                     continue
 
-                with setup_ec2_networking(
-                    credentials['access_key_id'],
-                    region,
-                    credentials['secret_access_key'],
-                    self.ssh_private_key_file,
-                    subnet_id=info.get('subnet')
-                ) as network_details:
-                    try:
-                        exit_status, result = test_image(
-                            self.cloud,
-                            access_key_id=credentials['access_key_id'],
-                            cleanup=True,
-                            description=self.description,
-                            distro=self.distro,
-                            image_id=self.status_msg['source_regions'][region],
-                            instance_type=instance_type,
-                            timeout=self.img_proof_timeout,
-                            log_level=logging.DEBUG,
-                            region=region,
-                            secret_access_key=credentials['secret_access_key'],
-                            security_group_id=network_details['security_group_id'],
-                            ssh_key_name=network_details['ssh_key_name'],
-                            ssh_private_key_file=self.ssh_private_key_file,
-                            ssh_user=self.ssh_user,
-                            subnet_id=network_details['subnet_id'],
-                            tests=self.tests,
-                            log_callback=self.log_callback,
-                            prefix_name='mash'
-                        )
-                    except Exception as error:
-                        self.add_error_msg(str(error))
-                        exit_status = 1
-                        result = {
-                            'status': EXCEPTION,
-                            'msg': str(traceback.format_exc())
-                        }
+                status = self.run_tests(
+                    access_key_id=credentials['access_key_id'],
+                    secret_access_key=credentials['secret_access_key'],
+                    region=region,
+                    ssh_private_key_file=self.ssh_private_key_file,
+                    subnet=info.get('subnet'),
+                    cloud=self.cloud,
+                    description=self.description,
+                    distro=self.distro,
+                    image_id=self.status_msg['source_regions'][region],
+                    instance_type=instance_type,
+                    img_proof_timeout=self.img_proof_timeout,
+                    ssh_user=self.ssh_user,
+                    tests=self.tests,
+                    log_callback=self.log_callback
+                )
 
-                    status = process_test_result(
-                        exit_status,
-                        result,
-                        self.log_callback,
-                        region,
-                        self.status_msg
+                if status != SUCCESS:
+                    self.status = status
+                    self.add_error_msg(
+                        'Image failed img-proof test suite. '
+                        'See "mash job test-results --job-id {GUID} -v" '
+                        'for details on the failing tests.'
                     )
-
-                    instance_id = result.get('info', {}).get('instance')
-                    if instance_id:
-                        # Wait until instance is terminated to exit
-                        # context manager and cleanup resources.
-                        wait_for_instance_termination(
-                            credentials['access_key_id'],
-                            instance_id,
-                            region,
-                            credentials['secret_access_key']
-                        )
-
-                    if status != SUCCESS:
-                        self.status = status
-                        self.add_error_msg(
-                            'Image failed img-proof test suite. '
-                            'See "mash job test-results --job-id {GUID} -v" '
-                            'for details on the failing tests.'
-                        )
-                        break  # Fail eagerly, if the image fails in any partition.
+                    break  # Fail eagerly, if the image fails in any partition.
 
         if self.cleanup_images or (self.status != SUCCESS and self.cleanup_images is not False):  # noqa
             for region, info in self.test_regions.items():
@@ -221,3 +182,79 @@ class EC2TestJob(MashJob):
                     region,
                     image_id=self.status_msg['source_regions'][region]
                 )
+
+    def run_tests(
+        self,
+        access_key_id,
+        secret_access_key,
+        region,
+        ssh_private_key_file,
+        subnet,
+        cloud,
+        description,
+        distro,
+        image_id,
+        instance_type,
+        img_proof_timeout,
+        ssh_user,
+        tests,
+        log_callback
+    ):
+        with setup_ec2_networking(
+            access_key_id,
+            region,
+            secret_access_key,
+            ssh_private_key_file,
+            subnet_id=subnet
+        ) as network_details:
+
+            try:
+                exit_status, result = test_image(
+                    cloud,
+                    access_key_id=access_key_id,
+                    cleanup=True,
+                    description=description,
+                    distro=distro,
+                    image_id=image_id,
+                    instance_type=instance_type,
+                    timeout=img_proof_timeout,
+                    log_level=logging.DEBUG,
+                    region=region,
+                    secret_access_key=secret_access_key,
+                    security_group_id=network_details['security_group_id'],
+                    ssh_key_name=network_details['ssh_key_name'],
+                    ssh_private_key_file=ssh_private_key_file,
+                    ssh_user=ssh_user,
+                    subnet_id=network_details['subnet_id'],
+                    tests=tests,
+                    log_callback=log_callback,
+                    prefix_name='mash'
+                )
+            except Exception as error:
+                self.add_error_msg(str(error))
+                exit_status = 1
+                result = {
+                    'status': EXCEPTION,
+                    'msg': str(traceback.format_exc())
+                }
+
+            status = process_test_result(
+                exit_status,
+                result,
+                log_callback,
+                region,
+                self.status_msg
+            )
+
+            instance_id = result.get('info', {}).get('instance', None)
+            if instance_id:
+                # Wait until instance is terminated to exit
+                # context manager and cleanup resources.
+                wait_for_instance_termination(
+                    access_key_id,
+                    instance_id,
+                    region,
+                    secret_access_key
+                )
+
+        return status

--- a/mash/services/test/ec2_job.py
+++ b/mash/services/test/ec2_job.py
@@ -145,31 +145,40 @@ class EC2TestJob(MashJob):
                     # There are no aarch64 based instance types available.
                     continue
 
-                status = self.run_tests(
-                    access_key_id=credentials['access_key_id'],
-                    secret_access_key=credentials['secret_access_key'],
-                    region=region,
-                    ssh_private_key_file=self.ssh_private_key_file,
-                    subnet=info.get('subnet'),
-                    cloud=self.cloud,
-                    description=self.description,
-                    distro=self.distro,
-                    image_id=self.status_msg['source_regions'][region],
-                    instance_type=instance_type,
-                    img_proof_timeout=self.img_proof_timeout,
-                    ssh_user=self.ssh_user,
-                    tests=self.tests,
-                    log_callback=self.log_callback
-                )
+                with setup_ec2_networking(
+                    credentials['access_key_id'],
+                    region,
+                    credentials['secret_access_key'],
+                    self.ssh_private_key_file,
+                    subnet_id=info.get('subnet')
+                ) as network_details:
 
-                if status != SUCCESS:
-                    self.status = status
-                    self.add_error_msg(
-                        'Image failed img-proof test suite. '
-                        'See "mash job test-results --job-id {GUID} -v" '
-                        'for details on the failing tests.'
+                    status = self.run_tests(
+                        access_key_id=credentials['access_key_id'],
+                        secret_access_key=credentials['secret_access_key'],
+                        region=region,
+                        ssh_private_key_file=self.ssh_private_key_file,
+                        subnet=info.get('subnet'),
+                        cloud=self.cloud,
+                        description=self.description,
+                        distro=self.distro,
+                        image_id=self.status_msg['source_regions'][region],
+                        instance_type=instance_type,
+                        img_proof_timeout=self.img_proof_timeout,
+                        ssh_user=self.ssh_user,
+                        tests=self.tests,
+                        log_callback=self.log_callback,
+                        network_details=network_details
                     )
-                    break  # Fail eagerly, if the image fails in any partition.
+
+                    if status != SUCCESS:
+                        self.status = status
+                        self.add_error_msg(
+                            'Image failed img-proof test suite. '
+                            'See "mash job test-results --job-id {GUID} -v" '
+                            'for details on the failing tests.'
+                        )
+                        break  # Fail eagerly, if the image fails in any partition.
 
         if self.cleanup_images or (self.status != SUCCESS and self.cleanup_images is not False):  # noqa
             for region, info in self.test_regions.items():
@@ -198,63 +207,56 @@ class EC2TestJob(MashJob):
         img_proof_timeout,
         ssh_user,
         tests,
-        log_callback
+        log_callback,
+        network_details
     ):
-        with setup_ec2_networking(
-            access_key_id,
-            region,
-            secret_access_key,
-            ssh_private_key_file,
-            subnet_id=subnet
-        ) as network_details:
-
-            try:
-                exit_status, result = test_image(
-                    cloud,
-                    access_key_id=access_key_id,
-                    cleanup=True,
-                    description=description,
-                    distro=distro,
-                    image_id=image_id,
-                    instance_type=instance_type,
-                    timeout=img_proof_timeout,
-                    log_level=logging.DEBUG,
-                    region=region,
-                    secret_access_key=secret_access_key,
-                    security_group_id=network_details['security_group_id'],
-                    ssh_key_name=network_details['ssh_key_name'],
-                    ssh_private_key_file=ssh_private_key_file,
-                    ssh_user=ssh_user,
-                    subnet_id=network_details['subnet_id'],
-                    tests=tests,
-                    log_callback=log_callback,
-                    prefix_name='mash'
-                )
-            except Exception as error:
-                self.add_error_msg(str(error))
-                exit_status = 1
-                result = {
-                    'status': EXCEPTION,
-                    'msg': str(traceback.format_exc())
-                }
-
-            status = process_test_result(
-                exit_status,
-                result,
-                log_callback,
-                region,
-                self.status_msg
+        try:
+            exit_status, result = test_image(
+                cloud,
+                access_key_id=access_key_id,
+                cleanup=True,
+                description=description,
+                distro=distro,
+                image_id=image_id,
+                instance_type=instance_type,
+                timeout=img_proof_timeout,
+                log_level=logging.DEBUG,
+                region=region,
+                secret_access_key=secret_access_key,
+                security_group_id=network_details['security_group_id'],
+                ssh_key_name=network_details['ssh_key_name'],
+                ssh_private_key_file=ssh_private_key_file,
+                ssh_user=ssh_user,
+                subnet_id=network_details['subnet_id'],
+                tests=tests,
+                log_callback=log_callback,
+                prefix_name='mash'
             )
+        except Exception as error:
+            self.add_error_msg(str(error))
+            exit_status = 1
+            result = {
+                'status': EXCEPTION,
+                'msg': str(traceback.format_exc())
+            }
 
-            instance_id = result.get('info', {}).get('instance', None)
-            if instance_id:
-                # Wait until instance is terminated to exit
-                # context manager and cleanup resources.
-                wait_for_instance_termination(
-                    access_key_id,
-                    instance_id,
-                    region,
-                    secret_access_key
-                )
+        status = process_test_result(
+            exit_status,
+            result,
+            log_callback,
+            region,
+            self.status_msg
+        )
+
+        instance_id = result.get('info', {}).get('instance', None)
+        if instance_id:
+            # Wait until instance is terminated to exit
+            # context manager and cleanup resources.
+            wait_for_instance_termination(
+                access_key_id,
+                instance_id,
+                region,
+                secret_access_key
+            )
 
         return status


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
 This is a first PR to address [issue #854](https://github.com/SUSE-Enceladus/mash/issues/854) and be able to run specific tests per region with different instance flags.

There are no functional changes in this PR. It just encapsulates  the `test_image` call where the tests are run into a function so it's easier to add specific tests for some regions (where some features might be supported)  

### How will these changes be tested?

Unit tests have been run to the changed code.

### How will this change be deployed? Any special considerations?
Nope.

### Additional Information

My idea is to add a new field to the jobdoc where we will be able to overwrite some fields for the tests (region, cpuOptions, etc.)