### PR TITLE
Drop explicit requirement on sqlalchemy

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -29,4 +29,3 @@ google-cloud-storage
 google-api-python-client
 aliyun-img-utils>=1.4.0
 azure-img-utils>=0.4.1
-Sqlalchemy<2.0.0


### PR DESCRIPTION
Latest flask-sqlalchemy now supports sqlalchemy 2.0.0

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
