### PR TITLE
Fix issue in test instance selection for ec2 jobs with 'uefi' boot_firmware

### DIFF
--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -231,6 +231,9 @@ class EC2Job(BaseJob):
             test_message['test_job']['cloud_architecture'] = \
                 self.cloud_architecture
 
+        if self.boot_firmware:
+            test_message['test_job']['boot_firmware'] = self.boot_firmware
+
         test_message['test_job'].update(self.base_message)
 
         return JsonFormat.json_message(test_message)


### PR DESCRIPTION

Apparently the `boot_firmware` parameter was not being included in the test job doc and mash was always defaulting to 'uefi-preferred'.


