### PR TITLE
Includes the implementation of the S3Bucket download function

### DIFF
--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -230,6 +230,6 @@ class S3BucketDownloadJob(object):
         s3_prefix = 's3://'
         download_url = self.download_url
         if download_url.startswith(s3_prefix):
-            download_url = download_url.removeprefix(s3_prefix)
+            download_url = download_url[len(s3_prefix):]
         bucket_name, _, object_key = download_url.partition('/')
         return s3_prefix + bucket_name, object_key

--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -226,10 +226,15 @@ class S3BucketDownloadJob(object):
         pass
 
     def _get_bucket_name_and_key_from_download_url(self) -> (str, str):
-        """Returns the bucket name and s3 object key from download_url param"""
+        """Returns the bucket name and s3 object key from download_url param
+        For example: is the download_url provided is
+            s3://my-bucket-name/directory/my_file_name.tar.gz
+        It will return:
+            s3://my-bucket-name , my_file_name.tar.gz
+        """
         s3_prefix = 's3://'
         download_url = self.download_url
         if download_url.startswith(s3_prefix):
             download_url = download_url[len(s3_prefix):]
-        bucket_name, _, object_key = download_url.partition('/')
-        return s3_prefix + bucket_name, object_key
+        download_url_parts = download_url.split('/')
+        return s3_prefix + download_url_parts[0], download_url_parts[-1]

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -491,15 +491,15 @@ def get_file_list_from_s3_bucket(
 def download_file_from_s3_bucket(
     boto3_session,
     bucket_name,
-    file_name,
+    obj_key,
     download_directory
 ):
     """Downloads a file from a S3 bucket to the provided directory"""
 
-    if not os.path.exists(download_directory):
-        os.makedirs(download_directory)
-
-    download_path = os.path.join(download_directory, file_name)
+    download_path = os.path.join(download_directory, obj_key)
+    complete_dir_path, file_name = os.path.split(download_path)
+    if not os.path.exists(complete_dir_path):
+        os.makedirs(complete_dir_path)
 
     s3_client = boto3_session.client(service_name='s3')
-    s3_client.download_file(bucket_name, file_name, download_path)
+    s3_client.download_file(bucket_name, obj_key, download_path)

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -496,10 +496,10 @@ def download_file_from_s3_bucket(
 ):
     """Downloads a file from a S3 bucket to the provided directory"""
 
+    if not os.path.exists(download_directory):
+        os.makedirs(download_directory)
+
     download_path = os.path.join(download_directory, obj_key)
-    complete_dir_path, file_name = os.path.split(download_path)
-    if not os.path.exists(complete_dir_path):
-        os.makedirs(complete_dir_path)
 
     s3_client = boto3_session.client(service_name='s3')
     s3_client.download_file(bucket_name, obj_key, download_path)

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, MagicMock, Mock
+    patch, MagicMock, Mock, call
 )
 from pytz import utc
 from datetime import datetime
@@ -32,7 +32,7 @@ class TestS3BucketDownloadJob(object):
                 'access_key_id': 'my_access_key_id',
                 'secret_access_key': 'my_secret_access_key'
             },
-            download_directory="/tmp/download_directory"
+            download_directory='/tmp/download_directory'
         )
 
     def test_set_result_handler(self):
