### PR TITLE
Minor improvements for better support the usage of `directories` in the S3 storage bucket for s3DownloadJobs

### DIFF
--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -163,18 +163,18 @@ class S3BucketDownloadJob(object):
                 self.download_credentials['secret_access_key'],
                 None
             )
-            bucket_name, object_key = \
+            bucket_name, object_key, filename = \
                 self._get_bucket_name_and_key_from_download_url()
 
             destination_file = os.path.join(
                 self.download_directory,
-                object_key
+                filename
             )
             download_file_from_s3_bucket(
                 boto3_session,
                 bucket_name,
                 object_key,
-                self.download_directory
+                destination_file
             )
             self.log_callback.info(
                 'Downloaded: {0} from {1} S3 bucket to {2}'.format(
@@ -225,16 +225,24 @@ class S3BucketDownloadJob(object):
         # and keep the active job waiting for an obs change
         pass
 
-    def _get_bucket_name_and_key_from_download_url(self) -> (str, str):
-        """Returns the bucket name and s3 object key from download_url param
+    def _get_bucket_name_and_key_from_download_url(self) -> (str, str, str):
+        """
+        Returns the bucket name and s3 object key and filename from
+        download_url param
         For example: is the download_url provided is
             s3://my-bucket-name/directory/my_file_name.tar.gz
         It will return:
-            s3://my-bucket-name , my_file_name.tar.gz
+            s3://my-bucket-name ,
+            /directory/my_file_name.tar.gz,
+            my_file_name.tar.gz
         """
         s3_prefix = 's3://'
         download_url = self.download_url
         if download_url.startswith(s3_prefix):
             download_url = download_url[len(s3_prefix):]
         download_url_parts = download_url.split('/')
-        return download_url_parts[0], download_url_parts[-1]
+        return (
+            download_url_parts[0],
+            download_url[len(download_url_parts[0]) + 1:],
+            download_url_parts[-1]
+        )

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -492,14 +492,13 @@ def download_file_from_s3_bucket(
     boto3_session,
     bucket_name,
     obj_key,
-    download_directory
+    download_path
 ):
     """Downloads a file from a S3 bucket to the provided directory"""
 
+    download_directory, download_file = os.path.split(download_path)
     if not os.path.exists(download_directory):
         os.makedirs(download_directory)
-
-    download_path = os.path.join(download_directory, obj_key)
 
     s3_client = boto3_session.client(service_name='s3')
     s3_client.download_file(bucket_name, obj_key, download_path)

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -112,20 +112,34 @@ class TestS3BucketDownloadJob(object):
             (
                 's3://my_download_bucket/path/to/object/filename.tar.gz',
                 'my_download_bucket',
+                'path/to/object/filename.tar.gz',
                 'filename.tar.gz'
             ),
             (
                 'my_download_bucket/path/to/object/filename.tar.gz',
                 'my_download_bucket',
+                'path/to/object/filename.tar.gz',
+                'filename.tar.gz'
+            ),
+            (
+                'my_download_bucket/filename.tar.gz',
+                'my_download_bucket',
+                'filename.tar.gz',
                 'filename.tar.gz'
             )
         ]
-        for download_url, expected_bucket_name, expected_obj_key in tests:
+        for (
+            download_url,
+            expected_bucket_name,
+            expected_obj_key,
+            expected_filename
+        ) in tests:
             self.download_result.download_url = download_url
-            bucket_name, obj_key = \
+            bucket_name, obj_key , filename = \
                 self.download_result._get_bucket_name_and_key_from_download_url()  # NOQA
             assert bucket_name == expected_bucket_name
             assert obj_key == expected_obj_key
+            assert filename == expected_filename
 
         self.download_result.download_url = previous_download_url
 
@@ -164,7 +178,7 @@ class TestS3BucketDownloadJob(object):
         )
         client_mock.download_file.assert_called_once_with(
             'my_bucket_name',
-            'myfile.tar.gz',
+            'my_dir/myfile.tar.gz',
             '/tmp/download_directory/815/myfile.tar.gz'
         )
         mock_os_makedirs.assert_called_once_with(
@@ -173,7 +187,7 @@ class TestS3BucketDownloadJob(object):
         self.log_callback.info.assert_has_calls(
             [
                 call('Job running'),
-                call('Downloaded: myfile.tar.gz from my_bucket_name S3 bucket to /tmp/download_directory/815/myfile.tar.gz'),  # NOQA
+                call('Downloaded: my_dir/myfile.tar.gz from my_bucket_name S3 bucket to /tmp/download_directory/815/myfile.tar.gz'),  # NOQA
                 call('Job status: success'),
                 call('Job done')
             ]

--- a/test/unit/utils/ec2_test.py
+++ b/test/unit/utils/ec2_test.py
@@ -792,7 +792,7 @@ def test_get_file_list_from_s3_bucket():
 
 
 @patch('mash.utils.ec2.os.path.exists')
-def test_download_file_from_s3_bucket(os_path_exists_mock):
+def test_download_file_from_s3_bucket2(os_path_exists_mock):
 
     os_path_exists_mock.return_value = True
 
@@ -804,24 +804,26 @@ def test_download_file_from_s3_bucket(os_path_exists_mock):
     tests_parameters = [
         (
             'my_bucket_name',
-            'my_file_name',
-            '/my/directory/name'
+            '/obj_key/my_file_name',
+            '/my/download/directory/my_file_name'
         )
     ]
 
-    for bucket_name, file_name, directory_name in tests_parameters:
+    for bucket_name, object_key, download_path in tests_parameters:
         download_file_from_s3_bucket(
             boto3_session_mock,
             bucket_name,
-            file_name,
-            directory_name
+            object_key,
+            download_path
         )
         boto3_session_mock.client.assert_called_once_with(service_name='s3')
         s3_client_mock.download_file.assert_called_once_with(
             bucket_name,
-            file_name,
-            os.path.join(directory_name, file_name)
+            object_key,
+            download_path
         )
+
+        directory_name, file_name = os.path.split(download_path)
         os_path_exists_mock.assert_called_once_with(directory_name)
         os_path_exists_mock.reset_mock()
         boto3_session_mock.reset_mock()
@@ -846,24 +848,25 @@ def test_download_file_from_s3_bucket_non_existing_directory(
     tests_parameters = [
         (
             'my_bucket_name',
-            'my_file_name',
-            '/my/directory/name'
+            '/my_obj_key/my_file_name',
+            '/my/directory/name/my_destination_filename'
         )
     ]
 
-    for bucket_name, file_name, directory_name in tests_parameters:
+    for bucket_name, obj_key, download_path in tests_parameters:
         download_file_from_s3_bucket(
             boto3_session_mock,
             bucket_name,
-            file_name,
-            directory_name
+            obj_key,
+            download_path
         )
         boto3_session_mock.client.assert_called_once_with(service_name='s3')
         s3_client_mock.download_file.assert_called_once_with(
             bucket_name,
-            file_name,
-            os.path.join(directory_name, file_name)
+            obj_key,
+            download_path
         )
+        directory_name, file_name = os.path.split(download_path)
         os_path_exists_mock.assert_called_once_with(directory_name)
         os_makedirs_mock.assert_called_once_with(directory_name)
         os_path_exists_mock.reset_mock()


### PR DESCRIPTION

Minor change to handle better the support of directories in `object_keys` when downloading images from S3-compatible `download_url`s.

Tests have been modified accordingly.