### PR TITLE
Add function to generate version restriction doc

### DIFF
--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -217,6 +217,24 @@ def image_exists(client, cloud_image_name):
     return False
 
 
+def create_restrict_version_change_doc(
+    entity_id,
+    delivery_option_id
+):
+    data = {
+        'ChangeType': 'RestrictDeliveryOptions',
+        'Entity': {
+            'Type': 'AmiProduct@1.0',
+            'Identifier': entity_id
+        },
+        'Details': {
+            'DeliveryOptionIds': [delivery_option_id]
+        }
+    }
+
+    return data
+
+
 def start_mp_change_set(
     region,
     access_key_id,

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -26,7 +26,8 @@ from mash.utils.ec2 import (
     cleanup_all_ec2_images,
     get_image,
     image_exists,
-    start_mp_change_set
+    start_mp_change_set,
+    create_restrict_version_change_doc
 )
 from mash.mash_exceptions import MashEc2UtilsException
 import botocore.session
@@ -636,3 +637,19 @@ def test_start_mp_change_set_ongoing_change_ResInUseExc_not_changeid(
         ],
         any_order=True
     )
+
+
+def test_create_restrict_version_change_doc():
+    expected = {
+        'ChangeType': 'RestrictDeliveryOptions',
+        'Entity': {
+            'Type': 'AmiProduct@1.0',
+            'Identifier': '123456789'
+        },
+        'Details': {
+            'DeliveryOptionIds': ['987654321']
+        }
+    }
+
+    actual = create_restrict_version_change_doc('123456789', '987654321')
+    assert expected == actual


### PR DESCRIPTION
To enable aws mp version restriction in change sets.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
