### PR TITLE
Remove the filename from download_url for S3Downloads

### DIFF
--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -198,7 +198,7 @@ class S3BucketDownloadJob(object):
                     destination_file
                 )
             )
-            self.image_filename = self.image_name
+            self.image_filename = destination_file
 
             # job finished successfully
             self.job_status = 'success'

--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -46,7 +46,7 @@ class S3BucketDownloadJob(object):
 
     * :attr:`download_url`
       S3 bucket URL.
-      Includes the `directory` part of the URL iif the key object contains some
+      Includes the `directory` part of the URL if the key object contains some
       directory structure.
 
     * :attr:`image_name`

--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -45,7 +45,13 @@ class S3BucketDownloadJob(object):
       job file containing the job description
 
     * :attr:`download_url`
-      S3 bucket URL
+      S3 bucket URL.
+      Includes the `directory` part of the URL iif the key object contains some
+      directory structure.
+
+    * :attr:`image_name`
+      Image name for the download.
+      Contains the filename for the image to be downloaded.
 
     * :attr:`last_service`
       The last service for the job.
@@ -163,27 +169,36 @@ class S3BucketDownloadJob(object):
                 self.download_credentials['secret_access_key'],
                 None
             )
-            bucket_name, object_key, filename = \
+            bucket_name, dir_part_of_object_key = \
                 self._get_bucket_name_and_key_from_download_url()
 
             destination_file = os.path.join(
                 self.download_directory,
-                filename
+                self.image_name
             )
+
+            if dir_part_of_object_key:
+                if dir_part_of_object_key.endswith('/'):
+                    dir_part_of_object_key = dir_part_of_object_key[:-1]
+                full_object_key = dir_part_of_object_key + '/' \
+                    + self.image_name
+            else:
+                full_object_key = self.image_name
+
             download_file_from_s3_bucket(
                 boto3_session,
                 bucket_name,
-                object_key,
+                full_object_key,
                 destination_file
             )
             self.log_callback.info(
                 'Downloaded: {0} from {1} S3 bucket to {2}'.format(
-                    object_key,
+                    full_object_key,
                     bucket_name,
                     destination_file
                 )
             )
-            self.image_filename = filename
+            self.image_filename = self.image_name
 
             # job finished successfully
             self.job_status = 'success'
@@ -227,22 +242,21 @@ class S3BucketDownloadJob(object):
 
     def _get_bucket_name_and_key_from_download_url(self) -> (str, str, str):
         """
-        Returns the bucket name and s3 object key and filename from
-        download_url param
+        Returns the bucket name and the 'directory' part of download_url param
         For example: is the download_url provided is
-            s3://my-bucket-name/directory/my_file_name.tar.gz
+            s3://my-bucket-name/directory1/directory2
         It will return:
-            s3://my-bucket-name ,
-            /directory/my_file_name.tar.gz,
-            my_file_name.tar.gz
+            my-bucket-name ,
+            /directory1/directory2
         """
         s3_prefix = 's3://'
         download_url = self.download_url
         if download_url.startswith(s3_prefix):
             download_url = download_url[len(s3_prefix):]
         download_url_parts = download_url.split('/')
-        return (
-            download_url_parts[0],
-            download_url[len(download_url_parts[0]) + 1:],
-            download_url_parts[-1]
-        )
+        if len(download_url_parts) > 1:
+            return (
+                download_url_parts[0],
+                download_url[len(download_url_parts[0]) + 1:]
+            )
+        return (download_url, '')

--- a/mash/services/download/s3bucket_job.py
+++ b/mash/services/download/s3bucket_job.py
@@ -178,10 +178,10 @@ class S3BucketDownloadJob(object):
             )
 
             if dir_part_of_object_key:
-                if dir_part_of_object_key.endswith('/'):
-                    dir_part_of_object_key = dir_part_of_object_key[:-1]
-                full_object_key = dir_part_of_object_key + '/' \
-                    + self.image_name
+                full_object_key = os.path.join(
+                    dir_part_of_object_key,
+                    self.image_name
+                )
             else:
                 full_object_key = self.image_name
 
@@ -240,7 +240,7 @@ class S3BucketDownloadJob(object):
         # and keep the active job waiting for an obs change
         pass
 
-    def _get_bucket_name_and_key_from_download_url(self) -> (str, str, str):
+    def _get_bucket_name_and_key_from_download_url(self) -> (str, str):
         """
         Returns the bucket name and the 'directory' part of download_url param
         For example: is the download_url provided is
@@ -249,14 +249,8 @@ class S3BucketDownloadJob(object):
             my-bucket-name ,
             /directory1/directory2
         """
