### PR TITLE
Add partner center account for azure jobs

### DIFF
--- a/mash/services/api/v1/schema/jobs/azure.py
+++ b/mash/services/api/v1/schema/jobs/azure.py
@@ -65,7 +65,12 @@ azure_job_message['properties']['vm_images_key'] = string_with_example(
 azure_job_message['properties']['cloud_account'] = string_with_example(
     'account1',
     description='The name of the cloud account to use for image '
-                'publishing.'
+                'storage and gallery image creation.'
+)
+azure_job_message['properties']['partner_center_account'] = string_with_example(
+    'account2',
+    description='The name of the cloud account to use for image '
+                'publishing in partner center.'
 )
 azure_job_message['properties']['source_container'] = string_with_example(
     'container1',

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -48,6 +48,7 @@ class AzureJob(BaseJob):
         self.generation_id = self.kwargs.get('generation_id')
         self.gallery_name = self.kwargs.get('gallery_name')
         self.gallery_resource_group = self.kwargs.get('gallery_resource_group')
+        self.partner_center_account = self.kwargs.get('partner_center_account')
 
     def get_deprecate_message(self):
         """
@@ -71,7 +72,7 @@ class AzureJob(BaseJob):
                 'offer_id': self.offer_id,
                 'cloud': self.cloud,
                 'sku': self.sku,
-                'account': self.cloud_account,
+                'account': self.partner_center_account or self.cloud_account,
                 'region': self.region,
                 'container': self.source_container,
                 'resource_group': self.source_resource_group,

--- a/test/unit/services/jobcreator/azure_job_test.py
+++ b/test/unit/services/jobcreator/azure_job_test.py
@@ -51,6 +51,7 @@ def test_azure_job_cleanup(mock_init):
         'publisher_id': 'suse',
         'sku': 'sp1',
         'cloud': 'azure',
+        'partner_center_account': 'acnt2'
     }
     job.cloud = 'azure'
     job.tests = ['test1']


### PR DESCRIPTION
This allows mash to use different accounts for partner center, storage and gallery image processing.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
