### PR TITLE
Removes unused code about services requiring non_credentials

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -23,8 +23,6 @@ services:
   - replicate
   - publish
   - deprecate
-non_cred_services:
-  - download
 credentials:
   credentials_directory: /var/lib/mash/credentials/
 cloud:

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -138,23 +138,13 @@ class BaseConfig(object):
 
         return data
 
-    def get_service_names(self, credentials_required=False):
+    def get_service_names(self):
         """
         Return a list of all service names.
-
-        If credentials_required is True return only services that require
-        credentials to execute.
+.
         """
         services = self._get_attribute(attribute='services') or \
             Defaults.get_service_names()
-
-        if credentials_required:
-            non_cred_services = self._get_attribute(
-                attribute='non_cred_services'
-            ) or Defaults.get_non_credential_service_names()
-            services = [service for service in services
-                        if service not in non_cred_services]
-
         return services
 
     def get_ssh_private_key_file(self):

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -65,10 +65,6 @@ class Defaults(object):
         return 'guest'
 
     @classmethod
-    def get_non_credential_service_names(self):
-        return ['download']
-
-    @classmethod
     def get_azure_max_retry_attempts(self):
         return 5
 

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -24,8 +24,6 @@ services:
   - replicate
   - publish
   - deprecate
-non_cred_services:
-  - download
 cloud:
   ec2:
     regions:

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -40,19 +40,12 @@ class TestBaseConfig(object):
         assert str(error.value) == \
             'cloud data must be provided in config file.'
 
-    def test_get_services_names(self):
-        # Services requiring credentials
+    def test_get_service_names(self):
+        # Services
         expected = [
-            'upload', 'create', 'test', 'raw_image_upload',
+            'download', 'upload', 'create', 'test', 'raw_image_upload',
             'replicate', 'publish', 'deprecate'
         ]
-        services = self.empty_config.get_service_names(
-            credentials_required=True
-        )
-        assert expected == services
-
-        # All services
-        expected = ['download'] + expected
         services = self.empty_config.get_service_names()
         assert expected == services
 


### PR DESCRIPTION
With the implementation of the extensibility of the download service, all services require credentials, so this code is no longer required.