### PR TITLE
Test regions configuration

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,8 +23,8 @@ jobs:
         pip install -e .
     - name: Lint with flake8
       run: |
-        flake8 --statistics -j auto --count mash
-        flake8 --statistics -j auto --count test/unit
+        flake8 --statistics -j auto --count --extend-ignore W503,W504 mash
+        flake8 --statistics -j auto --count --extend-ignore W503,W504 test/unit
     - name: Test with pytest
       run: |
         py.test --no-cov-on-fail --cov=mash \

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -58,6 +58,15 @@ cloud:
       aws-us-gov:
         - us-gov-east-1
         - us-gov-west-1
+    test_regions:
+      aws:
+        - us-east-1
+        - us-east-2
+        - us-west-1
+        - us-west-2
+      aws-us-gov:
+        - us-gov-east-1
+        - us-gov-west-1
     helper_images:
       af-south-1: ami-093ca241e4c72c205
       ap-east-1: ami-0e992f1e63814db10

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -60,13 +60,17 @@ cloud:
         - us-gov-west-1
     test_regions:
       aws:
-        - us-east-1
-        - us-east-2
-        - us-west-1
-        - us-west-2
+        us-east-1:
+          - subnet: subnet_1
+        us-east-2:
+          - subnet: subnet_2
+        us-west-1:
+          - subnet: subnet_3
       aws-us-gov:
-        - us-gov-east-1
-        - us-gov-west-1
+        us-gov-east-1:
+          - subnet: subnet_4
+        us-gov-west-1:
+          - subnet: subnet_5
     helper_images:
       af-south-1: ami-093ca241e4c72c205
       ap-east-1: ami-0e992f1e63814db10

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -38,6 +38,23 @@ def get_ec2_regions_by_partition(partition):
     return regions
 
 
+def get_ec2_test_regions_by_partition(partition):
+    """
+    Get EC2 test regions from config file based on partition.
+    """
+    test_regions = []
+    if (
+        'CLOUD_DATA' in current_app.config and
+        'ec2' in current_app.config['CLOUD_DATA'] and
+        'test_regions' in current_app.config['CLOUD_DATA']['ec2'] and
+        partition in current_app.config['CLOUD_DATA']['ec2']['test_regions']
+    ):
+        test_regions = copy.deepcopy(
+            current_app.config['CLOUD_DATA']['ec2']['test_regions'][partition]
+        )
+    return test_regions
+
+
 def get_ec2_helper_images():
     """
     Get helper image data for EC2 from config file.
@@ -78,6 +95,8 @@ def add_target_ec2_account(
                 helper_images[region['name']] = region['helper_image']
                 regions.append(region['name'])
 
+    test_regions = get_ec2_test_regions_by_partition(account['partition'])
+
     if use_root_swap:
         try:
             helper_image = job_doc_data['root_swap_ami']
@@ -93,6 +112,7 @@ def add_target_ec2_account(
         'account': account['name'],
         'partition': account['partition'],
         'target_regions': list(set(regions)),  # Remove any duplicates
+        'test_regions': list(set(test_regions)),
         'helper_image': helper_image,
         'subnet': subnet
     }

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -112,7 +112,7 @@ def add_target_ec2_account(
         'account': account['name'],
         'partition': account['partition'],
         'target_regions': list(set(regions)),  # Remove any duplicates
-        'test_regions': list(set(test_regions)),
+        'test_regions': test_regions,
         'helper_image': helper_image,
         'subnet': subnet
     }

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -44,10 +44,10 @@ def get_ec2_test_regions_by_partition(partition):
     """
     test_regions = []
     if (
-        'CLOUD_DATA' in current_app.config and
-        'ec2' in current_app.config['CLOUD_DATA'] and
-        'test_regions' in current_app.config['CLOUD_DATA']['ec2'] and
-        partition in current_app.config['CLOUD_DATA']['ec2']['test_regions']
+        'CLOUD_DATA' in current_app.config
+        and 'ec2' in current_app.config['CLOUD_DATA']
+        and 'test_regions' in current_app.config['CLOUD_DATA']['ec2']
+        and partition in current_app.config['CLOUD_DATA']['ec2']['test_regions']
     ):
         test_regions = copy.deepcopy(
             current_app.config['CLOUD_DATA']['ec2']['test_regions'][partition]

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -41,13 +41,18 @@ def test_get_ec2_regions_by_partition(mock_get_current_object):
         'CLOUD_DATA': {
             'ec2': {
                 'regions': {
-                    'aws': ['us-east-99']
+                    'aws': {
+                        'us-east-99': {
+                            'subnet': 'subnet_1'
+                        }
+                    }
                 }
             }
         }
     }
 
-    assert get_ec2_regions_by_partition('aws') == ['us-east-99']
+    assert get_ec2_regions_by_partition('aws')['us-east-99']['subnet'] == \
+        'subnet_1'
 
 
 @patch.object(LocalProxy, '_get_current_object')

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 
 # Source code quality/integrity check
 [testenv:check]
-extend_ignore = W504
+extend_ignore = W503,W504
 deps = {[testenv]deps}
 skip_install = True
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,10 @@ commands =
 
 # Source code quality/integrity check
 [testenv:check]
+extend_ignore = W504
 deps = {[testenv]deps}
 skip_install = True
 usedevelop = True
 commands =
-    flake8 --statistics -j auto --count {toxinidir}/mash
-    flake8 --statistics -j auto --count {toxinidir}/test/unit
+    flake8 --statistics -j auto --count --extend-ignore {[testenv:check]extend_ignore} {toxinidir}/mash
+    flake8 --statistics -j auto --count --extend-ignore {[testenv:check]extend_ignore} {toxinidir}/test/unit


### PR DESCRIPTION
For EC2 images (for now) adds a config setting to indicate the regions where the image should be replicated __for testing__ in each partition.

As this information is not expected to change frequently, I think setting the values in a config file is enough flexibility.

This information is taken into account in the API when the new job is created and is included in the job field where the regions for replication are kept.
