### PR TITLE
Renames the service that gets the images from `obs` service to `download` service

### DIFF
--- a/config/mash_download.service
+++ b/config/mash_download.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Mash OBS service
+Description=Mash Download service
 After=syslog.target network.target rabbitmq-server.service
 Before=systemd-user-sessions.service
 Requires=rabbitmq-server.service
@@ -8,7 +8,7 @@ Requires=rabbitmq-server.service
 User=mash
 Group=mash
 Type=simple
-ExecStart=/usr/bin/mash-obs-service
+ExecStart=/usr/bin/mash-download-service
 StandardOutput=journal
 Restart=always
 RestartSec=3

--- a/mash/services/api/v1/schema/jobs/__init__.py
+++ b/mash/services/api/v1/schema/jobs/__init__.py
@@ -80,7 +80,7 @@ base_job_message = {
             'type': 'string',
             'example': 'create',
             'description': 'The last service in the pipeline to be executed. '
-                           'All services except the OBS service are valid '
+                           'All services except the download service are valid '
                            'values.'
         },
         'utctime': utctime,

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -48,7 +48,7 @@ class Defaults(object):
     @classmethod
     def get_service_names(self):
         return [
-            'obs', 'upload', 'create', 'test', 'raw_image_upload',
+            'download', 'upload', 'create', 'test', 'raw_image_upload',
             'replicate', 'publish', 'deprecate'
         ]
 
@@ -66,7 +66,7 @@ class Defaults(object):
 
     @classmethod
     def get_non_credential_service_names(self):
-        return ['obs']
+        return ['download']
 
     @classmethod
     def get_azure_max_retry_attempts(self):

