### PR TITLE
Implements the skeleton for the S3DownloadJob class

### DIFF
--- a/mash/services/api/v1/schema/jobs/__init__.py
+++ b/mash/services/api/v1/schema/jobs/__init__.py
@@ -128,6 +128,14 @@ base_job_message = {
                            'itself. Valid condition operators are >, <, >=, '
                            '<=, or ==.'
         },
+        'download_account': string_with_example(
+            'my_aws_account',
+            description='The cloud framework account as configured with '
+                        'the mash account add client command when the mash '
+                        'user was setup. The credentials associated with '
+                        'this cloud framework account will be used for the '
+                        'image download.'
+        ),
         'download_type': string_with_example(
             'OBS',
             description='Service from which to download the image file.'
@@ -140,9 +148,12 @@ base_job_message = {
         'download_url': string_with_example(
             'https://download.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
-            description='The URL to a download repository. The URL is '
+            description='The URL to a download repository.'
+                        'In the case of OBS download, the URL is '
                         'expected to have the image tarball, checksum and '
                         'a packages file.'
+                        'For the S3 download case, it contains the URL of the'
+                        'S3 bucket containing the image file.'
         ),
         'image_description': string_with_example(
             'openSUSE Leap 15.0 (HVM, 64-bit, SSD-Backed)',

--- a/mash/services/download/s3_job.py
+++ b/mash/services/download/s3_job.py
@@ -16,6 +16,167 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+
+import logging
+import os
+
+from datetime import datetime
+from pytz import utc
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.events import EVENT_JOB_SUBMITTED
+# project
+from mash.services.base_defaults import Defaults
+
+
 class S3DownloadJob(object):
-    # To Be Completed
-    pass
+    """
+    Implements S3 bucket image download job
+
+    Attributes
+
+    * :attr:`job_id`
+      job id number
+
+    * :attr:`job_file`
+      job file containing the job description
+
+    * :attr:`download_url`
+      S3 bucket URL
+
+    * :attr:`download_directory`
+      Download directory name, defaults to: /tmp
+
+    * :attr:`last_service`
+      The last service for the job.
+
+    * :attr:`log_callback`
+      The callback that is used for logs.
+
+    * :attr:`notification_email`
+      The email address to send notifications to.
+
+    * :attr:`download_account`
+      The account that will be used for the S3 download.
+
+    * :attr:`download_credentials`
+      The dictionary containing the credentials for S3 bucket authentication.
+
+    * :attr:`download_directory`
+      The directory that will be used to download the files to.
+    """
+
+    def __init__(
+        self,
+        job_id,
+        job_file,
+        download_url,
+        image_name,
+        cloud_architecture,
+        last_service,
+        log_callback,
+        notification_email,
+        download_account,
+        download_credentials,
+        download_directory=Defaults.get_download_dir(),
+    ):
+        self.job_id = job_id
+        self.job_file = job_file
+        self.download_directory = os.path.join(download_directory, job_id)
+        self.download_url = download_url
+        self.image_name = image_name
+        self.last_service = last_service
+        self.log_callback = logging.LoggerAdapter(
+            log_callback,
+            {'job_id': self.job_id}
+        )
+        self.notification_email = notification_email
+        self.job_status = 'prepared'
+        self.progress_log = {}
+        self.errors = []
+        self.scheduler = None
+        self.job_deleted = False
+        self.download_account = download_account
+        self.download_credentials = download_credentials
+        self.image_filename = ''
+
+    def set_result_handler(self, function):
+        self.result_callback = function
+
+    def call_result_handler(self):
+        self._result_callback()
+
+    def start_watchdog(self, isotime=None):
+        """
+        Start a background job which fetches the image from the S3 bucket.
+
+        The job is started at a given data/time which must
+        be the result of a isoformat() call. If no data/time is
+        specified the job runs immediately.
+
+        :param string isotime: data and time by isoformat()
+        """
+        job_time = None
+
+        if isotime:
+            job_time = datetime.strptime(isotime[:19], '%Y-%m-%dT%H:%M:%S')
+
+        self.scheduler = BackgroundScheduler(timezone=utc)
+
+        self.job = self.scheduler.add_job(
+            self._download_image_file,
+            'date',
+            run_date=job_time,
+            timezone='utc'
+        )
+        self.scheduler.add_listener(
+            self._job_submit_event, EVENT_JOB_SUBMITTED
+        )
+        self.scheduler.start()
+
+    def stop_watchdog(self):
+        """
+        Remove active job from scheduler
+
+        Current image status is retained
+        """
+        try:
+            self.job.remove()
+            self.job_deleted = True
+        except Exception:
+            pass
+
+    def _job_submit_event(self, event):
+        self.log_callback.info('Oneshot Job submitted')
+
+    def _download_image_file(self):
+        """ Download the image file to the destination directory"""
+        pass
+
+    def _result_callback(self):
+        if self.result_callback:
+            self.result_callback(
+                self.job_id, {
+                    'download_result': {
+                        'id': self.job_id,
+                        'image_file': os.path.join(
+                            self.download_directory,
+                            self.image_filename
+                        ),
+                        'status': self.job_status,
+                        'errors': self.errors,
+                        'notification_email': self.notification_email,
+                        'last_service': self.last_service,
+                        'build_time':
+                            self._get_build_time(self.image_name),
+                    }
+                }
+            )
+
+    def _get_build_time(self, image_name):
+        return 'unknown'
+
+    def _job_skipped_event(self, event):
+        # Job is still active while the next _update_image_status
+        # event was scheduled. In this case we just skip the event
+        # and keep the active job waiting for an obs change
+        pass

--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -28,7 +28,7 @@ from apscheduler.events import EVENT_JOB_SUBMITTED
 from mash.services.base_defaults import Defaults
 
 
-class S3DownloadJob(object):
+class S3BucketDownloadJob(object):
     """
     Implements S3 bucket image download job
 
@@ -42,9 +42,6 @@ class S3DownloadJob(object):
 
     * :attr:`download_url`
       S3 bucket URL
-
-    * :attr:`download_directory`
-      Download directory name, defaults to: /tmp
 
     * :attr:`last_service`
       The last service for the job.
@@ -60,9 +57,12 @@ class S3DownloadJob(object):
 
     * :attr:`download_credentials`
       The dictionary containing the credentials for S3 bucket authentication.
+      Credentials must be setup to provide list and download permission on the
+      S3 bucket.
 
     * :attr:`download_directory`
-      The directory that will be used to download the files to.
+      Target download directory name where the files will be downloaded/stored.
+      Defaults to: '/var/lib/mash/images/'.
     """
 
     def __init__(
@@ -110,10 +110,10 @@ class S3DownloadJob(object):
         Start a background job which fetches the image from the S3 bucket.
 
         The job is started at a given data/time which must
-        be the result of a isoformat() call. If no data/time is
+        be the result of a isoformat() call. If no date/time is
         specified the job runs immediately.
 
-        :param string isotime: data and time by isoformat()
+        :param string isotime: date and time by isoformat()
         """
         job_time = None
 

--- a/mash/services/download/service.py
+++ b/mash/services/download/service.py
@@ -22,7 +22,7 @@ import dateutil.parser
 # project
 from mash.services.mash_service import MashService
 from mash.services.download.obs_job import OBSDownloadJob
-from mash.services.download.s3_job import S3DownloadJob
+from mash.services.download.s3bucket_job import S3BucketDownloadJob
 from mash.utils.json_format import JsonFormat
 from mash.utils.mash_utils import persist_json, restart_jobs, setup_logfile
 
@@ -252,7 +252,7 @@ class DownloadService(MashService):
                 [kwargs['download_account']],
                 'ec2'
             )
-            job_worker = S3DownloadJob(**kwargs)
+            job_worker = S3BucketDownloadJob(**kwargs)
         else:
             job_worker = OBSDownloadJob(**kwargs)
         job_worker.set_result_handler(self._send_job_result_for_upload)

--- a/mash/services/download/service.py
+++ b/mash/services/download/service.py
@@ -246,6 +246,12 @@ class DownloadService(MashService):
             kwargs['disallow_packages'] = job['disallow_packages']
 
         if 'download_type' in job and job['download_type'] == 'S3':
+            # Fetching the images from a S3 bucket
+            kwargs['download_account'] = job.get('download_account', 'default')
+            kwargs['download_credentials'] = self.request_credentials(
+                [kwargs['download_account']],
+                'ec2'
+            )
             job_worker = S3DownloadJob(**kwargs)
         else:
             job_worker = OBSDownloadJob(**kwargs)

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -70,6 +70,7 @@ class BaseJob(object):
         self.use_build_time = kwargs.get('use_build_time')
         self.force_replace_image = kwargs.get('force_replace_image')
         self.download_type = kwargs.get('download_type', 'OBS')
+        self.download_account = kwargs.get('download_account', 'default')
         self.kwargs = kwargs
 
         if self.raw_image_upload_type and self.last_service == 'upload':
@@ -137,6 +138,10 @@ class BaseJob(object):
         if self.download_type:
             download_message['download_job']['download_type'] = \
                 self.download_type
+
+        if self.download_account:
+            download_message['download_job']['download_account'] = \
+                self.download_account
 
         return JsonFormat.json_message(download_message)
 

--- a/test/unit/services/download/s3_job_test.py
+++ b/test/unit/services/download/s3_job_test.py
@@ -1,0 +1,107 @@
+from unittest.mock import (
+    patch, MagicMock, Mock
+)
+from pytz import utc
+from datetime import datetime
+import dateutil.parser
+
+from apscheduler.events import EVENT_JOB_SUBMITTED
+
+from mash.services.download.s3_job import S3DownloadJob
+
+
+class TestS3DownloadJob(object):
+    @patch('mash.services.download.s3_job.logging')
+    def setup_method(self, method, mock_logging):
+        self.logger = MagicMock()
+
+        self.log_callback = MagicMock()
+        mock_logging.LoggerAdapter.return_value = self.log_callback
+
+        self.download_result = S3DownloadJob(
+            '815',
+            'job_file',
+            's3://my_s3_bucket',
+            'my_image_name-v20231231-lto',
+            'x86_64',
+            'upload',
+            self.log_callback,
+            notification_email='test@fake.com',
+            download_account='download_account',
+            download_credentials={
+                'access_key_id': 'my_access_key_id',
+                'secret_access_key': 'my_secret_access_key'
+            },
+            download_directory="/tmp/download_directory"
+        )
+
+    def test_set_result_handler(self):
+        function = Mock()
+        self.download_result.set_result_handler(function)
+        assert self.download_result.result_callback == function
+
+    @patch.object(S3DownloadJob, '_result_callback')
+    def test_call_result_handler(self, mock_result_callback):
+        self.download_result.call_result_handler()
+        mock_result_callback.assert_called_once_with()
+
+    def test_result_callback(self):
+        self.download_result.result_callback = Mock()
+        self.download_result.job_status = 'success'
+        self.download_result._result_callback()
+        self.download_result.result_callback.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/',
+                    'status': 'success',
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': 'unknown'
+                }
+            }
+        )
+
+    @patch('mash.services.download.s3_job.BackgroundScheduler')
+    @patch.object(S3DownloadJob, '_download_image_file')
+    @patch.object(S3DownloadJob, '_job_submit_event')
+    def test_start_watchdog_single_shot(
+        self, mock_job_submit_event, mock_download_image_file,
+        mock_BackgroundScheduler
+    ):
+        scheduler = Mock()
+        mock_BackgroundScheduler.return_value = scheduler
+        time = 'Tue Oct 10 14:40:42 UTC 2017'
+        iso_time = dateutil.parser.parse(time).isoformat()
+        run_time = datetime.strptime(iso_time[:19], '%Y-%m-%dT%H:%M:%S')
+        self.download_result.start_watchdog(isotime=iso_time)
+        mock_BackgroundScheduler.assert_called_once_with(
+            timezone=utc
+        )
+        scheduler.add_job.assert_called_once_with(
+            mock_download_image_file, 'date', run_date=run_time,
+            timezone='utc'
+        )
+        scheduler.add_listener.assert_called_once_with(
+            mock_job_submit_event, EVENT_JOB_SUBMITTED
+        )
+        scheduler.start.assert_called_once_with()
+
+    def test_stop_watchdog_no_exception(self):
+        self.download_result.job = Mock()
+        self.download_result.stop_watchdog()
+        self.download_result.job.remove.assert_called_once_with()
+
+    def test_stop_watchdog_just_pass_with_exception(self):
+        self.download_result.job = Mock()
+        self.download_result.job.remove.side_effect = Exception
+        self.download_result.stop_watchdog()
+
+    def test_job_submit_event(self):
+        self.download_result._job_submit_event(Mock())
+        self.log_callback.info.assert_called_once_with('Oneshot Job submitted')
+
+    @patch.object(S3DownloadJob, '_result_callback')
+    def test_job_skipped_event(self, mock_result_callback):
+        self.download_result._job_skipped_event(Mock())

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -7,18 +7,18 @@ import dateutil.parser
 
 from apscheduler.events import EVENT_JOB_SUBMITTED
 
-from mash.services.download.s3_job import S3DownloadJob
+from mash.services.download.s3bucket_job import S3BucketDownloadJob
 
 
-class TestS3DownloadJob(object):
-    @patch('mash.services.download.s3_job.logging')
+class TestS3BucketDownloadJob(object):
+    @patch('mash.services.download.s3bucket_job.logging')
     def setup_method(self, method, mock_logging):
         self.logger = MagicMock()
 
         self.log_callback = MagicMock()
         mock_logging.LoggerAdapter.return_value = self.log_callback
 
-        self.download_result = S3DownloadJob(
+        self.download_result = S3BucketDownloadJob(
             '815',
             'job_file',
             's3://my_s3_bucket',
@@ -40,7 +40,7 @@ class TestS3DownloadJob(object):
         self.download_result.set_result_handler(function)
         assert self.download_result.result_callback == function
 
-    @patch.object(S3DownloadJob, '_result_callback')
+    @patch.object(S3BucketDownloadJob, '_result_callback')
     def test_call_result_handler(self, mock_result_callback):
         self.download_result.call_result_handler()
         mock_result_callback.assert_called_once_with()
@@ -63,9 +63,9 @@ class TestS3DownloadJob(object):
             }
         )
 
-    @patch('mash.services.download.s3_job.BackgroundScheduler')
-    @patch.object(S3DownloadJob, '_download_image_file')
-    @patch.object(S3DownloadJob, '_job_submit_event')
+    @patch('mash.services.download.s3bucket_job.BackgroundScheduler')
+    @patch.object(S3BucketDownloadJob, '_download_image_file')
+    @patch.object(S3BucketDownloadJob, '_job_submit_event')
     def test_start_watchdog_single_shot(
         self, mock_job_submit_event, mock_download_image_file,
         mock_BackgroundScheduler
@@ -102,6 +102,6 @@ class TestS3DownloadJob(object):
         self.download_result._job_submit_event(Mock())
         self.log_callback.info.assert_called_once_with('Oneshot Job submitted')
 
-    @patch.object(S3DownloadJob, '_result_callback')
+    @patch.object(S3BucketDownloadJob, '_result_callback')
     def test_job_skipped_event(self, mock_result_callback):
         self.download_result._job_skipped_event(Mock())


### PR DESCRIPTION
Implements the skeleton for the S3 Download job class.

The function that implements the actual S3 download `_download_image_file` will be implemented in next PRs.

The following additional parameter has been included to the `mash` job doc schema:
- `download_account`: contains the account that will be used to get the credentials to authenticate against the S3 bucket where the image is stored.