### PR TITLE
Implements a function to get the regex to filter all the images for the image_name and cloud provided

### DIFF
--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -105,3 +105,26 @@ class TestS3BucketDownloadJob(object):
     @patch.object(S3BucketDownloadJob, '_result_callback')
     def test_job_skipped_event(self, mock_result_callback):
         self.download_result._job_skipped_event(Mock())
+
+    def test_get_regex_for_filename(self):
+        test_params = [
+            (
+                'whatever-my_image-version-flavour-v20240228-suffix',
+                'ec2',
+                r'^whatever\-my_image\-version\-flavour\-v(?P<date>\d{8})\-suffix\.raw\.xz$'
+            ),
+            (
+                'whatever-my_image-version-flavour-v20240128-suffix',
+                'azure',
+                r'^my_image\-version\-flavour\-v(?P<date>\d{8})\-suffix\.vhdfixed\.xz$'
+            ),
+            (
+                'whatever-my_image-version-flavour-v20240328-suffix',
+                'gce',
+                r'^my_image\-version\-flavour\-v(?P<date>\d{8})\-suffix\.tar\.gz$'
+            ),
+        ]
+
+        for (image_name, cloud, expected_regex) in test_params:
+            assert expected_regex == \
+                self.download_result._get_regex_for_filename(image_name, cloud)


### PR DESCRIPTION

This function provides a regex that matches the different versions for the same image taking into account the cloud provider:
- It removes the first '-' delimited segment in the name for some cloud vendors.
- Postpones the appropriate file extension for the cloud provider.