--- a/mash/services/download/obs_build_result.py
+++ b/mash/services/download/obs_build_result.py
@@ -200,7 +200,7 @@ class OBSImageBuildResult(object):
         if self.result_callback:
             self.result_callback(
                 self.job_id, {
-                    'obs_result': {
+                    'download_result': {
                         'id': self.job_id,
                         'image_file':
                             self.downloader.image_source,

--- a/mash/services/download/obs_job.py
+++ b/mash/services/download/obs_job.py
@@ -21,7 +21,7 @@ import dateutil.parser
 
 # project
 from mash.services.mash_service import MashService
-from mash.services.obs.build_result import OBSImageBuildResult
+from mash.services.download.obs_build_result import OBSImageBuildResult
 from mash.utils.json_format import JsonFormat
 from mash.utils.mash_utils import persist_json, restart_jobs, setup_logfile
 
@@ -118,11 +118,11 @@ class OBSImageBuildResultService(MashService):
 
     def _handle_jobs(self, job_data):
         """
-        handle obs job document
+        handle download job document for the OBS type
         """
         job_id = None
-        if 'obs_job' in job_data:
-            job_id = job_data['obs_job'].get('id', None)
+        if 'download_job' in job_data:
+            job_id = job_data['download_job'].get('id', None)
             result = self._add_job(job_data)
         else:
             result = {
@@ -137,7 +137,7 @@ class OBSImageBuildResultService(MashService):
 
         job description example:
         {
-          "obs_job": {
+          "download_job": {
               "id": "123",
               "download_url": "http://download.suse.de/ibs/Devel:/PubCloud
               :/Stable:/Images12/images",
@@ -159,7 +159,7 @@ class OBSImageBuildResultService(MashService):
           }
         }
         """
-        data = data['obs_job']
+        data = data['download_job']
         data['job_file'] = '{0}job-{1}.json'.format(
             self.job_directory, data['id']
         )
@@ -174,7 +174,7 @@ class OBSImageBuildResultService(MashService):
 
         delete job description example:
         {
-            "obs_job_delete": "123"
+            "download_job_delete": "123"
         }
         """
         if job_id not in self.jobs:

--- a/mash/services/download_service.py
+++ b/mash/services/download_service.py
@@ -22,20 +22,21 @@ import traceback
 # project
 from mash.mash_exceptions import MashException
 from mash.services.base_config import BaseConfig
-from mash.services.obs.service import OBSImageBuildResultService
+from mash.services.download.obs_job import OBSImageBuildResultService
 
 
 def main():
     """
-    mash - obs service application entry point
+    mash - download service application entry point
     """
     try:
         logging.basicConfig()
         log = logging.getLogger('MashService')
         log.setLevel(logging.DEBUG)
         # run service, enter main loop
+        # keeping OBSImageBuildResultService as only entry point for now
         OBSImageBuildResultService(
-            service_exchange='obs',
+            service_exchange='download',
             config=BaseConfig()
         )
     except MashException as e:

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -99,39 +99,39 @@ class BaseJob(object):
             )
         )
 
-    def get_obs_message(self):
+    def get_download_message(self):
         """
-        Build OBS job message.
+        Build download job message.
         """
-        obs_message = {
-            'obs_job': {
+        download_message = {
+            'download_job': {
                 'download_url': self.download_url,
                 'image': self.image
             }
         }
-        obs_message['obs_job'].update(self.base_message)
+        download_message['download_job'].update(self.base_message)
 
         if self.cloud_architecture:
-            obs_message['obs_job']['cloud_architecture'] = \
+            download_message['download_job']['cloud_architecture'] = \
                 self.cloud_architecture
 
         if self.conditions:
-            obs_message['obs_job']['conditions'] = self.conditions
+            download_message['download_job']['conditions'] = self.conditions
 
         if self.profile:
-            obs_message['obs_job']['profile'] = self.profile
+            download_message['download_job']['profile'] = self.profile
 
         if self.conditions_wait_time:
-            obs_message['obs_job']['conditions_wait_time'] = \
+            download_message['download_job']['conditions_wait_time'] = \
                 self.conditions_wait_time
 
         if self.disallow_licenses:
-            obs_message['obs_job']['disallow_licenses'] = self.disallow_licenses
+            download_message['download_job']['disallow_licenses'] = self.disallow_licenses
 
         if self.disallow_packages:
-            obs_message['obs_job']['disallow_packages'] = self.disallow_packages
+            download_message['download_job']['disallow_packages'] = self.disallow_packages
 
-        return JsonFormat.json_message(obs_message)
+        return JsonFormat.json_message(download_message)
 
     def get_publish_message(self):
         """

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -184,9 +184,9 @@ class JobCreatorService(MashService):
                 self.publish_job_doc(
                     'create', job.get_create_message()
                 )
-            elif service == 'obs':
+            elif service == 'download':
                 self.publish_job_doc(
-                    'obs', job.get_obs_message()
+                    'download', job.get_download_message()
                 )
             elif service == 'publish':
                 self.publish_job_doc(

--- a/mash/services/mash_service.py
+++ b/mash/services/mash_service.py
@@ -98,7 +98,7 @@ class MashService(object):
         """
         Return formatted name based on exchange and queue name.
 
-        Example: obs.service
+        Example download.service
         """
         return '{0}.{1}'.format(exchange, name)
 

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -124,8 +124,8 @@ install -D -m 644 config/database.conf \
 install -d -m 755 %{buildroot}%{_localstatedir}/lib/%{name}/database/migrations
 cp -r mash/services/database/migrations/* %{buildroot}%{_localstatedir}/lib/%{name}/database/migrations/
 
-install -D -m 644 config/mash_obs.service \
-    %{buildroot}%{_unitdir}/mash_obs.service
+install -D -m 644 config/mash_download.service \
+    %{buildroot}%{_unitdir}/mash_download.service
 
 install -D -m 644 config/mash_upload.service \
     %{buildroot}%{_unitdir}/mash_upload.service
@@ -190,8 +190,8 @@ python3 -m pytest
 %config(noreplace) %attr(640, mash, mash)%{_sysconfdir}/apache2/vhosts.d/database.conf
 %config(noreplace) %attr(640, mash, mash)%{_sysconfdir}/%{name}/mash_config.yaml
 
-%{_bindir}/mash-obs-service
-%{_unitdir}/mash_obs.service
+%{_bindir}/mash-download-service
+%{_unitdir}/mash_download.service
 
 %{_bindir}/mash-upload-service
 %{_unitdir}/mash_upload.service

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ config = {
     'packages': ['mash'],
     'entry_points': {
         'console_scripts': [
-            'mash-obs-service=mash.services.obs_service:main',
+            'mash-download-service=mash.services.download_service:main',
             'mash-logger-service=mash.services.logger_service:main',
             'mash-job-creator-service=mash.services.job_creator_service:main',
             'mash-test-service=mash.services.test_service:main',

--- a/test/data/job1.json
+++ b/test/data/job1.json
@@ -1,5 +1,5 @@
 {
-  "obsjob": {
+  "downloadjob": {
     "id": "123",
     "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
     "image": "test-image-oem",

--- a/test/data/job2.json
+++ b/test/data/job2.json
@@ -1,5 +1,5 @@
 {
-  "obsjob": {
+  "downloadjob": {
     "id": "123",
     "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
     "image": "test-image-oem",

--- a/test/data/job3.json
+++ b/test/data/job3.json
@@ -1,5 +1,5 @@
 {
-  "obsjob": {
+  "downloadjob": {
     "id": "123",
     "download_url": "http://download.opensuse.org/repositories/Cloud:Tools/images",
     "image": "test-image-oem",

--- a/test/unit/services/api/v1/utils/jobs/base_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/base_job_utils_test.py
@@ -32,7 +32,7 @@ def test_create_job(
     app.config = {
         'DATABASE_API_URL': 'http://localhost:5007',
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'uploader',
             'create',
             'testing',
@@ -135,7 +135,7 @@ def test_validate_last_service(mock_get_current_obj):
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'uploader',
             'create',
             'testing',

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -166,7 +166,7 @@ def test_validate_ec2_job(
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'uploader',
             'create',
             'testing',
@@ -248,7 +248,7 @@ def test_validate_mp_fields(mock_get_current_obj):
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'upload',
             'create',
             'test',

--- a/test/unit/services/api/v1/utils/jobs/gce_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/gce_job_utils_test.py
@@ -44,7 +44,7 @@ def test_update_gce_job_accounts(
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'upload',
             'create',
             'test',
@@ -57,7 +57,7 @@ def test_update_gce_job_accounts(
     mock_get_current_obj.return_value = app
 
     mock_get_services.return_value = [
-        'obs',
+        'download',
         'upload',
         'create',
         'test'

--- a/test/unit/services/api/v1/utils/jobs/oci_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/oci_job_utils_test.py
@@ -46,7 +46,7 @@ def test_validate_oci_job(
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'upload',
             'create',
             'test',
@@ -59,7 +59,7 @@ def test_validate_oci_job(
     mock_get_current_obj.return_value = app
 
     mock_get_services.return_value = [
-        'obs',
+        'download',
         'upload',
         'create',
         'test'

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -52,7 +52,7 @@ class TestBaseConfig(object):
         assert expected == services
 
         # All services
-        expected = ['obs'] + expected
+        expected = ['download'] + expected
         services = self.empty_config.get_service_names()
         assert expected == services
 

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -28,16 +28,16 @@ class TestBaseService(object):
 
         config = Mock()
         config.get_service_names.return_value = [
-            'obs', 'upload', 'create', 'raw_image_upload', 'test',
+            'download', 'upload', 'create', 'raw_image_upload', 'test',
             'replicate', 'publish', 'deprecate'
         ]
 
-        self.service = MashService('obs', config=config)
+        self.service = MashService('download', config=config)
 
         self.service.log = Mock()
         mock_connection.side_effect = Exception
         with raises(MashRabbitConnectionException):
-            MashService('obs', config=config)
+            MashService('download', config=config)
         self.channel.reset_mock()
 
     def test_post_init(self):
@@ -45,9 +45,9 @@ class TestBaseService(object):
 
     def test_consume_queue(self):
         callback = Mock()
-        self.service.consume_queue(callback, 'service', 'obs')
+        self.service.consume_queue(callback, 'service', 'download')
         self.channel.basic.consume.assert_called_once_with(
-            callback=callback, queue='obs.service'
+            callback=callback, queue='download.service'
         )
 
     def test_close_connection(self):

--- a/test/unit/services/download/build_result_test.py
+++ b/test/unit/services/download/build_result_test.py
@@ -7,12 +7,12 @@ import dateutil.parser
 
 from apscheduler.events import EVENT_JOB_SUBMITTED
 
-from mash.services.obs.build_result import OBSImageBuildResult
+from mash.services.download.obs_build_result import OBSImageBuildResult
 
 
 class TestOBSImageBuildResult(object):
-    @patch('mash.services.obs.build_result.logging')
-    @patch('mash.services.obs.build_result.OBSImageUtil')
+    @patch('mash.services.download.obs_build_result.logging')
+    @patch('mash.services.download.obs_build_result.OBSImageUtil')
     def setup_method(self, method, mock_obs_img_util, mock_logging):
         self.logger = MagicMock()
         self.downloader = MagicMock()
@@ -21,7 +21,7 @@ class TestOBSImageBuildResult(object):
         self.log_callback = MagicMock()
         mock_logging.LoggerAdapter.return_value = self.log_callback
 
-        self.obs_result = OBSImageBuildResult(
+        self.download_result = OBSImageBuildResult(
             '815', 'job_file', 'obs_project', 'obs_package', 'publish',
             self.logger,
             notification_email='test@fake.com',
@@ -31,23 +31,23 @@ class TestOBSImageBuildResult(object):
 
     def test_set_result_handler(self):
         function = Mock()
-        self.obs_result.set_result_handler(function)
-        assert self.obs_result.result_callback == function
+        self.download_result.set_result_handler(function)
+        assert self.download_result.result_callback == function
 
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_call_result_handler(self, mock_result_callback):
-        self.obs_result.call_result_handler()
+        self.download_result.call_result_handler()
         mock_result_callback.assert_called_once_with()
 
     def test_result_callback(self):
-        self.obs_result.result_callback = Mock()
-        self.obs_result.job_status = 'success'
+        self.download_result.result_callback = Mock()
+        self.download_result.job_status = 'success'
         self.downloader.image_source = 'image'
         self.downloader.build_time = '1601061355'
-        self.obs_result._result_callback()
-        self.obs_result.result_callback.assert_called_once_with(
+        self.download_result._result_callback()
+        self.download_result.result_callback.assert_called_once_with(
             '815', {
-                'obs_result': {
+                'download_result': {
                     'id': '815',
                     'image_file': 'image',
                     'status': 'success',
@@ -59,7 +59,7 @@ class TestOBSImageBuildResult(object):
             }
         )
 
-    @patch('mash.services.obs.build_result.BackgroundScheduler')
+    @patch('mash.services.download.obs_build_result.BackgroundScheduler')
     @patch.object(OBSImageBuildResult, '_update_image_status')
     @patch.object(OBSImageBuildResult, '_job_submit_event')
     def test_start_watchdog_single_shot(
@@ -71,7 +71,7 @@ class TestOBSImageBuildResult(object):
         time = 'Tue Oct 10 14:40:42 UTC 2017'
         iso_time = dateutil.parser.parse(time).isoformat()
         run_time = datetime.strptime(iso_time[:19], '%Y-%m-%dT%H:%M:%S')
-        self.obs_result.start_watchdog(isotime=iso_time)
+        self.download_result.start_watchdog(isotime=iso_time)
         mock_BackgroundScheduler.assert_called_once_with(
             timezone=utc
         )
@@ -85,22 +85,22 @@ class TestOBSImageBuildResult(object):
         scheduler.start.assert_called_once_with()
 
     def test_stop_watchdog_no_exception(self):
-        self.obs_result.job = Mock()
-        self.obs_result.stop_watchdog()
-        self.obs_result.job.remove.assert_called_once_with()
+        self.download_result.job = Mock()
+        self.download_result.stop_watchdog()
+        self.download_result.job.remove.assert_called_once_with()
 
     def test_stop_watchdog_just_pass_with_exception(self):
-        self.obs_result.job = Mock()
-        self.obs_result.job.remove.side_effect = Exception
-        self.obs_result.stop_watchdog()
+        self.download_result.job = Mock()
+        self.download_result.job.remove.side_effect = Exception
+        self.download_result.stop_watchdog()
 
     def test_job_submit_event(self):
-        self.obs_result._job_submit_event(Mock())
+        self.download_result._job_submit_event(Mock())
         self.log_callback.info.assert_called_once_with('Oneshot Job submitted')
 
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_job_skipped_event(self, mock_result_callback):
-        self.obs_result._job_skipped_event(Mock())
+        self.download_result._job_skipped_event(Mock())
 
     @patch.object(OBSImageBuildResult, '_result_callback')
     def test_update_image_status(
@@ -108,7 +108,7 @@ class TestOBSImageBuildResult(object):
         mock_result_callback
     ):
         self.downloader.get_image.return_value = 'new-image.xz'
-        self.obs_result._update_image_status()
+        self.download_result._update_image_status()
         mock_result_callback.assert_called_once_with()
 
     @patch.object(OBSImageBuildResult, '_result_callback')
@@ -119,7 +119,7 @@ class TestOBSImageBuildResult(object):
         self.downloader.get_image.side_effect = Exception(
             'request error'
         )
-        self.obs_result._update_image_status()
+        self.download_result._update_image_status()
         mock_result_callback.assert_called_once_with()
         assert self.log_callback.info.call_args_list == [
             call('Job running')
@@ -127,16 +127,16 @@ class TestOBSImageBuildResult(object):
         assert self.log_callback.error.call_args_list == [
             call('Exception: request error')
         ]
-        assert len(self.obs_result.errors) == 2
+        assert len(self.download_result.errors) == 2
 
     def test_progress_callback(self):
-        self.obs_result.progress_callback(0, 0, 0, done=True)
+        self.download_result.progress_callback(0, 0, 0, done=True)
         self.log_callback.info.assert_called_once_with(
             'Image download finished.'
         )
         self.log_callback.info.reset_mock()
 
-        self.obs_result.progress_callback(4, 25, 400)
+        self.download_result.progress_callback(4, 25, 400)
         self.log_callback.info.assert_called_once_with(
             'Image 25% downloaded.'
         )

--- a/test/unit/services/download/main_test.py
+++ b/test/unit/services/download/main_test.py
@@ -1,24 +1,24 @@
 from unittest.mock import patch, Mock
 
 from mash.mash_exceptions import MashException
-from mash.services.obs_service import main
+from mash.services.download_service import main
 
 
-class TestOBS(object):
-    @patch('mash.services.obs_service.BaseConfig')
-    @patch('mash.services.obs_service.OBSImageBuildResultService')
+class TestDownload(object):
+    @patch('mash.services.download_service.BaseConfig')
+    @patch('mash.services.download_service.OBSImageBuildResultService')
     def test_main(self, mock_OBSImageBuildResultService, mock_config):
         config = Mock()
         mock_config.return_value = config
 
         main()
         mock_OBSImageBuildResultService.assert_called_once_with(
-            service_exchange='obs',
+            service_exchange='download',
             config=config
         )
 
-    @patch('mash.services.obs_service.BaseConfig')
-    @patch('mash.services.obs_service.OBSImageBuildResultService')
+    @patch('mash.services.download_service.BaseConfig')
+    @patch('mash.services.download_service.OBSImageBuildResultService')
     @patch('sys.exit')
     def test_main_mash_error(
         self, mock_exit, mock_OBSImageBuildResultService, mock_conofig
@@ -27,8 +27,8 @@ class TestOBS(object):
         main()
         mock_exit.assert_called_once_with(1)
 
-    @patch('mash.services.obs_service.BaseConfig')
-    @patch('mash.services.obs_service.OBSImageBuildResultService')
+    @patch('mash.services.download_service.BaseConfig')
+    @patch('mash.services.download_service.OBSImageBuildResultService')
     @patch('sys.exit')
     def test_main_keyboard_interrupt(
         self, mock_exit, mock_OBSImageBuildResultService, mock_config
@@ -37,8 +37,8 @@ class TestOBS(object):
         main()
         mock_exit.assert_called_once_with(0)
 
-    @patch('mash.services.obs_service.BaseConfig')
-    @patch('mash.services.obs_service.OBSImageBuildResultService')
+    @patch('mash.services.download_service.BaseConfig')
+    @patch('mash.services.download_service.OBSImageBuildResultService')
     @patch('sys.exit')
     def test_main_system_exit(
         self, mock_exit, mock_OBSImageBuildResultService, mock_config
@@ -47,8 +47,8 @@ class TestOBS(object):
         main()
         mock_exit.assert_called_once_with(0)
 
-    @patch('mash.services.obs_service.BaseConfig')
-    @patch('mash.services.obs_service.OBSImageBuildResultService')
+    @patch('mash.services.download_service.BaseConfig')
+    @patch('mash.services.download_service.OBSImageBuildResultService')
     @patch('sys.exit')
     def test_main_unexpected_error(
         self, mock_exit, mock_OBSImageBuildResultService, mock_config

--- a/test/unit/services/download/service_test.py
+++ b/test/unit/services/download/service_test.py
@@ -7,17 +7,17 @@ from test.unit.test_helper import (
     patch_open
 )
 
-from mash.services.obs.service import OBSImageBuildResultService
+from mash.services.download.obs_job import OBSImageBuildResultService
 from mash.services.mash_service import MashService
 
 
 class TestOBSImageBuildResultService(object):
 
-    @patch('mash.services.obs.service.os.makedirs')
-    @patch('mash.services.obs.service.setup_logfile')
+    @patch('mash.services.download.obs_job.os.makedirs')
+    @patch('mash.services.download.obs_job.setup_logfile')
     @patch.object(OBSImageBuildResultService, '_process_message')
     @patch.object(OBSImageBuildResultService, '_send_job_result_for_upload')
-    @patch('mash.services.obs.service.restart_jobs')
+    @patch('mash.services.download.obs_job.restart_jobs')
     @patch.object(MashService, '__init__')
     @patch('os.listdir')
     @patch('logging.getLogger')
@@ -30,60 +30,60 @@ class TestOBSImageBuildResultService(object):
     ):
         config = Mock()
         config.get_log_file.return_value = 'logfile'
-        config.get_job_directory.return_value = '/var/lib/mash/obs_jobs/'
+        config.get_job_directory.return_value = '/var/lib/mash/download_jobs/'
         self.log = Mock()
         mock_listdir.return_value = ['job']
         mock_MashService.return_value = None
 
-        self.obs_result = OBSImageBuildResultService()
+        self.download_result = OBSImageBuildResultService()
 
-        self.obs_result.log = self.log
-        self.obs_result.config = config
-        self.obs_result.consume_queue = Mock()
-        self.obs_result.bind_service_queue = Mock()
-        self.obs_result.channel = Mock()
-        self.obs_result.channel.is_open = True
-        self.obs_result.close_connection = Mock()
-        self.obs_result.service_exchange = 'obs'
-        self.obs_result.service_queue = 'service'
-        self.obs_result.next_service = 'upload'
-        self.obs_result.job_document_key = 'job_document'
-        self.obs_result.listener_msg_key = 'listener_msg'
+        self.download_result.log = self.log
+        self.download_result.config = config
+        self.download_result.consume_queue = Mock()
+        self.download_result.bind_service_queue = Mock()
+        self.download_result.channel = Mock()
+        self.download_result.channel.is_open = True
+        self.download_result.close_connection = Mock()
+        self.download_result.service_exchange = 'obs'
+        self.download_result.service_queue = 'service'
+        self.download_result.next_service = 'upload'
+        self.download_result.job_document_key = 'job_document'
+        self.download_result.listener_msg_key = 'listener_msg'
 
-        self.obs_result.post_init()
+        self.download_result.post_init()
 
         config.get_job_directory.assert_called_once_with('obs')
         mock_makedirs.assert_called_once_with(
-            '/var/lib/mash/obs_jobs/', exist_ok=True
+            '/var/lib/mash/download_jobs/', exist_ok=True
         )
 
         mock_setup_logfile.assert_called_once_with('logfile')
         mock_restart_jobs.assert_called_once_with(
-            '/var/lib/mash/obs_jobs/',
-            self.obs_result._start_job
+            '/var/lib/mash/download_jobs/',
+            self.download_result._start_job
         )
 
-        self.obs_result.consume_queue.assert_called_once_with(
+        self.download_result.consume_queue.assert_called_once_with(
             mock_process_message, 'service', 'obs'
         )
-        self.obs_result.channel.start_consuming.assert_called_once_with()
+        self.download_result.channel.start_consuming.assert_called_once_with()
 
-        self.obs_result.channel.start_consuming.side_effect = Exception
+        self.download_result.channel.start_consuming.side_effect = Exception
         with raises(Exception):
-            self.obs_result.post_init()
-            self.obs_result.close_connection.assert_called_once_with()
+            self.download_result.post_init()
+            self.download_result.close_connection.assert_called_once_with()
 
-        self.obs_result.channel.start_consuming.side_effect = KeyboardInterrupt()
-        self.obs_result.post_init()
+        self.download_result.channel.start_consuming.side_effect = KeyboardInterrupt()
+        self.download_result.post_init()
 
     @patch.object(MashService, '_publish')
     @patch.object(OBSImageBuildResultService, '_delete_job')
     def test_send_job_result_for_upload(
         self, mock_delete_job, mock_publish
     ):
-        self.obs_result.jobs['815'] = Mock()
-        self.obs_result.jobs['815'].job_nonstop = False
-        self.obs_result._send_job_result_for_upload('815', {})
+        self.download_result.jobs['815'] = Mock()
+        self.download_result.jobs['815'].job_nonstop = False
+        self.download_result._send_job_result_for_upload('815', {})
         mock_delete_job.assert_called_once_with('815')
         mock_publish.assert_called_once_with(
             'obs', 'listener_msg', '{}'
@@ -94,8 +94,8 @@ class TestOBSImageBuildResultService(object):
             'message': 'message',
             'ok': False
         }
-        self.obs_result._send_control_response(result, '4711')
-        self.obs_result.log.error.assert_called_once_with(
+        self.download_result._send_control_response(result, '4711')
+        self.download_result.log.error.assert_called_once_with(
             'message',
             extra={'job_id': '4711'}
         )
@@ -105,8 +105,8 @@ class TestOBSImageBuildResultService(object):
             'message': 'message',
             'ok': True
         }
-        self.obs_result._send_control_response(result)
-        self.obs_result.log.info.assert_called_once_with(
+        self.download_result._send_control_response(result)
+        self.download_result.log.info.assert_called_once_with(
             'message',
             extra={}
         )
@@ -121,16 +121,16 @@ class TestOBSImageBuildResultService(object):
     ):
         message = Mock()
         message.method = {'routing_key': 'job_document'}
-        message.body = '{"obs_job":{"id": "4711","download_url": ' + \
+        message.body = '{"download_job":{"id": "4711","download_url": ' + \
             '"http://download.suse.de/ibs/Devel:/PubCloud:/Stable:/' + \
             'Images12/images","image": ' + \
             '"test-image-docker","utctime": ' + \
             '"always"}}'
-        self.obs_result._process_message(message)
+        self.download_result._process_message(message)
         message.ack.assert_called_once_with()
         mock_add_job.assert_called_once_with(
             {
-                'obs_job': {
+                'download_job': {
                     "download_url": "http://download.suse.de/ibs/Devel:/"
                                     "PubCloud:/Stable:/Images12/images",
                     'image': 'test-image-docker',
@@ -141,10 +141,10 @@ class TestOBSImageBuildResultService(object):
         )
 
         message.body = '{"job_delete": "4711"}'
-        self.obs_result._process_message(message)
+        self.download_result._process_message(message)
 
         message.body = 'foo'
-        self.obs_result._process_message(message)
+        self.download_result._process_message(message)
         assert mock_send_control_response.call_args_list == [
             call(mock_add_job.return_value, '4711'),
             call(
@@ -165,13 +165,13 @@ class TestOBSImageBuildResultService(object):
             )
         ]
 
-    @patch('mash.services.obs.service.persist_json')
+    @patch('mash.services.download.obs_job.persist_json')
     @patch.object(OBSImageBuildResultService, '_start_job')
     @patch_open
     def test_add_job(self, mock_open, mock_start_job, mock_persist_json):
-        self.obs_result.job_directory = 'tmp/'
+        self.download_result.job_directory = 'tmp/'
         job_data = {
-            "obs_job": {
+            "download_job": {
                 "id": "123",
                 "download_url": "http://download.suse.de/ibs/Devel:/"
                                 "PubCloud:/Stable:/Images12/images",
@@ -189,39 +189,39 @@ class TestOBSImageBuildResultService(object):
                 ]
             }
         }
-        self.obs_result._add_job(job_data)
+        self.download_result._add_job(job_data)
         mock_persist_json.assert_called_once_with(
             'tmp/job-123.json',
-            job_data['obs_job']
+            job_data['download_job']
         )
-        mock_start_job.assert_called_once_with(job_data['obs_job'])
+        mock_start_job.assert_called_once_with(job_data['download_job'])
 
     @patch('os.remove')
     def test_delete_job(self, mock_os_remove):
-        assert self.obs_result._delete_job('815') == {
+        assert self.download_result._delete_job('815') == {
             'message': 'Job does not exist, can not delete it', 'ok': False
         }
         job_worker = Mock()
         job_worker.job_file = 'job_file'
-        self.obs_result.jobs = {'815': job_worker}
-        assert self.obs_result._delete_job('815') == {
+        self.download_result.jobs = {'815': job_worker}
+        assert self.download_result._delete_job('815') == {
             'message': 'Job Deleted', 'ok': True
         }
         mock_os_remove.assert_called_once_with('job_file')
         job_worker.stop_watchdog.assert_called_once_with()
-        assert '815' not in self.obs_result.jobs
-        self.obs_result.jobs = {'815': job_worker}
+        assert '815' not in self.download_result.jobs
+        self.download_result.jobs = {'815': job_worker}
         mock_os_remove.side_effect = Exception('remove_error')
-        assert self.obs_result._delete_job('815') == {
+        assert self.download_result._delete_job('815') == {
             'message': 'Job deletion failed: remove_error', 'ok': False
         }
 
-    @patch('mash.services.obs.service.OBSImageBuildResult')
+    @patch('mash.services.download.obs_job.OBSImageBuildResult')
     def test_start_job_with_conditions(self, mock_OBSImageBuildResult):
         job_worker = Mock()
         mock_OBSImageBuildResult.return_value = job_worker
-        self.obs_result._send_job_response = Mock()
-        self.obs_result._send_job_result_for_upload = Mock()
+        self.download_result._send_job_response = Mock()
+        self.download_result._send_job_result_for_upload = Mock()
         data = {
             "id": "123",
             "job_file": "tempfile",
@@ -248,15 +248,15 @@ class TestOBSImageBuildResultService(object):
             "disallow_licenses": ["MIT"],
             "disallow_packages": ["*-mini"]
         }
-        self.obs_result._start_job(data)
+        self.download_result._start_job(data)
         job_worker.set_result_handler.assert_called_once_with(
-            self.obs_result._send_job_result_for_upload
+            self.download_result._send_job_result_for_upload
         )
         job_worker.start_watchdog.assert_called_once_with(
             isotime=None
         )
 
-    @patch('mash.services.obs.service.OBSImageBuildResult')
+    @patch('mash.services.download.obs_job.OBSImageBuildResult')
     def test_start_job_without_conditions(self, mock_OBSImageBuildResult):
         job_worker = Mock()
         mock_OBSImageBuildResult.return_value = job_worker
@@ -269,12 +269,12 @@ class TestOBSImageBuildResultService(object):
             "last_service": "publish",
             "utctime": "now"
         }
-        self.obs_result._start_job(data)
+        self.download_result._start_job(data)
         job_worker.start_watchdog.assert_called_once_with(
             isotime=None
         )
 
-    @patch('mash.services.obs.service.OBSImageBuildResult')
+    @patch('mash.services.download.obs_job.OBSImageBuildResult')
     def test_start_job_at_utctime(self, mock_OBSImageBuildResult):
         job_worker = Mock()
         mock_OBSImageBuildResult.return_value = job_worker
@@ -287,7 +287,7 @@ class TestOBSImageBuildResultService(object):
             "last_service": "publish",
             "utctime": "Wed Oct 11 17:50:26 UTC 2017"
         }
-        self.obs_result._start_job(data)
+        self.download_result._start_job(data)
         job_worker.start_watchdog.assert_called_once_with(
             isotime='2017-10-11T17:50:26+00:00'
         )

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -13,7 +13,7 @@ class TestJobCreatorService(object):
     @patch.object(MashService, '__init__')
     def setup_method(self, method, mock_base_init):
         services = [
-            'obs', 'upload', 'create', 'test', 'raw_image_upload',
+            'download', 'upload', 'create', 'test', 'raw_image_upload',
             'replicate', 'publish', 'deprecate'
         ]
         mock_base_init.return_value = None
@@ -103,9 +103,9 @@ class TestJobCreatorService(object):
         message.body = JsonFormat.json_message(job)
         self.jobcreator._handle_service_message(message)
 
-        # OBS Job Doc
+        # Download Job Doc
 
-        data = json.loads(mock_publish.mock_calls[0][1][2])['obs_job']
+        data = json.loads(mock_publish.mock_calls[0][1][2])['download_job']
         check_base_attrs(data, cloud=False)
         assert data['cloud_architecture'] == 'aarch64'
         assert data['download_url'] == \
@@ -243,9 +243,9 @@ class TestJobCreatorService(object):
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
 
-        # OBS Job Doc
+        # Download Job Doc
 
-        data = json.loads(mock_publish.mock_calls[0][1][2])['obs_job']
+        data = json.loads(mock_publish.mock_calls[0][1][2])['download_job']
         check_base_attrs(data, cloud=False)
         assert data['cloud_architecture'] == 'x86_64'
         assert data['download_url'] == \
@@ -344,9 +344,9 @@ class TestJobCreatorService(object):
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
 
-        # OBS Job Doc
+        # Download Job Doc
 
-        data = json.loads(mock_publish.mock_calls[0][1][2])['obs_job']
+        data = json.loads(mock_publish.mock_calls[0][1][2])['download_job']
         check_base_attrs(data, cloud=False)
         assert data['cloud_architecture'] == 'x86_64'
         assert data['download_url'] == \
@@ -434,9 +434,9 @@ class TestJobCreatorService(object):
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
 
-        # OBS Job Doc
+        # Download Job Doc
 
-        data = json.loads(mock_publish.mock_calls[0][1][2])['obs_job']
+        data = json.loads(mock_publish.mock_calls[0][1][2])['download_job']
         check_base_attrs(data, cloud=False)
         assert data['cloud_architecture'] == 'x86_64'
         assert data['download_url'] == \
@@ -665,9 +665,9 @@ class TestJobCreatorService(object):
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)
 
-        # OBS Job Doc
+        # Download Job Doc
 
-        data = json.loads(mock_publish.mock_calls[0][1][2])['obs_job']
+        data = json.loads(mock_publish.mock_calls[0][1][2])['download_job']
         check_base_attrs(data, cloud=False)
         assert data['cloud_architecture'] == 'x86_64'
         assert data['download_url'] == \

--- a/test/unit/services/listener/service_test.py
+++ b/test/unit/services/listener/service_test.py
@@ -22,7 +22,7 @@ class TestListenerService(object):
         self.config = Mock()
         self.config.config_data = None
         self.config.get_service_names.return_value = [
-            'obs', 'upload', 'test', 'replicate', 'publish',
+            'download', 'upload', 'test', 'replicate', 'publish',
             'deprecate'
         ]
         self.config.get_job_directory.return_value = '/var/lib/mash/replicate_jobs/'
@@ -564,7 +564,7 @@ class TestListenerService(object):
         assert prev_service is None
 
         # Test service as beginning of pipeline
-        self.service.service_exchange = 'obs'
+        self.service.service_exchange = 'download'
         prev_service = self.service._get_previous_service()
         assert prev_service is None
 

--- a/test/unit/utils/json_format_test.py
+++ b/test/unit/utils/json_format_test.py
@@ -6,7 +6,7 @@ class TestJsonFormat(object):
         with open('test/data/job1.json') as file_handle:
             assert JsonFormat.json_load(
                 file_handle
-            )['obsjob']['id'] == '123'
+            )['downloadjob']['id'] == '123'
 
     def test_json_loads(self):
         assert JsonFormat.json_loads('["a", "b"]') == ['a', 'b']
@@ -15,7 +15,7 @@ class TestJsonFormat(object):
         }
 
     def test_json_message(self):
-        message = '{"obsjob_delete": "4711"}'
+        message = '{"downloadjob_delete": "4711"}'
         dump_load = JsonFormat.json_loads(
             JsonFormat.json_message(message)
         )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
First PR from a series to make the download service extendable. This will allow us to have different image sources than IBS repositories (as for example S3 buckets).

This PR just changes the name of the service from `obs` to a more generic `download` service.

Note that in order not to break `mash` build, we're using a feature branch that will be merged into main when the whole change is finished and tested.

### How will these changes be tested?

### How will this change be deployed? Any special considerations?

### Additional Information
