### PR TITLE
S3 download class implementation

### DIFF
--- a/mash/services/api/v1/schema/jobs/__init__.py
+++ b/mash/services/api/v1/schema/jobs/__init__.py
@@ -92,6 +92,19 @@ base_job_message = {
                         'Build1.206.vhdfixed.xz.sha256 The "image" is '
                         'openSUSE-Leap-15.0-EC2-HVM.'
         ),
+        's3_download_file_prefix': string_with_example(
+            'suse-',
+            description='This should include any prefix that is prepended in'
+                        'the image filename present when image files are'
+                        'downloaded from an S3 bucket'
+        ),
+        's3_download_file_suffix': string_with_example(
+            '.tar.gz',
+            description='This should include any suffix that is included in '
+                        'the image filename present, after the architecture'
+                        'substring when image files are downloaded from an S3'
+                        ' bucket.'
+        ),
         'cloud_image_name': string_with_example(
             'openSUSE-Leap-15.0-v{date}-hvm-ssd-x86_64',
             description='The name to use for the uploaded image in the cloud '
@@ -128,6 +141,14 @@ base_job_message = {
                            'itself. Valid condition operators are >, <, >=, '
                            '<=, or ==.'
         },
+        'download_account': string_with_example(
+            'my_aws_account',
+            description='The cloud framework account as configured with '
+                        'the mash account add client command when the mash '
+                        'user was setup. The credentials associated with '
+                        'this cloud framework account will be used for the '
+                        'image download.'
+        ),
         'download_type': string_with_example(
             'OBS',
             description='Service from which to download the image file.'
@@ -140,9 +161,12 @@ base_job_message = {
         'download_url': string_with_example(
             'https://download.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
-            description='The URL to a download repository. The URL is '
+            description='The URL to a download repository.'
+                        'In the case of OBS download, the URL is '
                         'expected to have the image tarball, checksum and '
                         'a packages file.'
+                        'For the S3 download case, it contains the URL of the'
+                        'S3 bucket containing the image file.'
         ),
         'image_description': string_with_example(
             'openSUSE Leap 15.0 (HVM, 64-bit, SSD-Backed)',

--- a/mash/services/download/s3_job.py
+++ b/mash/services/download/s3_job.py
@@ -21,8 +21,7 @@ import logging
 import re
 import os
 
-from datetime import datetime
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone
 from pytz import utc
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.events import EVENT_JOB_SUBMITTED
@@ -212,7 +211,7 @@ class S3DownloadJob(object):
             date_str = match.group(1)
             date_str = date_str + 'T00:00:00.000'
             date = datetime.strptime(date_str, '%Y%m%dT%H:%M:%S.%f').replace(
-                tzinfo=ZoneInfo('UTC')
+                tzinfo=timezone.utc
             )
             return date.strftime('%s')
         else:

--- a/mash/services/download/s3_job.py
+++ b/mash/services/download/s3_job.py
@@ -18,10 +18,9 @@
 
 
 import logging
-import re
 import os
 
-from datetime import datetime, timezone
+from datetime import datetime
 from pytz import utc
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.events import EVENT_JOB_SUBMITTED
@@ -206,16 +205,7 @@ class S3DownloadJob(object):
             )
 
     def _get_build_time(self, image_name):
-        match = re.search(r'^.*-v(\d{8})-.*', image_name)
-        if match:
-            date_str = match.group(1)
-            date_str = date_str + 'T00:00:00.000'
-            date = datetime.strptime(date_str, '%Y%m%dT%H:%M:%S.%f').replace(
-                tzinfo=timezone.utc
-            )
-            return date.strftime('%s')
-        else:
-            return 'unknown'
+        return 'unknown'
 
     def _job_skipped_event(self, event):
         # Job is still active while the next _update_image_status

--- a/mash/services/download/s3_job.py
+++ b/mash/services/download/s3_job.py
@@ -16,6 +16,210 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+
+import logging
+import re
+import os
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from pytz import utc
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.events import EVENT_JOB_SUBMITTED
+# project
+from mash.services.base_defaults import Defaults
+from mash.utils.ec2 import get_client
+
+
 class S3DownloadJob(object):
-    # To Be Completed
-    pass
+    """
+    Implements S3 bucket image download job
+
+    Attributes
+
+    * :attr:`job_id`
+      job id number
+
+    * :attr:`job_file`
+      job file containing the job description
+
+    * :attr:`download_url`
+      S3 bucket URL
+
+    * :attr:`download_directory`
+      Download directory name, defaults to: /tmp
+
+    * :attr:`last_service`
+      The last service for the job.
+
+
+    """
+    def __init__(
+        self,
+        job_id,
+        job_file,
+        download_url,
+        image_name,
+        cloud_architecture,
+        s3_download_file_prefix,
+        s3_download_file_suffix,
+        last_service,
+        log_callback,
+        notification_email,
+        download_account,
+        download_credentials,
+        download_directory=Defaults.get_download_dir(),
+    ):
+        self.job_id = job_id
+        self.job_file = job_file
+        self.download_directory = os.path.join(download_directory, job_id)
+        self.download_url = download_url
+        self.image_name = image_name
+        self.last_service = last_service
+        self.log_callback = logging.LoggerAdapter(
+            log_callback,
+            {'job_id': self.job_id}
+        )
+        self.notification_email = notification_email
+        self.job_status = 'prepared'
+        self.progress_log = {}
+        self.errors = []
+        self.scheduler = None
+        self.job_deleted = False
+        self.download_account = download_account
+        self.download_credentials = download_credentials
+        self.s3_download_file_prefix = s3_download_file_prefix
+        self.s3_download_file_suffix = s3_download_file_suffix
+        self.image_filename = (
+            f'{s3_download_file_prefix}'
+            f'{image_name}'
+            f'-{cloud_architecture}'
+            f'{s3_download_file_suffix}'
+        )
+
+    def set_result_handler(self, function):
+        self.result_callback = function
+
+    def call_result_handler(self):
+        self._result_callback()
+
+    def start_watchdog(self, isotime=None):
+        """
+        Start a background job which fetches the image from the S3 bucket.
+
+        The job is started at a given data/time which must
+        be the result of a isoformat() call. If no data/time is
+        specified the job runs immediately.
+
+        :param string isotime: data and time by isoformat()
+        """
+        job_time = None
+
+        if isotime:
+            job_time = datetime.strptime(isotime[:19], '%Y-%m-%dT%H:%M:%S')
+
+        self.scheduler = BackgroundScheduler(timezone=utc)
+
+        self.job = self.scheduler.add_job(
+            self._download_image_file,
+            'date',
+            run_date=job_time,
+            timezone='utc'
+        )
+        self.scheduler.add_listener(
+            self._job_submit_event, EVENT_JOB_SUBMITTED
+        )
+        self.scheduler.start()
+
+    def stop_watchdog(self):
+        """
+        Remove active job from scheduler
+
+        Current image status is retained
+        """
+        try:
+            self.job.remove()
+            self.job_deleted = True
+        except Exception:
+            pass
+
+    def _job_submit_event(self, event):
+        self.log_callback.info('Oneshot Job submitted')
+
+    def _download_image_file(self):
+        """ Download the image file to the destination directory"""
+        self.log_callback.info('Job running')
+
+        try:
+
+            client = get_client(
+                's3',
+                self.download_credentials['access_key_id'],
+                self.download_credentials['secret_access_key'],
+                None
+            )
+            destination_file = os.path.join(
+                self.download_directory, self.image_filename
+            )
+            client.download_fileobj(
+                self.download_url,
+                self.image_filename,
+                destination_file
+            )
+            self.log_callback.info('Downloaded: {0} from {1} S3 bucket'.format(
+                self.image_filename,
+                self.download_url
+            ))
+
+            # job finished successfully
+            self.job_status = 'success'
+            self.log_callback.info(
+                'Job status: {0}'.format(self.job_status)
+            )
+            self._result_callback()
+            self.log_callback.info('Job done')
+        except Exception as issue:
+
+            msg = '{0}: {1}'.format(type(issue).__name__, issue)
+            self.job_status = 'failed'
+            self.errors.append(msg)
+            self.log_callback.error(msg)
+            self._result_callback()
+
+    def _result_callback(self):
+        if self.result_callback:
+            self.result_callback(
+                self.job_id, {
+                    'download_result': {
+                        'id': self.job_id,
+                        'image_file': os.path.join(
+                            self.download_directory,
+                            self.image_filename
+                        ),
+                        'status': self.job_status,
+                        'errors': self.errors,
+                        'notification_email': self.notification_email,
+                        'last_service': self.last_service,
+                        'build_time':
+                            self._get_build_time(self.image_name),
+                    }
+                }
+            )
+
+    def _get_build_time(self, image_name):
+        match = re.search(r'^.*-v(\d{8})-.*', image_name)
+        if match:
+            date_str = match.group(1)
+            date_str = date_str + 'T00:00:00.000'
+            date = datetime.strptime(date_str, '%Y%m%dT%H:%M:%S.%f').replace(
+                tzinfo=ZoneInfo('UTC')
+            )
+            return date.strftime('%s')
+        else:
+            return 'unknown'
+
+    def _job_skipped_event(self, event):
+        # Job is still active while the next _update_image_status
+        # event was scheduled. In this case we just skip the event
+        # and keep the active job waiting for an obs change
+        pass

--- a/mash/services/download/service.py
+++ b/mash/services/download/service.py
@@ -246,6 +246,14 @@ class DownloadService(MashService):
             kwargs['disallow_packages'] = job['disallow_packages']
 
         if 'download_type' in job and job['download_type'] == 'S3':
+            # Fetching the images from a S3 bucket
+            kwargs['download_account'] = job.get('download_account', 'default')
+            kwargs['download_credentials'] = self.request_credentials(
+                [kwargs['download_account']],
+                'ec2'
+            )
+            kwargs['s3_download_file_prefix'] = job['s3_download_file_prefix']
+            kwargs['s3_download_file_suffix'] = job['s3_download_file_suffix']
             job_worker = S3DownloadJob(**kwargs)
         else:
             job_worker = OBSDownloadJob(**kwargs)

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -70,6 +70,10 @@ class BaseJob(object):
         self.use_build_time = kwargs.get('use_build_time')
         self.force_replace_image = kwargs.get('force_replace_image')
         self.download_type = kwargs.get('download_type', 'OBS')
+        self.s3_download_file_prefix = \
+            kwargs.get('s3_download_file_prefix', '')
+        self.s3_download_file_suffix = \
+            kwargs.get('s3_download_file_suffix', '')
         self.kwargs = kwargs
 
         if self.raw_image_upload_type and self.last_service == 'upload':
@@ -107,7 +111,7 @@ class BaseJob(object):
         download_message = {
             'download_job': {
                 'download_url': self.download_url,
-                'image': self.image
+                'image': self.image,
             }
         }
         download_message['download_job'].update(self.base_message)
@@ -137,6 +141,14 @@ class BaseJob(object):
         if self.download_type:
             download_message['download_job']['download_type'] = \
                 self.download_type
+
+        if self.s3_download_file_prefix:
+            download_message['download_job']['s3_download_file_prefix'] = \
+                self.s3_download_file_prefix
+
+        if self.s3_download_file_suffix:
+            download_message['download_job']['s3_download_file_suffix'] = \
+                self.s3_download_file_suffix
 
         return JsonFormat.json_message(download_message)
 

--- a/test/unit/services/download/s3_job_test.py
+++ b/test/unit/services/download/s3_job_test.py
@@ -1,0 +1,262 @@
+from unittest.mock import (
+    patch, call, MagicMock, Mock
+)
+from pytz import utc
+from datetime import datetime
+import dateutil.parser
+
+from apscheduler.events import EVENT_JOB_SUBMITTED
+
+from mash.services.download.s3_job import S3DownloadJob
+
+
+class TestS3DownloadJob(object):
+    @patch('mash.services.download.s3_job.logging')
+    # @patch('mash.utils.ec2.get_client')
+    def setup_method(self, method, mock_logging):
+        # def setup_method(self, method, mock_get_client, mock_logging):
+        self.logger = MagicMock()
+        # self.downloader = MagicMock()
+    #     mock_obs_img_util.return_value = self.downloader
+
+        self.log_callback = MagicMock()
+        mock_logging.LoggerAdapter.return_value = self.log_callback
+
+        self.download_result = S3DownloadJob(
+            '815',
+            'job_file',
+            's3://my_s3_bucket',
+            'my_image_name-v20231231-lto',
+            'x86_64',
+            'suse-',
+            '.raw.xz',
+            'upload',
+            self.log_callback,
+            notification_email='test@fake.com',
+            download_account='download_account',
+            download_credentials={
+                'access_key_id': 'my_access_key_id',
+                'secret_access_key': 'my_secret_access_key'
+            },
+            download_directory="/tmp/download_directory"
+        )
+
+    def test_set_result_handler(self):
+        function = Mock()
+        self.download_result.set_result_handler(function)
+        assert self.download_result.result_callback == function
+
+    @patch.object(S3DownloadJob, '_result_callback')
+    def test_call_result_handler(self, mock_result_callback):
+        self.download_result.call_result_handler()
+        mock_result_callback.assert_called_once_with()
+
+    def test_result_callback(self):
+        self.download_result.result_callback = Mock()
+        self.download_result.job_status = 'success'
+        # self.downloader.build_time = '1703977200'
+        self.download_result._result_callback()
+        self.download_result.result_callback.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz',  # NOQA
+                    'status': 'success',
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': '1703977200'
+                }
+            }
+        )
+
+    def test_result_callback_unknown_build_time(self):
+        self.download_result.result_callback = Mock()
+        self.download_result.job_status = 'success'
+        orig_image_name = self.download_result.image_name
+        self.download_result.image_name = 'my_image_name'
+        # self.downloader.build_time = 'unknown'
+        self.download_result._result_callback()
+        self.download_result.result_callback.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz',  # NOQA
+                    'status': 'success',
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': 'unknown'
+                }
+            }
+        )
+        self.download_result.image_name = orig_image_name
+
+    @patch('mash.services.download.s3_job.BackgroundScheduler')
+    @patch.object(S3DownloadJob, '_download_image_file')
+    @patch.object(S3DownloadJob, '_job_submit_event')
+    def test_start_watchdog_single_shot(
+        self, mock_job_submit_event, mock_download_image_file,
+        mock_BackgroundScheduler
+    ):
+        scheduler = Mock()
+        mock_BackgroundScheduler.return_value = scheduler
+        time = 'Tue Oct 10 14:40:42 UTC 2017'
+        iso_time = dateutil.parser.parse(time).isoformat()
+        run_time = datetime.strptime(iso_time[:19], '%Y-%m-%dT%H:%M:%S')
+        self.download_result.start_watchdog(isotime=iso_time)
+        mock_BackgroundScheduler.assert_called_once_with(
+            timezone=utc
+        )
+        scheduler.add_job.assert_called_once_with(
+            mock_download_image_file, 'date', run_date=run_time,
+            timezone='utc'
+        )
+        scheduler.add_listener.assert_called_once_with(
+            mock_job_submit_event, EVENT_JOB_SUBMITTED
+        )
+        scheduler.start.assert_called_once_with()
+
+    def test_stop_watchdog_no_exception(self):
+        self.download_result.job = Mock()
+        self.download_result.stop_watchdog()
+        self.download_result.job.remove.assert_called_once_with()
+
+    def test_stop_watchdog_just_pass_with_exception(self):
+        self.download_result.job = Mock()
+        self.download_result.job.remove.side_effect = Exception
+        self.download_result.stop_watchdog()
+
+    def test_job_submit_event(self):
+        self.download_result._job_submit_event(Mock())
+        self.log_callback.info.assert_called_once_with('Oneshot Job submitted')
+
+    @patch.object(S3DownloadJob, '_result_callback')
+    def test_job_skipped_event(self, mock_result_callback):
+        self.download_result._job_skipped_event(Mock())
+
+    # @patch.object(S3DownloadJob, '_result_callback')
+    @patch('mash.services.download.s3_job.get_client')
+    def test_download_image_file(self, mock_get_client):
+        # set up
+        client_mock = MagicMock()
+        mock_get_client.return_value = client_mock
+        self.download_result.result_callback = Mock()
+
+        # test
+        self.download_result._download_image_file()
+
+        # assertions
+        mock_get_client.assert_called_once_with(
+            's3',
+            'my_access_key_id',
+            'my_secret_access_key',
+            None
+        )
+        client_mock.download_fileobj.assert_called_once_with(
+            's3://my_s3_bucket',
+            'suse-my_image_name-v20231231-lto-x86_64.raw.xz',
+            '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz'
+        )
+        log_info_calls = [
+            call('Job running'),
+            call('Downloaded: suse-my_image_name-v20231231-lto-x86_64.raw.xz from s3://my_s3_bucket S3 bucket'),
+            call('Job status: success'),
+            call('Job done')
+        ]
+        self.log_callback.info.assert_has_calls(log_info_calls, any_order=False)
+
+        self.download_result.result_callback.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz',  # NOQA
+                    'status': 'success',
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': '1703977200'
+                }
+            }
+        )
+
+    # @patch.object(S3DownloadJob, '_result_callback')
+    @patch('mash.services.download.s3_job.get_client')
+    def test_download_image_file_exception(self, mock_get_client):
+        # set up
+        client_mock = MagicMock()
+        client_mock.download_fileobj.side_effect = Exception('my_exception')
+        mock_get_client.return_value = client_mock
+        self.download_result.result_callback = Mock()
+
+        # test
+        self.download_result._download_image_file()
+
+        # assertions
+        mock_get_client.assert_called_once_with(
+            's3',
+            'my_access_key_id',
+            'my_secret_access_key',
+            None
+        )
+        client_mock.download_fileobj.assert_called_once_with(
+            's3://my_s3_bucket',
+            'suse-my_image_name-v20231231-lto-x86_64.raw.xz',
+            '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz'
+        )
+        log_info_calls = [
+            call('Job running')
+        ]
+        self.log_callback.info.assert_has_calls(log_info_calls, any_order=False)
+        self.log_callback.error.assert_called_once_with('Exception: my_exception')  # NOQA
+
+        self.download_result.result_callback.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz',  # NOQA
+                    'status': 'failed',
+                    'errors': ['Exception: my_exception'],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': '1703977200'
+                }
+            }
+        )
+
+    #     self,
+    #     mock_result_callback
+    # ):
+    #     self.downloader.get_image.return_value = 'new-image.xz'
+    #     self.download_result._update_image_status()
+    #     mock_result_callback.assert_called_once_with()
+
+    # @patch.object(S3DownloadJob, '_result_callback')
+    # def test_update_image_status_raises(
+    #     self, mock_result_callback
+    # ):
+    #     self.downloader.conditions = [{'version': '1.2.3', 'status': False}]
+    #     self.downloader.get_image.side_effect = Exception(
+    #         'request error'
+    #     )
+    #     self.download_result._update_image_status()
+    #     mock_result_callback.assert_called_once_with()
+    #     assert self.log_callback.info.call_args_list == [
+    #         call('Job running')
+    #     ]
+    #     assert self.log_callback.error.call_args_list == [
+    #         call('Exception: request error')
+    #     ]
+    #     assert len(self.download_result.errors) == 2
+
+    # def test_progress_callback(self):
+    #     self.download_result.progress_callback(0, 0, 0, done=True)
+    #     self.log_callback.info.assert_called_once_with(
+    #         'Image download finished.'
+    #     )
+    #     self.log_callback.info.reset_mock()
+
+    #     self.download_result.progress_callback(4, 25, 400)
+    #     self.log_callback.info.assert_called_once_with(
+    #         'Image 25% downloaded.'
+    #     )

