### PR TITLE
Remove some last obs service references

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,12 +425,14 @@ See [.virtualenv.requirements.txt](https://github.com/SUSE-Enceladus/mash/.virtu
 The implementation of the Mash is based on a collection of services. Each service completes
 an individual task of the process. At present the following services exist:
 
-- __OBS (retrieval) service__:
-  
-  Images are built in a build service. The retrieval service currently relies
-  on [OBS](https://openbuildservice.org/). The service Validates that a compute
-  image in OBS meets certain conditions. When conditions are met the image is
-  downloaded locally.
+- __Download service__:
+
+  Images are built in a build service or provided from some other source. The
+  download service currently relies on [OBS](https://openbuildservice.org/) or
+  a storage solution (S3 bucket) to provide the image files.
+  For OBS, the service can validate that a compute image in OBS meets certain
+  conditions. When conditions are met the image is downloaded locally.
+  For S3 buckets, the images are downloaded directly from the S3 bucket.
 
 The remaining services have cloud framework specific implementations. The services
 handle communication via a centralized message broker. By default MASH has been
@@ -601,7 +603,7 @@ openAPI spec which is used to host the Swagger based API docs.
 
 ## License
 
-Copyright (c) 2022 SUSE LLC.
+Copyright (c) 2023 SUSE LLC.
 
 Distributed under the terms of GPL-3.0+ license, see
 [LICENSE](LICENSE) for details.

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -15,7 +15,7 @@ database_api_url: http://localhost:5007/
 database_uri: sqlite:////var/lib/mash/app.db
 download_directory: /var/lib/mash/images
 services:
-  - obs
+  - download
   - upload
   - create
   - test
@@ -24,7 +24,7 @@ services:
   - publish
   - deprecate
 non_cred_services:
-  - obs
+  - download
 credentials:
   credentials_directory: /var/lib/mash/credentials/
 cloud:

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -18,14 +18,14 @@ base_thread_pool_count: 20
 publish_thread_pool_count: 60
 download_directory: /images
 services:
-  - obs
+  - download
   - upload
   - test
   - replicate
   - publish
   - deprecate
 non_cred_services:
-  - obs
+  - download
 cloud:
   ec2:
     regions:

--- a/test/unit/services/api/v1/utils/jobs/aliyun_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/aliyun_job_utils_test.py
@@ -40,7 +40,7 @@ def test_update_aliyun_job_accounts(
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
-            'obs',
+            'download',
             'upload',
             'create',
             'test',

--- a/test/unit/services/download/service_test.py
+++ b/test/unit/services/download/service_test.py
@@ -44,7 +44,7 @@ class TestOBSImageBuildResultService(object):
         self.download_result.channel = Mock()
         self.download_result.channel.is_open = True
         self.download_result.close_connection = Mock()
-        self.download_result.service_exchange = 'obs'
+        self.download_result.service_exchange = 'download'
         self.download_result.service_queue = 'service'
         self.download_result.next_service = 'upload'
         self.download_result.job_document_key = 'job_document'
@@ -52,7 +52,7 @@ class TestOBSImageBuildResultService(object):
 
         self.download_result.post_init()
 
-        config.get_job_directory.assert_called_once_with('obs')
+        config.get_job_directory.assert_called_once_with('download')
         mock_makedirs.assert_called_once_with(
             '/var/lib/mash/download_jobs/', exist_ok=True
         )
@@ -64,7 +64,7 @@ class TestOBSImageBuildResultService(object):
         )
 
         self.download_result.consume_queue.assert_called_once_with(
-            mock_process_message, 'service', 'obs'
+            mock_process_message, 'service', 'download'
         )
         self.download_result.channel.start_consuming.assert_called_once_with()
 
@@ -86,7 +86,7 @@ class TestOBSImageBuildResultService(object):
         self.download_result._send_job_result_for_upload('815', {})
         mock_delete_job.assert_called_once_with('815')
         mock_publish.assert_called_once_with(
-            'obs', 'listener_msg', '{}'
+            'download', 'listener_msg', '{}'
         )
 
     def test_send_control_response_local(self):


### PR DESCRIPTION

Found some missing references to `obs` service that where not changed in the previous PR, like the Readme file and some tests.

### What does this PR do? Why are we making this change?
### How will these changes be tested?
### How will this change be deployed? Any special considerations?
### Additional Information