@@ -53,7 +53,7 @@ class TestS3BucketDownloadJob(object):
             '815', {
                 'download_result': {
                     'id': '815',
-                    'image_file': '/tmp/download_directory/815/',
+                    'image_file': '',
                     'status': 'success',
                     'errors': [],
                     'notification_email': 'test@fake.com',
@@ -105,3 +105,154 @@ class TestS3BucketDownloadJob(object):
     @patch.object(S3BucketDownloadJob, '_result_callback')
     def test_job_skipped_event(self, mock_result_callback):
         self.download_result._job_skipped_event(Mock())
+
+    def test_get_bucket_name_and_key_from_download_url(self):
+        previous_download_url = self.download_result.download_url
+        tests = [
+            (
+                's3://my_download_bucket/path/to/object/filename.tar.gz',
+                's3://my_download_bucket',
+                'path/to/object/filename.tar.gz'
+            ),
+            (
+                'my_download_bucket/path/to/object/filename.tar.gz',
+                's3://my_download_bucket',
+                'path/to/object/filename.tar.gz'
+            )
+        ]
+        for download_url, expected_bucket_name, expected_obj_key in tests:
+            self.download_result.download_url = download_url
+            bucket_name, obj_key = \
+                self.download_result._get_bucket_name_and_key_from_download_url()  # NOQA
+            assert bucket_name == expected_bucket_name
+            assert obj_key == expected_obj_key
+
+        self.download_result.download_url = previous_download_url
+
+    @patch('mash.services.download.s3bucket_job.os.makedirs')
+    @patch('mash.services.download.s3bucket_job.get_session')
+    def test_download_image_file(
+        self,
+        mock_get_session,
+        mock_os_makedirs,
+    ):
+        client_mock = MagicMock()
+        client_mock.download_file.return_value = True
+        session_mock = MagicMock()
+        session_mock.client.return_value = client_mock
+        mock_get_session.return_value = session_mock
+        self.log_callback.reset_mock()
+
+        result_callback_mock = MagicMock()
+
+        previous_download_url = self.download_result.download_url
+
+        self.download_result.download_url = \
+            's3://my_bucket_name/my_dir/myfile.tar.gz'
+        self.download_result.result_callback = result_callback_mock
+
+        self.download_result._download_image_file()
+
+        # assertions
+        mock_get_session.assert_called_once_with(
+            'my_access_key_id',
+            'my_secret_access_key',
+            None
+        )
+        session_mock.client.assert_called_once_with(
+            service_name='s3'
+        )
+        client_mock.download_file.assert_called_once_with(
+            's3://my_bucket_name',
+            'my_dir/myfile.tar.gz',
+            '/tmp/download_directory/815/my_dir/myfile.tar.gz'
+        )
+        mock_os_makedirs.assert_called_once_with(
+            '/tmp/download_directory/815/my_dir'
+        )
+        self.log_callback.info.assert_has_calls(
+            [
+                call('Job running'),
+                call('Downloaded: my_dir/myfile.tar.gz from s3://my_bucket_name S3 bucket to /tmp/download_directory/815/my_dir/myfile.tar.gz'),  # NOQA
+                call('Job status: success'),
+                call('Job done')
+            ]
+        )
+        self.download_result.download_url = previous_download_url
+        result_callback_mock.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '/tmp/download_directory/815/my_dir/myfile.tar.gz',  # NOQA
+                    'status': 'success',
+                    'errors': [],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': 'unknown'
+                }
+            }
+        )
+
+    @patch('mash.services.download.s3bucket_job.os.makedirs')
+    @patch('mash.services.download.s3bucket_job.get_session')
+    def test_download_image_file_exception(
+        self,
+        mock_get_session,
+        mock_os_makedirs
+    ):
+        client_mock = MagicMock()
+        client_mock.download_file.side_effect = Exception('my_exception')
+        session_mock = MagicMock()
+        session_mock.client.return_value = client_mock
+        mock_get_session.return_value = session_mock
+        self.log_callback.reset_mock()
+
+        previous_download_url = self.download_result.download_url
+
+        self.download_result.download_url = \
+            's3://my_bucket_name/my_dir/myfile.tar.gz'
+
+        result_callback_mock = MagicMock()
+        self.download_result.result_callback = result_callback_mock
+
+        self.download_result._download_image_file()
+
+        # assertions
+        mock_get_session.assert_called_once_with(
+            'my_access_key_id',
+            'my_secret_access_key',
+            None
+        )
+        session_mock.client.assert_called_once_with(
+            service_name='s3'
+        )
+        client_mock.download_file.assert_called_once_with(
+            's3://my_bucket_name',
+            'my_dir/myfile.tar.gz',
+            '/tmp/download_directory/815/my_dir/myfile.tar.gz'
+        )
+        mock_os_makedirs.assert_called_once_with(
+            '/tmp/download_directory/815/my_dir'
+        )
+        self.log_callback.info.assert_has_calls(
+            [
+                call('Job running'),
+            ]
+        )
+        self.log_callback.error.assert_called_once_with(
+            'Exception: my_exception'
+        )
+        result_callback_mock.assert_called_once_with(
+            '815', {
+                'download_result': {
+                    'id': '815',
+                    'image_file': '',
+                    'status': 'failed',
+                    'errors': ['Exception: my_exception'],
+                    'notification_email': 'test@fake.com',
+                    'last_service': 'upload',
+                    'build_time': 'unknown'
+                }
+            }
+        )
+        self.download_result.download_url = previous_download_url

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -112,12 +112,12 @@ class TestS3BucketDownloadJob(object):
             (
                 's3://my_download_bucket/path/to/object/filename.tar.gz',
                 's3://my_download_bucket',
-                'path/to/object/filename.tar.gz'
+                'filename.tar.gz'
             ),
             (
                 'my_download_bucket/path/to/object/filename.tar.gz',
                 's3://my_download_bucket',
-                'path/to/object/filename.tar.gz'
+                'filename.tar.gz'
             )
         ]
         for download_url, expected_bucket_name, expected_obj_key in tests:
@@ -164,16 +164,16 @@ class TestS3BucketDownloadJob(object):
         )
         client_mock.download_file.assert_called_once_with(
             's3://my_bucket_name',
-            'my_dir/myfile.tar.gz',
-            '/tmp/download_directory/815/my_dir/myfile.tar.gz'
+            'myfile.tar.gz',
+            '/tmp/download_directory/815/myfile.tar.gz'
         )
         mock_os_makedirs.assert_called_once_with(
-            '/tmp/download_directory/815/my_dir'
+            '/tmp/download_directory/815'
         )
         self.log_callback.info.assert_has_calls(
             [
                 call('Job running'),
-                call('Downloaded: my_dir/myfile.tar.gz from s3://my_bucket_name S3 bucket to /tmp/download_directory/815/my_dir/myfile.tar.gz'),  # NOQA
+                call('Downloaded: myfile.tar.gz from s3://my_bucket_name S3 bucket to /tmp/download_directory/815/myfile.tar.gz'),  # NOQA
                 call('Job status: success'),
                 call('Job done')
             ]
@@ -183,7 +183,7 @@ class TestS3BucketDownloadJob(object):
             '815', {
                 'download_result': {
                     'id': '815',
-                    'image_file': '/tmp/download_directory/815/my_dir/myfile.tar.gz',  # NOQA
+                    'image_file': '/tmp/download_directory/815/myfile.tar.gz',  # NOQA
                     'status': 'success',
                     'errors': [],
                     'notification_email': 'test@fake.com',
@@ -210,7 +210,7 @@ class TestS3BucketDownloadJob(object):
         previous_download_url = self.download_result.download_url
 
         self.download_result.download_url = \
-            's3://my_bucket_name/my_dir/myfile.tar.gz'
+            's3://my_bucket_name/myfile.tar.gz'
 
         result_callback_mock = MagicMock()
         self.download_result.result_callback = result_callback_mock
@@ -228,11 +228,11 @@ class TestS3BucketDownloadJob(object):
         )
         client_mock.download_file.assert_called_once_with(
             's3://my_bucket_name',
-            'my_dir/myfile.tar.gz',
-            '/tmp/download_directory/815/my_dir/myfile.tar.gz'
+            'myfile.tar.gz',
+            '/tmp/download_directory/815/myfile.tar.gz'
         )
         mock_os_makedirs.assert_called_once_with(
-            '/tmp/download_directory/815/my_dir'
+            '/tmp/download_directory/815'
         )
         self.log_callback.info.assert_has_calls(
             [


### PR DESCRIPTION
This PR implements the function called to download the image file to the download directory.

The function expects to have the complete url for the file to be downloaded in the `download_url` parameter. It will responsibility of the entity creating the mash job to provide the complete URL for the file to be downloaded for the image publication.