--- a/test/unit/services/download/s3_job_test.py
+++ b/test/unit/services/download/s3_job_test.py
@@ -65,32 +65,10 @@ class TestS3DownloadJob(object):
                     'errors': [],
                     'notification_email': 'test@fake.com',
                     'last_service': 'upload',
-                    'build_time': '1703977200'
-                }
-            }
-        )
-
-    def test_result_callback_unknown_build_time(self):
-        self.download_result.result_callback = Mock()
-        self.download_result.job_status = 'success'
-        orig_image_name = self.download_result.image_name
-        self.download_result.image_name = 'my_image_name'
-        # self.downloader.build_time = 'unknown'
-        self.download_result._result_callback()
-        self.download_result.result_callback.assert_called_once_with(
-            '815', {
-                'download_result': {
-                    'id': '815',
-                    'image_file': '/tmp/download_directory/815/suse-my_image_name-v20231231-lto-x86_64.raw.xz',  # NOQA
-                    'status': 'success',
-                    'errors': [],
-                    'notification_email': 'test@fake.com',
-                    'last_service': 'upload',
                     'build_time': 'unknown'
                 }
             }
         )
-        self.download_result.image_name = orig_image_name
 
     @patch('mash.services.download.s3_job.BackgroundScheduler')
     @patch.object(S3DownloadJob, '_download_image_file')
