### PR TITLE
Enable version restriction for aws mp jobs

### DIFF
--- a/mash/services/deprecate/ec2_mp_job.py
+++ b/mash/services/deprecate/ec2_mp_job.py
@@ -30,7 +30,7 @@ from mash.utils.ec2 import (
 
 class EC2MPDeprecateJob(MashJob):
     """
-    Class for an EC2 deprecate job.
+    Class for EC2 Marketplace restriction.
     """
 
     def post_init(self):
@@ -54,7 +54,7 @@ class EC2MPDeprecateJob(MashJob):
 
     def run_job(self):
         """
-        Deprecate image in all target regions in each source region.
+        Restrict the image in each source region.
         """
         self.status = SUCCESS
 

--- a/mash/services/deprecate/ec2_mp_job.py
+++ b/mash/services/deprecate/ec2_mp_job.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.mash_exceptions import MashDeprecateException
+from mash.services.mash_job import MashJob
+from mash.services.status_levels import SUCCESS
+from mash.utils.ec2 import (
+    create_restrict_version_change_doc,
+    start_mp_change_set,
+    get_delivery_option_id,
+    get_session,
+    get_image
+)
+
+
+class EC2MPDeprecateJob(MashJob):
+    """
+    Class for an EC2 deprecate job.
+    """
+
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        try:
+            self.deprecate_regions = self.job_config['deprecate_regions']
+            self.entity_id = self.job_config['entity_id']
+        except KeyError as error:
+            raise MashDeprecateException(
+                'EC2 deprecate Jobs require a(n) {0} '
+                'key in the job doc.'.format(
+                    error
+                )
+            )
+
+        self.old_cloud_image_name = self.job_config.get(
+            'old_cloud_image_name'
+        )
+
+    def run_job(self):
+        """
+        Deprecate image in all target regions in each source region.
+        """
+        self.status = SUCCESS
+
+        if self.old_cloud_image_name is None:
+            # There is no old image that needs deprecate for the job.
+            return
+
+        # Get all account credentials in one request
+        self.request_credentials(list(self.deprecate_regions.keys()), cloud='ec2')
+
+        for account, region in self.deprecate_regions.items():
+            credential = self.credentials[account]
+
+            session = get_session(
+                credential['access_key_id'],
+                credential['secret_access_key'],
+                region
+            )
+            old_image = get_image(
+                session.client('ec2'),
+                self.old_cloud_image_name
+            )
+            delivery_option_id = get_delivery_option_id(
+                session,
+                self.entity_id,
+                old_image['ImageId']
+            )
+            restrict_version_doc = create_restrict_version_change_doc(
+                entity_id=self.entity_id,
+                delivery_option_id=delivery_option_id
+            )
+
+            response = start_mp_change_set(
+                session,
+                change_set=[
+                    self.status_msg.pop('add_version_doc'),
+                    restrict_version_doc
+                ]
+            )
+
+            self.status_msg['change_set_id'] = response.get('ChangeSetId')
+            self.log_callback.info(
+                'Marketplace change set submitted. Change set id: '
+                '{change_set}'.format(
+                    change_set=self.status_msg['change_set_id']
+                )
+            )

--- a/test/unit/services/deprecate/ec2_mp_job_test.py
+++ b/test/unit/services/deprecate/ec2_mp_job_test.py
@@ -1,0 +1,101 @@
+from pytest import raises
+from unittest.mock import Mock, patch
+
+from mash.mash_exceptions import MashDeprecateException
+from mash.services.deprecate.ec2_mp_job import EC2MPDeprecateJob
+
+
+class TestEC2MPDeprecateJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'last_service': 'deprecate',
+            'requesting_user': 'user1',
+            'cloud': 'ec2',
+            'entity_id': '123',
+            'deprecate_regions': {'test-aws': 'us-east-2'},
+            'old_cloud_image_name': 'old-cloud-image-123',
+            'utctime': 'now'
+        }
+
+        self.config = Mock()
+        self.job = EC2MPDeprecateJob(self.job_config, self.config)
+        self.job._log_callback = Mock()
+        self.job.credentials = {
+            'test-aws': {
+                'access_key_id': '123456',
+                'secret_access_key': '654321',
+                'ssh_key_name': 'key-123',
+                'ssh_private_key': 'key123'
+            }
+        }
+        self.job.status_msg['add_version_doc'] = {
+            'ChangeType': 'AddDeliveryOptions',
+            'Entity': {
+                'Type': 'AmiProduct@1.0',
+                'Identifier': '123'
+            },
+            'Details': '{"new": "version"}'
+        }
+        self.job._log_callback = Mock()
+
+    def test_deprecate_ec2_missing_key(self):
+        del self.job_config['deprecate_regions']
+
+        with raises(MashDeprecateException):
+            EC2MPDeprecateJob(self.job_config, self.config)
+
+    @patch('mash.services.deprecate.ec2_mp_job.get_delivery_option_id')
+    @patch('mash.services.deprecate.ec2_mp_job.get_session')
+    @patch('mash.services.deprecate.ec2_mp_job.start_mp_change_set')
+    @patch('mash.services.deprecate.ec2_mp_job.get_image')
+    def test_deprecate(
+        self,
+        mock_get_image,
+        mock_start_change_set,
+        mock_get_session,
+        mock_get_delivery_option_id
+    ):
+        mock_get_image.return_value = {'ImageId': 'ami-123'}
+        mock_get_delivery_option_id.return_value = '1234567-12345-23456-23456'
+        mock_start_change_set.return_value = {'ChangeSetId': '123'}
+
+        session = Mock()
+        mock_get_session.return_value = session
+
+        self.job.run_job()
+
+        mock_start_change_set.assert_called_once_with(
+            session,
+            change_set=[
+                {
+                    'ChangeType': 'AddDeliveryOptions',
+                    'Entity': {
+                        'Type': 'AmiProduct@1.0',
+                        'Identifier': '123'
+                    },
+                    'Details': '{"new": "version"}'
+                },
+                {
+                    'ChangeType': 'RestrictDeliveryOptions',
+                    'Entity': {
+                        'Type': 'AmiProduct@1.0',
+                        'Identifier': '123'
+                    },
+                    'Details': '{"DeliveryOptionIds": ["1234567-12345-23456-23456"]}'
+                }
+            ]
+        )
+
+        assert self.job.status == 'success'
+        assert self.job.status_msg['change_set_id'] == '123'
+
+    @patch('mash.services.deprecate.ec2_mp_job.get_image')
+    def test_deprecate_exception(
+        self,
+        mock_get_image,
+    ):
+        mock_get_image.side_effect = Exception('Failed to get image.')
+
+        with raises(Exception):
+            self.job.run_job()

