### PR TITLE
Use upstream name filter in describe images call

### DIFF
--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -199,11 +199,24 @@ def get_image(client, cloud_image_name):
     """
     Get image if it exists given image name.
     """
-    images = describe_images(client)
+    filters = [{
+        'Name': 'name',
+        'Values': [
+            cloud_image_name,
+        ]
+    }]
+    images = describe_images(client, filters=filters)
 
-    for image in images:
-        if cloud_image_name == image.get('Name'):
-            return image
+    if images and len(images) > 1:
+        raise MashEc2UtilsException(
+            'Expected only one image but multiple images found'
+            f' using the filter {cloud_image_name}.'
+        )
+
+    if images:
+        return images[0]
+
+    return None
 
 
 def image_exists(client, cloud_image_name):
@@ -211,9 +224,9 @@ def image_exists(client, cloud_image_name):
     Determine if image exists given image name.
     """
     image = get_image(client, cloud_image_name)
-    if image and cloud_image_name == image.get('Name'):
-        return True
 
+    if image:
+        return True
     return False
 
 

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -162,16 +162,30 @@ def test_get_image(mock_describe_images):
     client = Mock()
     image = {'Name': 'image name 123'}
 
-    mock_describe_images.return_value = [image]
+    mock_describe_images.side_effect = [
+        [image],
+        [image, image],
+        []
+    ]
+
+    # One image found
     result = get_image(client, 'image name 123')
     assert result == image
+
+    # multiple images found
+    with raises(MashEc2UtilsException):
+        get_image(client, 'image name 123')
+
+    # No image found
+    result = get_image(client, 'image name 123')
+    assert result is None
 
 
 @patch('mash.utils.ec2.get_image')
 def test_image_exists(mock_get_image):
     client = Mock()
     image = {'Name': 'image name 123'}
-    mock_get_image.return_value = image
+    mock_get_image.side_effect = [image, None]
 
     assert image_exists(client, 'image name 123')
     assert not image_exists(client, 'image name 321')


### PR DESCRIPTION
Raise exception if more than one image is found.

Note: This is pre-work for enabling version restriction in aws mp.