### PR TITLE
Ec2 utils get bucket file list

### DIFF
--- a/mash/services/download/service.py
+++ b/mash/services/download/service.py
@@ -246,7 +246,7 @@ class DownloadService(MashService):
             kwargs['disallow_packages'] = job['disallow_packages']
 
         if 'download_type' in job and job['download_type'] == 'S3':
-            # Fetching the images from a S3 bucket
+            # Fetching an image from a S3 bucket
             kwargs['download_account'] = job.get('download_account', 'default')
             kwargs['download_credentials'] = self.request_credentials(
                 [kwargs['download_account']],

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -457,13 +457,18 @@ def get_ongoing_change_id_from_error(message: str):
         )
 
 
-def get_file_list_from_s3_bucket(s3_client, bucket_name, filter_regex=None):
+def get_file_list_from_s3_bucket(
+    boto3_session,
+    bucket_name,
+    filter_regex=None
+):
     """Provides the list of files in a bucket
     If a regex is provided in filter_regex parameter, only the matching
     files will be included in the list returned.
     For the file to be included in the returned list, the S3 object name has to
     be a full match for the regex provided.
     """
+    s3_client = boto3_session.client(service_name='s3')
     files = []
     if filter_regex:
         regex = re.compile(filter_regex)

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -455,3 +455,26 @@ def get_ongoing_change_id_from_error(message: str):
         raise MashEc2UtilsException(
             f'Unable to extract changeset id from aws err response: {message}'
         )
+
+
+def get_file_list_from_s3_bucket(s3_client, bucket_name, filter_regex=None):
+    """Provides the list of files in a bucket
+    If a regex is provided in filter_regex parameter, only the matching
+    files will be included in the list returned.
+    """
+    files = []
+    if filter_regex:
+        regex = re.compile(filter_regex)
+
+    paginator = s3_client.get_paginator('list_objects_v2')
+    response_iterator = paginator.paginate(Bucket=bucket_name)
+
+    for page in response_iterator:
+        for s3_obj in page.get('Contents'):
+            file_name = s3_obj['Key']
+            if not filter_regex:
+                files.append(file_name)
+            elif re.fullmatch(regex, file_name):
+                files.append(file_name)
+
+    return files

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -461,6 +461,8 @@ def get_file_list_from_s3_bucket(s3_client, bucket_name, filter_regex=None):
     """Provides the list of files in a bucket
     If a regex is provided in filter_regex parameter, only the matching
     files will be included in the list returned.
+    For the file to be included in the returned list, the S3 object name has to
+    be a full match for the regex provided.
     """
     files = []
     if filter_regex:

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -747,6 +747,8 @@ def test_get_file_list_from_s3_bucket():
     paginator_mock.paginate.return_value = response_iterator
     s3_client_mock = Mock()
     s3_client_mock.get_paginator.return_value = paginator_mock
+    boto3_session_mock = Mock()
+    boto3_session_mock.client.return_value = s3_client_mock
 
     tests_parameters = [
         (
@@ -774,4 +776,8 @@ def test_get_file_list_from_s3_bucket():
 
     for bucket_name, regex, expected_output in tests_parameters:
         assert expected_output == \
-            get_file_list_from_s3_bucket(s3_client_mock, bucket_name, regex)
+            get_file_list_from_s3_bucket(
+                boto3_session_mock,
+                bucket_name,
+                regex
+            )


### PR DESCRIPTION

This PR includes a new function in the ec2 utils files that allows to get a list of the files in a S3 bucket.

The function includes the option to include a regex and get the file names in the bucket that are a `fullmatch` to the regex provided.

