### PR TITLE
Modifies the ec2 accounts API to include the `subnets` element

### DIFF
--- a/mash/services/api/extensions.py
+++ b/mash/services/api/extensions.py
@@ -31,7 +31,7 @@ authorizations = {
 }
 
 api = Api(
-    version='13.11.0',
+    version='14.0.0',
     contact='public-cloud-dev@susecloud.net',
     title='MASH API',
     description='MASH provides a set of endpoints for Image Release '

--- a/mash/services/api/v1/schema/accounts/ec2.py
+++ b/mash/services/api/v1/schema/accounts/ec2.py
@@ -40,7 +40,7 @@ partition = {
     'enum': ['aws', 'aws-cn', 'aws-us-gov']
 }
 
-ec2_subnets = {
+test_regions = {
     'type': 'array',
     'items': {
         'type': 'object',
@@ -63,7 +63,7 @@ ec2_account = {
         'group': string_with_example('group1'),
         'partition': partition,
         'region': string_with_example('us-east-1'),
-        'subnets': ec2_subnets
+        'test_regions': test_regions
     },
     'additionalProperties': False,
     'required': [

--- a/mash/services/api/v1/schema/accounts/ec2.py
+++ b/mash/services/api/v1/schema/accounts/ec2.py
@@ -40,6 +40,21 @@ partition = {
     'enum': ['aws', 'aws-cn', 'aws-us-gov']
 }
 
+ec2_subnets = {
+    'type': 'array',
+    'items': {
+        'type': 'object',
+        'properties': {
+            'region': string_with_example('us-east-44'),
+            'subnet': string_with_example('T-12345678')
+        },
+        'required': ['region', 'subnet'],
+        'additionalProperties': False
+    },
+    'minItems': 1,
+    'example': [{'region': 'us-east-44', 'subnet': 'subnet-12345678'}]
+}
+
 ec2_account = {
     'type': 'object',
     'properties': {
@@ -48,7 +63,7 @@ ec2_account = {
         'group': string_with_example('group1'),
         'partition': partition,
         'region': string_with_example('us-east-1'),
-        'subnet': string_with_example('subnet-12345678')
+        'subnets': ec2_subnets
     },
     'additionalProperties': False,
     'required': [
@@ -79,7 +94,7 @@ ec2_account_update = {
         'additional_regions': additional_regions,
         'group': string_with_example('group1'),
         'region': string_with_example('us-east-1'),
-        'subnet': string_with_example('subnet-12345678'),
+        'subnets': ec2_subnets,
         'credentials': ec2_credentials
     },
     'additionalProperties': False,
@@ -87,7 +102,7 @@ ec2_account_update = {
         {'required': ['additional_regions']},
         {'required': ['group']},
         {'required': ['region']},
-        {'required': ['subnet']},
+        {'required': ['subnets']},
         {'required': ['credentials']}
     ]
 }

--- a/mash/services/api/v1/schema/accounts/ec2.py
+++ b/mash/services/api/v1/schema/accounts/ec2.py
@@ -63,6 +63,7 @@ ec2_account = {
         'group': string_with_example('group1'),
         'partition': partition,
         'region': string_with_example('us-east-1'),
+        'subnet': string_with_example('subnet-12345678'),
         'test_regions': test_regions
     },
     'additionalProperties': False,
@@ -94,7 +95,8 @@ ec2_account_update = {
         'additional_regions': additional_regions,
         'group': string_with_example('group1'),
         'region': string_with_example('us-east-1'),
-        'subnets': ec2_subnets,
+        'subnet': string_with_example('subnet-12345678'),
+        'test_regions': test_regions,
         'credentials': ec2_credentials
     },
     'additionalProperties': False,
@@ -102,7 +104,8 @@ ec2_account_update = {
         {'required': ['additional_regions']},
         {'required': ['group']},
         {'required': ['region']},
-        {'required': ['subnets']},
+        {'required': ['subnet']},
+        {'required': ['test_regions']},
         {'required': ['credentials']}
     ]
 }

--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -31,8 +31,7 @@ ec2_job_account = {
         ),
         'region': string_with_example(
             'us-east-1',
-            description='Region to use for initial image creation and '
-                        'test.'
+            description='Region to use for initial image creation.'
         ),
         'root_swap_ami': string_with_example(
             'ami-1234567890',
@@ -41,8 +40,7 @@ ec2_job_account = {
         ),
         'subnet': string_with_example(
             'subnet-12345678',
-            description='The subnet to use for image test and image '
-                        'creation.'
+            description='The subnet to use for image creation.'
         )
     },
     'additionalProperties': False,

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -64,8 +64,9 @@ def add_target_ec2_account(
     """
     job_doc_data = cloud_accounts.get(account['name'], {})
     region_name = job_doc_data.get('region') or account.get('region')
-    subnet = job_doc_data.get('subnet') or account.get('subnet')
-
+    subnet = job_doc_data.get('subnet') or get_subnet_for_region(
+        account.get('subnets'), region_name
+    )
     if skip_replication:
         regions = [region_name]
         if account.get('additional_regions'):  # In case an additional region is used
@@ -202,3 +203,15 @@ def validate_ec2_job(job_doc):
     job_doc['target_account_info'] = accounts
 
     return job_doc
+
+
+def get_subnet_for_region(subnets, region_name):
+    """
+    Provides the subnet configured in some account for a specific region
+    """
+    subnet_name = ''
+    for subnet in subnets:
+        if subnet['region'] == region_name:
+            subnet_name = subnet['subnet']
+            break
+    return subnet_name

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -64,20 +64,23 @@ def add_target_ec2_account(
     """
     job_doc_data = cloud_accounts.get(account['name'], {})
     region_name = job_doc_data.get('region') or account.get('region')
-    subnet = job_doc_data.get('subnet') or get_subnet_for_region(
-        account.get('subnets'), region_name
-    )
+    subnet = job_doc_data.get('subnet') or account.get('subnet')
+    test_regions = []
     if skip_replication:
         regions = [region_name]
         if account.get('additional_regions'):  # In case an additional region is used
             for region in account['additional_regions']:
                 helper_images[region['name']] = region['helper_image']
+        if account.get('test_regions', []):
+            test_regions = account.get('test_regions')
     else:
         regions = get_ec2_regions_by_partition(account['partition'])
         if account.get('additional_regions'):
             for region in account['additional_regions']:
                 helper_images[region['name']] = region['helper_image']
                 regions.append(region['name'])
+        if account.get('test_regions', []):
+            test_regions = account.get('test_regions')
 
     if use_root_swap:
         try:
@@ -95,7 +98,8 @@ def add_target_ec2_account(
         'partition': account['partition'],
         'target_regions': list(set(regions)),  # Remove any duplicates
         'helper_image': helper_image,
-        'subnet': subnet
+        'subnet': subnet,
+        'test_regions': test_regions
     }
 
 

--- a/test/unit/services/api/v1/routes/accounts/ec2_account_routes_test.py
+++ b/test/unit/services/api/v1/routes/accounts/ec2_account_routes_test.py
@@ -23,7 +23,13 @@ def test_api_add_account_ec2(
         },
         'group': 'group1',
         'partition': 'aws',
-        'region': 'us-east-1'
+        'region': 'us-east-1',
+        'test_regions': [
+            {
+                'region': 'us-east-2',
+                'subnet': 'subnet-12345678'
+            }
+        ]
     }
     response = Mock()
     response.json.return_value = request

--- a/test/unit/services/api/v1/routes/jobs/ec2_job_routes_test.py
+++ b/test/unit/services/api/v1/routes/jobs/ec2_job_routes_test.py
@@ -40,10 +40,11 @@ def test_api_add_job_ec2(
         'region': 'ap-northeast-1',
         'name': 'test-aws-gov',
         'partition': 'aws',
-        'subnets': [
+        'subnet': 'subnet-1111111',
+        'test_regions': [
             {
-                'subnet': 'subnet-1111111',
-                'region': 'ap-northeast-1'
+                'subnet': 'subnet-2222222',
+                'region': 'ap-northeast-2'
             }
         ]
     }

--- a/test/unit/services/api/v1/routes/jobs/ec2_job_routes_test.py
+++ b/test/unit/services/api/v1/routes/jobs/ec2_job_routes_test.py
@@ -39,7 +39,13 @@ def test_api_add_job_ec2(
     account = {
         'region': 'ap-northeast-1',
         'name': 'test-aws-gov',
-        'partition': 'aws'
+        'partition': 'aws',
+        'subnets': [
+            {
+                'subnet': 'subnet-1111111',
+                'region': 'ap-northeast-1'
+            }
+        ]
     }
     mock_get_account.return_value = account
     mock_get_accounts.return_value = [account]

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -78,6 +78,12 @@ def test_add_target_ec2_account(mock_get_regions):
                 'name': 'us-east-100',
                 'helper_image': 'ami-987'
             }
+        ],
+        'subnets': [
+            {
+                'subnet': 'subnet-111111',
+                'region': 'us-east-100'
+            }
         ]
     }
 

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -79,7 +79,7 @@ def test_add_target_ec2_account(mock_get_regions):
                 'helper_image': 'ami-987'
             }
         ],
-        'subnets': [
+        'test_regions': [
             {
                 'subnet': 'subnet-111111',
                 'region': 'us-east-100'
@@ -106,6 +106,8 @@ def test_add_target_ec2_account(mock_get_regions):
     assert accounts['us-east-100']['helper_image'] == 'ami-456'
     assert 'us-east-99' in accounts['us-east-100']['target_regions']
     assert 'us-east-100' in accounts['us-east-100']['target_regions']
+    assert 'subnet-111111' in \
+        accounts['us-east-100']['test_regions'][0]['subnet']
 
     cloud_accounts = {'acnt1': {}}
 


### PR DESCRIPTION

As discussed in the previous PR, in order to maintain the multi-tenancy feature of mash we need multiple `subnet` elements for every account to be able to perform tests in different regions.

Thus, this change modifies the API for the `ec2` accounts API endpoint to support such feature.
The format for the parameter is the following:

```
...
'subnets': [
       {
             'region': 'us-east-99',
             'subnet': 'subnet-000099'
        },
        {
             'region': 'us-east-100',
             'subnet': 'subnet-000100'
        }
```

For now this PR just addresses the API change. The DB  changes will be implemented in the following PR.
`mash-client` will be modified accordingly to this change (if required)