### PR TITLE
Add launch_inst_type option for ec2 jobs

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -166,6 +166,10 @@ ec2_job_message['properties']['tpm_support'] = string_with_example(
     'v2.0',
     description='The NitroTPM version supported by the image.'
 )
+ec2_job_message['properties']['launch_inst_type'] = string_with_example(
+    'm1.large',
+    description='The helper instance type to use for image creation with ec2uploadimg.'
+)
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -68,6 +68,7 @@ class EC2CreateJob(MashJob):
         self.use_build_time = self.job_config.get('use_build_time')
         self.force_replace_image = self.job_config.get('force_replace_image')
         self.tpm_support = self.job_config.get('tpm_support')
+        self.launch_inst_type = self.job_config.get('launch_inst_type')
         self.boot_firmware = self.job_config.get(
             'boot_firmware',
             ['uefi-preferred']
@@ -114,7 +115,7 @@ class EC2CreateJob(MashJob):
             'use_private_ip': False,
             'root_volume_size': 10,
             'image_virt_type': 'hvm',
-            'launch_inst_type': 't2.micro',
+            'launch_inst_type': self.launch_inst_type or 't2.micro',
             'bootkernel': None,
             'inst_user_name': 'ec2-user',
             'ssh_timeout': 300,

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -50,6 +50,7 @@ class EC2Job(BaseJob):
             'publish_in_marketplace',
             False
         )
+        self.launch_inst_type = self.kwargs.get('launch_inst_type')
 
     def _get_target_regions_list(self):
         """
@@ -240,7 +241,8 @@ class EC2Job(BaseJob):
                 'target_regions': self.get_create_regions(),
                 'force_replace_image': self.force_replace_image,
                 'tpm_support': self.tpm_support,
-                'boot_firmware': self.boot_firmware
+                'boot_firmware': self.boot_firmware,
+                'launch_inst_type': self.launch_inst_type
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -42,7 +42,8 @@ class TestAmazonCreateJob(object):
             'cloud_image_name': 'name v{date}',
             'image_description': 'description',
             'use_build_time': True,
-            'tpm_support': 'v2.0'
+            'tpm_support': 'v2.0',
+            'launch_inst_type': 'm1.large'
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
@@ -140,7 +141,7 @@ class TestAmazonCreateJob(object):
             image_virt_type='hvm',
             inst_user_name='ec2-user',
             launch_ami='ami-bc5b48d0',
-            launch_inst_type='t2.micro',
+            launch_inst_type='m1.large',
             root_volume_size=10,
             running_id=None,
             secret_key='secret-access-key',

--- a/test/unit/services/jobcreator/ec2_job_test.py
+++ b/test/unit/services/jobcreator/ec2_job_test.py
@@ -22,7 +22,8 @@ def test_get_test_message_cleanup(mock_get_test_regions):
         'cleanup_images': True,
         'test_fallback_regions': [],
         'target_account_info': {},
-        'ssh_user': 'root'
+        'ssh_user': 'root',
+        'launch_inst_type': 'm1.large'
     })
 
     message = job.get_test_message()


### PR DESCRIPTION
This provides a way to override the default instance type to use in ec2uploadimg for ec2 image creation.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
