### PR TITLE
Adds support to imds_version parameter in Mash for ec2 images

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,7 +18,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0
 amqpstorm
-ec2imgutils>=9.0.3
+ec2imgutils>=10.0.3
 img-proof>=7.14.0
 requests
 obs-img-utils>=1.0.0

--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -170,6 +170,11 @@ ec2_job_message['properties']['launch_inst_type'] = string_with_example(
     'm1.large',
     description='The helper instance type to use for image creation with ec2uploadimg.'
 )
+ec2_job_message['properties']['imds_version'] = string_with_example(
+    'v2.0',
+    description='Set the protocol version to be used when instances are'
+                'launched from the image, supported values 2.0/v2.0. '
+)
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -73,6 +73,7 @@ class EC2CreateJob(MashJob):
             'boot_firmware',
             ['uefi-preferred']
         )
+        self.imds_version = self.job_config.get('imds_version', '')
 
         # EC2 images only support one firmware
         self.boot_firmware = self.boot_firmware[0]
@@ -136,6 +137,9 @@ class EC2CreateJob(MashJob):
 
         if self.tpm_support:
             self.ec2_upload_parameters['tpm_support'] = self.tpm_support
+
+        if self.imds_version:
+            self.ec2_upload_parameters['imds_version'] = self.imds_version
 
         # Get all account credentials in one request
         accounts = []

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -51,6 +51,7 @@ class EC2Job(BaseJob):
             False
         )
         self.launch_inst_type = self.kwargs.get('launch_inst_type')
+        self.imds_version = self.kwargs.get('imds_version', '')
 
     def _get_target_regions_list(self):
         """
@@ -272,6 +273,9 @@ class EC2Job(BaseJob):
         if self.cloud_architecture:
             create_message['create_job']['cloud_architecture'] = \
                 self.cloud_architecture
+
+        if self.imds_version:
+            create_message['create_job']['imds_version'] = self.imds_version
 
         return JsonFormat.json_message(create_message)
 

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -35,7 +35,7 @@ BuildRequires:  python3-PyJWT
 BuildRequires:  python3-amqpstorm >= 2.4.0
 BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
-BuildRequires:  python3-ec2imgutils >= 9.0.3
+BuildRequires:  python3-ec2imgutils >= 10.0.3
 BuildRequires:  python3-img-proof >= 7.14.0
 BuildRequires:  python3-img-proof-tests >= 7.14.0
 BuildRequires:  python3-Flask
@@ -61,7 +61,7 @@ Requires:       python3-PyJWT
 Requires:       python3-amqpstorm >= 2.4.0
 Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
-Requires:       python3-ec2imgutils >= 9.0.3
+Requires:       python3-ec2imgutils >= 10.0.3
 Requires:       python3-img-proof >= 7.14.0
 Requires:       python3-img-proof-tests >= 7.14.0
 Requires:       python3-Flask

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -43,7 +43,8 @@ class TestAmazonCreateJob(object):
             'image_description': 'description',
             'use_build_time': True,
             'tpm_support': 'v2.0',
-            'launch_inst_type': 'm1.large'
+            'launch_inst_type': 'm1.large',
+            'imds_version': 'v2.0',
         }
         self.job = EC2CreateJob(job_doc, self.config)
         self.job._log_callback = Mock()
@@ -156,7 +157,8 @@ class TestAmazonCreateJob(object):
             wait_count=3,
             log_callback=self.job._log_callback,
             tpm_support='v2.0',
-            boot_mode='uefi-preferred'
+            boot_mode='uefi-preferred',
+            imds_version='v2.0',
         )
         open_context.file_mock.write.assert_called_once_with('pkey')
         ec2_client.create_key_pair.assert_called_once_with(KeyName='mash-xxxx')

--- a/test/unit/services/jobcreator/ec2_job_test.py
+++ b/test/unit/services/jobcreator/ec2_job_test.py
@@ -90,3 +90,32 @@ def test_get_mp_deprecate_message(mock_get_test_regions):
 
     message = job.get_deprecate_message()
     assert JsonFormat.json_loads(message)['deprecate_job']['entity_id'] == '123'
+
+
+@patch.object(EC2Job, 'get_create_regions')
+def test_get_create_message(mock_get_create_regions):
+    mock_get_create_regions.return_value = {'us-east-2': {'account': 'acnt1'}}
+
+    job = EC2Job({
+        'job_id': '123',
+        'cloud': 'ec2',
+        'requesting_user': 'test-user',
+        'last_service': 'test',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here',
+        'cleanup_images': True,
+        'test_fallback_regions': [],
+        'target_account_info': {},
+        'publish_in_marketplace': True,
+        'entity_id': '123',
+        'ssh_user': 'root',
+        'imds_version': 'v2.0',
+    })
+
+    message = job.get_create_message()
+    assert JsonFormat.json_loads(message)['create_job']['imds_version'] == \
+        'v2.0'


### PR DESCRIPTION

Additionally updates the requirements over the version of `ec2imgutils` supporting this feature.

