### PR TITLE
Update quickstart docs to run mash as container

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the mash pipeline. The following steps are needed to get started:
 
 ```bash
 podman pull registry.opensuse.org/virtualization/appliances/images/images_tw/opensuse/mash:latest
-podman run -ti mash
+podman run --cap-add CAP_SYS_ADMIN -ti --name mash_server mash
 ```
 
 The mash instance starts up and a login prompt to the system appears.


### PR DESCRIPTION
Recent changes on the podman and systemd side requires the CAP_SYS_ADMIN cgroup capability to be allowed in the instance. Thus the startup options for podman needs to be adapted.

