### PR TITLE
Replacing `setup` functions for `setup_method` in tests classes as `setup` seems deprecated by pytest

### DIFF
--- a/test/unit/log_filter_test.py
+++ b/test/unit/log_filter_test.py
@@ -9,7 +9,7 @@ import os
 
 
 class TestSchedulerLoggingFilter(object):
-    def setup(self):
+    def setup_method(self):
         self.log_filter = SchedulerLoggingFilter()
         self.record_type = namedtuple(
             'record_type', ['msg']
@@ -27,7 +27,7 @@ class TestSchedulerLoggingFilter(object):
 
 
 class TestBaseServiceFilter(object):
-    def setup(self):
+    def setup_method(self):
         self.log_filter = BaseServiceFilter()
         self.record = Mock()
         self.record.msg = 'Log Message!'

--- a/test/unit/log_handler_test.py
+++ b/test/unit/log_handler_test.py
@@ -9,7 +9,7 @@ from mash.log.handler import (
 
 
 class TestRabbitMQHandler(object):
-    def setup(self):
+    def setup_method(self):
         self.connection = Mock()
         self.channel = Mock()
         self.channel.exchange.declare.return_value = None

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -6,7 +6,7 @@ from pytest import raises
 
 
 class TestBaseConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.empty_config = BaseConfig('test/data/empty_mash_config.yaml')
         self.config = BaseConfig('test/data/mash_config.yaml')
 

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -6,7 +6,7 @@ from mash.mash_exceptions import MashJobException
 
 
 class TestMashJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/cleanup/config_test.py
+++ b/test/unit/services/cleanup/config_test.py
@@ -2,7 +2,7 @@ from mash.services.cleanup.config import CleanupConfig
 
 
 class TestTestConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.empty_config = CleanupConfig('test/data/empty_mash_config.yaml')
         self.config = CleanupConfig('test/data/mash_config.yaml')
 

--- a/test/unit/services/create/aliyun_job_test.py
+++ b/test/unit/services/create/aliyun_job_test.py
@@ -9,7 +9,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestAliyunCreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = BaseConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/create/azure_job_test.py
+++ b/test/unit/services/create/azure_job_test.py
@@ -9,7 +9,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestAzureCreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.credentials = {
             'test': {
                 'clientId': 'a',

--- a/test/unit/services/create/azure_sig_job_test.py
+++ b/test/unit/services/create/azure_sig_job_test.py
@@ -9,7 +9,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestAzureSIGCreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.credentials = {
             'test': {
                 'clientId': 'a',

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -11,7 +11,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestAmazonCreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = BaseConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/create/gce_job_test.py
+++ b/test/unit/services/create/gce_job_test.py
@@ -9,7 +9,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestGCECreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = BaseConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/create/oci_job_test.py
+++ b/test/unit/services/create/oci_job_test.py
@@ -9,7 +9,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestOCICreateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = BaseConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/credentials/config_test.py
+++ b/test/unit/services/credentials/config_test.py
@@ -2,7 +2,7 @@ from mash.services.credentials.config import CredentialsConfig
 
 
 class TestCredentialsConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.config = CredentialsConfig(
             'test/data/mash_config.yaml'
         )

--- a/test/unit/services/deprecate/aliyun_job_test.py
+++ b/test/unit/services/deprecate/aliyun_job_test.py
@@ -6,7 +6,7 @@ from mash.services.deprecate.aliyun_job import AliyunDeprecateJob
 
 
 class TestAliyunDeprecateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'deprecate',

--- a/test/unit/services/deprecate/ec2_job_test.py
+++ b/test/unit/services/deprecate/ec2_job_test.py
@@ -6,7 +6,7 @@ from mash.services.deprecate.ec2_job import EC2DeprecateJob
 
 
 class TestEC2DeprecateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'deprecate',

--- a/test/unit/services/deprecate/ec2_mp_job_test.py
+++ b/test/unit/services/deprecate/ec2_mp_job_test.py
@@ -6,7 +6,7 @@ from mash.services.deprecate.ec2_mp_job import EC2MPDeprecateJob
 
 
 class TestEC2MPDeprecateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'deprecate',

--- a/test/unit/services/deprecate/gce_job_test.py
+++ b/test/unit/services/deprecate/gce_job_test.py
@@ -6,7 +6,7 @@ from mash.mash_exceptions import MashDeprecateException
 
 
 class TestGCEDeprecateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'deprecate',

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -6,7 +6,7 @@ from mash.services.jobcreator.base_job import BaseJob
 
 class TestJobCreatorBaseJob(object):
 
-    def setup(self):
+    def setup_method(self):
         self.job = BaseJob({
             'job_id': '123',
             'cloud': 'aws',

--- a/test/unit/services/no_op_job_test.py
+++ b/test/unit/services/no_op_job_test.py
@@ -4,7 +4,7 @@ from mash.services.no_op_job import NoOpJob
 
 
 class TestNoOpJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'deprecate',

--- a/test/unit/services/publish/aliyun_job_test.py
+++ b/test/unit/services/publish/aliyun_job_test.py
@@ -6,7 +6,7 @@ from mash.services.publish.aliyun_job import AliyunPublishJob
 
 
 class TestAliyunPublishJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'publish',

--- a/test/unit/services/publish/azure_job_test.py
+++ b/test/unit/services/publish/azure_job_test.py
@@ -6,7 +6,7 @@ from mash.services.publish.azure_job import AzurePublishJob
 
 
 class TestAzurePublishJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'emails': 'jdoe@fake.com',
             'id': '1',

--- a/test/unit/services/publish/ec2_job_test.py
+++ b/test/unit/services/publish/ec2_job_test.py
@@ -6,7 +6,7 @@ from mash.services.publish.ec2_job import EC2PublishJob
 
 
 class TestEC2PublishJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'allow_copy': '123,321',
             'id': '1',

--- a/test/unit/services/publish/ec2_mp_job_test.py
+++ b/test/unit/services/publish/ec2_mp_job_test.py
@@ -6,7 +6,7 @@ from mash.services.publish.ec2_mp_job import EC2MPPublishJob
 
 
 class TestEC2MPPublishJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'publish',

--- a/test/unit/services/replicate/aliyun_job_test.py
+++ b/test/unit/services/replicate/aliyun_job_test.py
@@ -7,7 +7,7 @@ from mash.services.replicate.aliyun_job import AliyunReplicateJob
 
 
 class TestAliyunReplicateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'bucket': 'images',

--- a/test/unit/services/replicate/ec2_job_test.py
+++ b/test/unit/services/replicate/ec2_job_test.py
@@ -7,7 +7,7 @@ from mash.services.replicate.ec2_job import EC2ReplicateJob
 
 
 class TestEC2ReplicateJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'image_description': 'My image',

--- a/test/unit/services/test/aliyun_job_test.py
+++ b/test/unit/services/test/aliyun_job_test.py
@@ -8,7 +8,7 @@ from mash.services.test.config import TestConfig
 
 
 class TestAliyunTestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/test/azure_job_test.py
+++ b/test/unit/services/test/azure_job_test.py
@@ -7,7 +7,7 @@ from mash.mash_exceptions import MashTestException
 
 
 class TestAzureTestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/test/azure_sig_job_test.py
+++ b/test/unit/services/test/azure_sig_job_test.py
@@ -7,7 +7,7 @@ from mash.mash_exceptions import MashTestException
 
 
 class TestAzureSIGTestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -2,7 +2,7 @@ from mash.services.test.config import TestConfig
 
 
 class TestTestConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.empty_config = TestConfig('test/data/empty_mash_config.yaml')
         self.config = TestConfig('test/data/mash_config.yaml')
 

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -7,7 +7,7 @@ from mash.mash_exceptions import MashTestException
 
 
 class TestEC2TestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/test/gce_job_test.py
+++ b/test/unit/services/test/gce_job_test.py
@@ -8,7 +8,7 @@ from img_proof.ipa_exceptions import IpaRetryableError
 
 
 class TestGCETestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/test/oci_job_test.py
+++ b/test/unit/services/test/oci_job_test.py
@@ -8,7 +8,7 @@ from mash.services.test.config import TestConfig
 
 
 class TestOCITestJob(object):
-    def setup(self):
+    def setup_method(self):
         self.job_config = {
             'id': '1',
             'last_service': 'test',

--- a/test/unit/services/upload/aliyun_job_test.py
+++ b/test/unit/services/upload/aliyun_job_test.py
@@ -9,7 +9,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestAliyunUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = UploadConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/upload/azure_job_test.py
+++ b/test/unit/services/upload/azure_job_test.py
@@ -10,7 +10,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestAzureUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.credentials = {
             'test': {
                 'clientId': 'a',

--- a/test/unit/services/upload/azure_raw_job_test.py
+++ b/test/unit/services/upload/azure_raw_job_test.py
@@ -11,7 +11,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestAzureRawUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.credentials = {
             'test': {
                 'clientId': 'a',

--- a/test/unit/services/upload/azure_sas_job_test.py
+++ b/test/unit/services/upload/azure_sas_job_test.py
@@ -10,7 +10,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestAzureSASUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         job_doc = {
             'id': '1',
             'last_service': 'upload',

--- a/test/unit/services/upload/config_test.py
+++ b/test/unit/services/upload/config_test.py
@@ -6,7 +6,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestUploadConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.config = UploadConfig(
             'test/data/mash_config.yaml'
         )

--- a/test/unit/services/upload/gce_job_test.py
+++ b/test/unit/services/upload/gce_job_test.py
@@ -9,7 +9,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestGCEUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = UploadConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/upload/oci_job_test.py
+++ b/test/unit/services/upload/oci_job_test.py
@@ -9,7 +9,7 @@ from mash.services.upload.config import UploadConfig
 
 
 class TestOCIUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = UploadConfig(
             config_file='test/data/mash_config.yaml'
         )

--- a/test/unit/services/upload/s3bucket_job_test.py
+++ b/test/unit/services/upload/s3bucket_job_test.py
@@ -11,7 +11,7 @@ from mash.services.base_config import BaseConfig
 
 
 class TestS3BucketUploadJob(object):
-    def setup(self):
+    def setup_method(self):
         self.config = BaseConfig(
             config_file='test/data/mash_config.yaml'
         )


### PR DESCRIPTION

Apparently [setup is now deprecated](https://docs.pytest.org/en/latest/deprecations.html#setup-teardown)