### PR TITLE
Removes the 's3://' prefix from the bucket_name parameter for S3 downloads

### DIFF
--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -237,4 +237,4 @@ class S3BucketDownloadJob(object):
         if download_url.startswith(s3_prefix):
             download_url = download_url[len(s3_prefix):]
         download_url_parts = download_url.split('/')
-        return s3_prefix + download_url_parts[0], download_url_parts[-1]
+        return download_url_parts[0], download_url_parts[-1]

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -111,12 +111,12 @@ class TestS3BucketDownloadJob(object):
         tests = [
             (
                 's3://my_download_bucket/path/to/object/filename.tar.gz',
-                's3://my_download_bucket',
+                'my_download_bucket',
                 'filename.tar.gz'
             ),
             (
                 'my_download_bucket/path/to/object/filename.tar.gz',
-                's3://my_download_bucket',
+                'my_download_bucket',
                 'filename.tar.gz'
             )
         ]
@@ -163,7 +163,7 @@ class TestS3BucketDownloadJob(object):
             service_name='s3'
         )
         client_mock.download_file.assert_called_once_with(
-            's3://my_bucket_name',
+            'my_bucket_name',
             'myfile.tar.gz',
             '/tmp/download_directory/815/myfile.tar.gz'
         )
@@ -173,7 +173,7 @@ class TestS3BucketDownloadJob(object):
         self.log_callback.info.assert_has_calls(
             [
                 call('Job running'),
-                call('Downloaded: myfile.tar.gz from s3://my_bucket_name S3 bucket to /tmp/download_directory/815/myfile.tar.gz'),  # NOQA
+                call('Downloaded: myfile.tar.gz from my_bucket_name S3 bucket to /tmp/download_directory/815/myfile.tar.gz'),  # NOQA
                 call('Job status: success'),
                 call('Job done')
             ]
@@ -227,7 +227,7 @@ class TestS3BucketDownloadJob(object):
             service_name='s3'
         )
         client_mock.download_file.assert_called_once_with(
-            's3://my_bucket_name',
+            'my_bucket_name',
             'myfile.tar.gz',
             '/tmp/download_directory/815/myfile.tar.gz'
         )


### PR DESCRIPTION

The function that is used to retrieve the `bucket_name` from the `download_url` for the images in the case of S3 bucket downloads was returning the value with the `s3://` prefix incorrectly.

Tests have been fixed accordingly.