### PR TITLE
Drop the version pin on werkzeug

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -5,7 +5,7 @@
 # $ pip install -U pip setuptools
 # $ pip install -r .virtualenv.requirements.txt
 
-Flask
+Flask<3.0.0
 flask-restx
 flask-sqlalchemy
 flask-migrate
@@ -23,7 +23,7 @@ img-proof>=7.14.0
 requests
 obs-img-utils>=1.0.0
 oci
-werkzeug<2.1.0
+werkzeug
 google-auth
 google-cloud-storage
 google-api-python-client


### PR DESCRIPTION
Add pin on Flask < 3.0.0 which is not supported by flask-restx atm

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
