### PR TITLE
Changes `OBSDownloadJob` to be initialized over job_config and config

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -23,8 +23,6 @@ services:
   - replicate
   - publish
   - deprecate
-non_cred_services:
-  - download
 credentials:
   credentials_directory: /var/lib/mash/credentials/
 cloud:

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -138,23 +138,13 @@ class BaseConfig(object):
 
         return data
 
-    def get_service_names(self, credentials_required=False):
+    def get_service_names(self):
         """
         Return a list of all service names.
-
-        If credentials_required is True return only services that require
-        credentials to execute.
+.
         """
         services = self._get_attribute(attribute='services') or \
             Defaults.get_service_names()
-
-        if credentials_required:
-            non_cred_services = self._get_attribute(
-                attribute='non_cred_services'
-            ) or Defaults.get_non_credential_service_names()
-            services = [service for service in services
-                        if service not in non_cred_services]
-
         return services
 
     def get_ssh_private_key_file(self):

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -65,10 +65,6 @@ class Defaults(object):
         return 'guest'
 
     @classmethod
-    def get_non_credential_service_names(self):
-        return ['download']
-
-    @classmethod
     def get_azure_max_retry_attempts(self):
         return 5
 

--- a/mash/services/download/obs_job.py
+++ b/mash/services/download/obs_job.py
@@ -27,7 +27,8 @@ from apscheduler.events import EVENT_JOB_SUBMITTED
 from obs_img_utils.api import OBSImageUtil
 
 # project
-from mash.services.base_defaults import Defaults
+from mash.log.filter import BaseServiceFilter
+from mash.utils.mash_utils import setup_rabbitmq_log_handler
 
 
 class OBSDownloadJob(object):