@@ -175,7 +153,7 @@ class TestS3DownloadJob(object):
                     'errors': [],
                     'notification_email': 'test@fake.com',
                     'last_service': 'upload',
-                    'build_time': '1703977200'
+                    'build_time': 'unknown'
                 }
             }
         )
@@ -219,44 +197,7 @@ class TestS3DownloadJob(object):
                     'errors': ['Exception: my_exception'],
                     'notification_email': 'test@fake.com',
                     'last_service': 'upload',
-                    'build_time': '1703977200'
+                    'build_time': 'unknown'
                 }
             }
         )
-
-    #     self,
-    #     mock_result_callback
-    # ):
-    #     self.downloader.get_image.return_value = 'new-image.xz'
-    #     self.download_result._update_image_status()
-    #     mock_result_callback.assert_called_once_with()
-
-    # @patch.object(S3DownloadJob, '_result_callback')
-    # def test_update_image_status_raises(
-    #     self, mock_result_callback
-    # ):
-    #     self.downloader.conditions = [{'version': '1.2.3', 'status': False}]
-    #     self.downloader.get_image.side_effect = Exception(
-    #         'request error'
-    #     )
-    #     self.download_result._update_image_status()
-    #     mock_result_callback.assert_called_once_with()
-    #     assert self.log_callback.info.call_args_list == [
-    #         call('Job running')
-    #     ]
-    #     assert self.log_callback.error.call_args_list == [
-    #         call('Exception: request error')
-    #     ]
-    #     assert len(self.download_result.errors) == 2
-
-    # def test_progress_callback(self):
-    #     self.download_result.progress_callback(0, 0, 0, done=True)
-    #     self.log_callback.info.assert_called_once_with(
-    #         'Image download finished.'
-    #     )
-    #     self.log_callback.info.reset_mock()
-
-    #     self.download_result.progress_callback(4, 25, 400)
-    #     self.log_callback.info.assert_called_once_with(
-    #         'Image 25% downloaded.'
-    #     )


### PR DESCRIPTION
This PR includes the implementation for the `S3DownloadJob` class.

### File naming scheme

The naming scheme agreed for the image files in the bucket is the following:

```
AWS:
    suse-liberty-$MAJOR-$MINOR-byos-vYYYYMMDD-$ARCH.raw.xz

Azure
    liberty-$MAJOR-$MINOR-byos-vYYYYMMDD-$ARCH.vhdfixed.xz

Google
    liberty-$MAJOR-$MINOR-byos-vYYYYMMDD-$ARCH.tar.gz
```

A couple new fields in the `mash` job document schema are included in this PR to keep mash abstracted from these details:

- `s3_download_file_prefix`: A prefix to be prepended to the image_name for the file download. The expected value for this is `suse-` for AWS and empty string (or not include the field) for the rest of cloud providers.
- `s3_download_file_suffix`: Same but for the suffix to be appended after the `$ARCH` segment.

For the bucket address the `download_url` file is reused.

### Authentication

A new field has been included(`download_account`) in the `mash` job document to include the account that will be used to authenticate in aws to access the S3 bucket.
The credentials corresponding to that account have to be provisioned in mash as usual.