-        s3_prefix = 's3://'
-        download_url = self.download_url
-        if download_url.startswith(s3_prefix):
-            download_url = download_url[len(s3_prefix):]
-        download_url_parts = download_url.split('/')
+        download_url = self.download_url.replace('s3://', '')
+        download_url_parts = download_url.split('/', maxsplit=1)
         if len(download_url_parts) > 1:
-            return (
-                download_url_parts[0],
-                download_url[len(download_url_parts[0]) + 1:]
-            )
+            return (download_url_parts[0], download_url_parts[1])
         return (download_url, '')

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -194,7 +194,7 @@ class TestS3BucketDownloadJob(object):
             '815', {
                 'download_result': {
                     'id': '815',
-                    'image_file': 'myfile.tar.gz',
+                    'image_file': '/tmp/download_directory/815/myfile.tar.gz',  # NOQA
                     'status': 'success',
                     'errors': [],
                     'notification_email': 'test@fake.com',

--- a/test/unit/services/download/s3bucket_job_test.py
+++ b/test/unit/services/download/s3bucket_job_test.py
@@ -110,42 +110,38 @@ class TestS3BucketDownloadJob(object):
         previous_download_url = self.download_result.download_url
         tests = [
             (
-                's3://my_download_bucket/path/to/object/filename.tar.gz',
+                's3://my_download_bucket/path/to/object',
                 'my_download_bucket',
-                'path/to/object/filename.tar.gz',
-                'filename.tar.gz'
+                'path/to/object',
+
             ),
             (
-                'my_download_bucket/path/to/object/filename.tar.gz',
+                'my_download_bucket/path/to/object',
                 'my_download_bucket',
-                'path/to/object/filename.tar.gz',
-                'filename.tar.gz'
+                'path/to/object'
             ),
             (
-                'my_download_bucket/filename.tar.gz',
                 'my_download_bucket',
-                'filename.tar.gz',
-                'filename.tar.gz'
+                'my_download_bucket',
+                ''
             )
         ]
         for (
             download_url,
             expected_bucket_name,
-            expected_obj_key,
-            expected_filename
+            expected_dir_part_of_obj_key
         ) in tests:
             self.download_result.download_url = download_url
-            bucket_name, obj_key , filename = \
+            bucket_name, dir_part_of_obj_key = \
                 self.download_result._get_bucket_name_and_key_from_download_url()  # NOQA
             assert bucket_name == expected_bucket_name
-            assert obj_key == expected_obj_key
-            assert filename == expected_filename
+            assert dir_part_of_obj_key == expected_dir_part_of_obj_key
 
         self.download_result.download_url = previous_download_url
 
     @patch('mash.services.download.s3bucket_job.os.makedirs')
     @patch('mash.services.download.s3bucket_job.get_session')
-    def test_download_image_file(
+    def test_download_image_file2(
         self,
         mock_get_session,
         mock_os_makedirs,
@@ -162,7 +158,8 @@ class TestS3BucketDownloadJob(object):
         previous_download_url = self.download_result.download_url
 
         self.download_result.download_url = \
-            's3://my_bucket_name/my_dir/myfile.tar.gz'
+            's3://my_bucket_name/my_dir'
+        self.download_result.image_name = 'myfile.tar.gz'
         self.download_result.result_callback = result_callback_mock
 
         self.download_result._download_image_file()
@@ -224,7 +221,8 @@ class TestS3BucketDownloadJob(object):
         previous_download_url = self.download_result.download_url
 
         self.download_result.download_url = \
-            's3://my_bucket_name/myfile.tar.gz'
+            's3://my_bucket_name/AWS/'
+        self.download_result.image_name = 'myfile.tar.gz'
 
         result_callback_mock = MagicMock()
         self.download_result.result_callback = result_callback_mock
@@ -242,7 +240,7 @@ class TestS3BucketDownloadJob(object):
         )
         client_mock.download_file.assert_called_once_with(
             'my_bucket_name',
-            'myfile.tar.gz',
+            'AWS/myfile.tar.gz',
             '/tmp/download_directory/815/myfile.tar.gz'
         )
         mock_os_makedirs.assert_called_once_with(


### PR DESCRIPTION
In order to have a more similar behavior in both download types, for `S3DownloadJobs` this change removes the filename from the `download_url` param and the filename will be obtained from the `image` parameter in the mash job doc.

So, for the download of an image from `s3://download_bucket/directory1/directory2/image_file.tar.gz` we'd expect the following values in the mash job doc:
- `download_url`: `s3://download_bucket/directory1/directory2`
- `image`:  `image_file.tar.gz`

Tests have been modified accordingly