--- a/test/unit/services/jobcreator/ec2_job_test.py
+++ b/test/unit/services/jobcreator/ec2_job_test.py
@@ -60,3 +60,32 @@ def test_get_mp_publish_message(mock_get_test_regions):
 
     message = job.get_publish_message()
     assert JsonFormat.json_loads(message)['publish_job']['entity_id'] == '123'
+
+
+@patch.object(EC2Job, 'get_test_regions')
+def test_get_mp_deprecate_message(mock_get_test_regions):
+    mock_get_test_regions.return_value = {}
+
+    job = EC2Job({
+        'job_id': '123',
+        'cloud': 'ec2',
+        'requesting_user': 'test-user',
+        'last_service': 'deprecate',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'old_cloud_image_name': 'old-test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here',
+        'cleanup_images': True,
+        'test_fallback_regions': [],
+        'target_account_info': {},
+        'publish_in_marketplace': True,
+        'entity_id': '123',
+        'ssh_user': 'root'
+    })
+    job.target_account_info = {'us-east-2': {'account': 'acnt1'}}
+
+    message = job.get_deprecate_message()
+    assert JsonFormat.json_loads(message)['deprecate_job']['entity_id'] == '123'


### PR DESCRIPTION
Version restriction is triggered based on the old image name attr. If it exists the restriction happens in deprecate service. The change set is submitted after the last change is created in either publish or deprecate service.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