@@ -88,39 +89,77 @@ class OBSDownloadJob(object):
     * :attr:`disallow_packages`
       A list of packages to disallow in the image.
     """
-    def __init__(
-        self, job_id, job_file, download_url, image_name, last_service,
-        log_callback, conditions=None, arch='x86_64',
-        download_directory=Defaults.get_download_dir(),
-        notification_email=None,
-        profile=None, conditions_wait_time=900, disallow_licenses=None,
-        disallow_packages=None
-    ):
-        self.arch = arch
-        self.job_id = job_id
-        self.job_file = job_file
-        self.download_directory = os.path.join(download_directory, job_id)
-        self.download_url = download_url
-        self.image_name = image_name
-        self.last_service = last_service
+    def __init__(self, job_config, config):
+        self.job_config = job_config
+        self.config = config
+        self.job_id = job_config['id']
+        self.job_file = job_config['job_file']
+        self.download_url = job_config['download_url']
+        self.image_name = job_config['image_name']
+        self.last_service = job_config['last_service']
+        self.download_directory = os.path.join(
+            config.get_download_directory(),
+            self.job_id
+        )
+
+        logging.basicConfig()
+        logger = logging.getLogger('DownloadService')
+        logger.setLevel(logging.DEBUG)
+        rabbit_handler = setup_rabbitmq_log_handler(
+            config.get_amqp_host(),
+            config.get_amqp_user(),
+            config.get_amqp_pass()
+        )
+        logger.addHandler(rabbit_handler)
+        logger.addFilter(BaseServiceFilter)
+        self.log_callback = logging.LoggerAdapter(
+            logger,
+            {'job_id': self.job_id}
+        )
+
+        if 'conditions' in job_config:
+            self.conditions = job_config['conditions']
+        else:
+            self.conditions = None
+
+        if 'cloud_architecture' in job_config:
+            self.arch = job_config['cloud_architecture']
+        else:
+            self.arch = 'x86_64'
+
+        if 'profile' in job_config:
+            self.profile = job_config['profile']
+        else:
+            self.profile = None
+
+        if 'notification_email' in job_config:
+            self.notification_email = job_config['notification_email']
+        else:
+            self.notification_email = None
+
+        if 'conditions_wait_time' in job_config:
+            self.conditions_wait_time = job_config['conditions_wait_time']
+        else:
+            self.conditions_wait_time = 900
+
+        if 'disallow_licenses' in job_config:
+            self.disallow_licenses = job_config['disallow_licenses']
+        else:
+            self.disallow_licenses = None
+
+        if 'disallow_packages' in job_config:
+            self.disallow_packages = job_config['disallow_packages']
+        else:
+            self.disallow_packages = None
+
         self.image_metadata_name = None
-        self.conditions = conditions
         self.scheduler = None
         self.job = None
         self.job_deleted = False
-        self.log_callback = None
+
         self.result_callback = None
-        self.notification_email = notification_email
-        self.profile = profile
         self.job_status = 'prepared'
         self.progress_log = {}
-        self.conditions_wait_time = conditions_wait_time
-        self.disallow_licenses = disallow_licenses
-        self.disallow_packages = disallow_packages
-        self.log_callback = logging.LoggerAdapter(
-            log_callback,
-            {'job_id': self.job_id}
-        )
         self.errors = []
 
         # How often to update log callback with download progress.
@@ -131,7 +170,7 @@ class OBSDownloadJob(object):
             'conditions': self.conditions,
             'arch': self.arch,
             'target_directory': self.download_directory,
-            'conditions_wait_time': conditions_wait_time,
+            'conditions_wait_time': self.conditions_wait_time,
             'log_callback': self.log_callback,
             'report_callback': self.progress_callback
         }

--- a/mash/services/download/service.py
+++ b/mash/services/download/service.py
@@ -252,7 +252,7 @@ class DownloadService(MashService):
             kwargs['requesting_user'] = job.get('requesting_user')
             job_worker = S3BucketDownloadJob(**kwargs)
         else:
-            job_worker = OBSDownloadJob(**kwargs)
+            job_worker = OBSDownloadJob(job, self.config)
         job_worker.set_result_handler(self._send_job_result_for_upload)
         job_worker.start_watchdog(isotime=time)
         self.jobs[job_id] = job_worker

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -24,8 +24,6 @@ services:
   - replicate
   - publish
   - deprecate
-non_cred_services:
-  - download
 cloud:
   ec2:
     regions:

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -40,19 +40,12 @@ class TestBaseConfig(object):
         assert str(error.value) == \
             'cloud data must be provided in config file.'
 
-    def test_get_services_names(self):
-        # Services requiring credentials
+    def test_get_service_names(self):
+        # Services
         expected = [
-            'upload', 'create', 'test', 'raw_image_upload',
+            'download', 'upload', 'create', 'test', 'raw_image_upload',
             'replicate', 'publish', 'deprecate'
         ]
-        services = self.empty_config.get_service_names(
-            credentials_required=True
-        )
-        assert expected == services
-
-        # All services
-        expected = ['download'] + expected
         services = self.empty_config.get_service_names()
         assert expected == services
 

--- a/test/unit/services/download/obs_job_test.py
+++ b/test/unit/services/download/obs_job_test.py
@@ -8,6 +8,7 @@ import dateutil.parser
 from apscheduler.events import EVENT_JOB_SUBMITTED
 
 from mash.services.download.obs_job import OBSDownloadJob
+from mash.services.base_config import BaseConfig
 
 
 class TestOBSDownloadJob(object):
@@ -21,13 +22,20 @@ class TestOBSDownloadJob(object):
         self.log_callback = MagicMock()
         mock_logging.LoggerAdapter.return_value = self.log_callback
 
-        self.download_result = OBSDownloadJob(
-            '815', 'job_file', 'obs_project', 'obs_package', 'publish',
-            self.logger,
-            notification_email='test@fake.com',
-            profile='Proxy', disallow_licenses=["MIT"],
-            disallow_packages=["fake"]
-        )
+        job_config = {
+            'id': '815',
+            'job_file': 'job_file',
+            'download_url': 'obs_project',
+            'image_name': 'obs_package',
+            'last_service': 'publish',
+            'notification_email': 'test@fake.com',
+            'profile': 'Proxy',
+            'disallow_licenses': ['MIT'],
+            'disallow_packages': ['fake']
+        }
+        config = BaseConfig('./test/data/mash_config.yaml')
+
+        self.download_result = OBSDownloadJob(job_config, config)
 
     def test_set_result_handler(self):
         function = Mock()


### PR DESCRIPTION
Note that this PR includes the changes from [PR 892](https://github.com/SUSE-Enceladus/mash/pull/892)

In order to have the Download Service with a Factory pattern like the rest of the services, it is necessary to make some refactoring in the initialization of the 2 download classes. This PR refactors the initialization of the `OBSDownloadJob`.