### PR TITLE
Removes `last_service` overwrite in API for aws MP jobs

### DIFF
--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -146,7 +146,6 @@ def validate_ec2_job(job_doc):
     and cloud_accounts keys from job_doc.
     """
     if job_doc.get('publish_in_marketplace'):
-        job_doc['last_service'] = 'publish'  # No deprecation for MP images
         job_doc['skip_replication'] = True  # No replication for MP images
         validate_mp_fields(job_doc)
 


### PR DESCRIPTION
`last_service` field was being overwritten to `publish` for aws MP jobs.

As we're sending the changelogs to AWS API for MP jobs in `deprecate` service, we need it not to be overwritten.