### PR TITLE
Flask sql alchemy paginate fix

### DIFF
--- a/mash/services/database/utils/jobs.py
+++ b/mash/services/database/utils/jobs.py
@@ -63,8 +63,8 @@ def get_jobs(user_id, page=1, per_page=10):
     Retrieve all jobs for user.
     """
     job_query = Job.query.filter_by(user_id=user_id).paginate(
-        page,
-        per_page,
+        page=page,
+        per_page=per_page,
         error_out=False,  # Return empty set if no results
         max_per_page=20
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,15 @@
 [tox]
+minversion = 3.3.0
+isolated_build = True
+skip_missing_interpreters = True
 skipsdist = True
 envlist =
-    unit_py3, check
+    unit_py3,
+    check
 
 
 [testenv]
+allowlist_externals = {toxinidir}/pip.sh
 install_command = {toxinidir}/pip.sh {opts} {packages}
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
This change is two fold

**Fixing type error of paginate**
    
As of Flask-SQLAlchemy >= 3.0 all arguments to paginate are keyword-only. This commit changes the call to be keyword based and thus continues to work on older and newer Flask-SQLAlchemy

**Update tox.ini to work in this century**

For running the tests and actually using tox in newer versions, these changes are required due to tox being more restrictive in newer versions