### PR TITLE
Implements the new test preparation service

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -18,7 +18,9 @@ services:
   - download
   - upload
   - create
+  - test_preparation
   - test
+  - test_cleanup
   - raw_image_upload
   - replicate
   - publish

--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -195,3 +195,9 @@ class MashEc2UtilsException(MashException):
     """
     Exception raised if an error occurs in EC2 Utils.
     """
+
+
+class MashTestPreparationException(MashException):
+    """
+    Base exception for test preparation service.
+    """

--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -168,6 +168,11 @@ ec2_job_message['properties']['launch_inst_type'] = string_with_example(
     'm1.large',
     description='The helper instance type to use for image creation with ec2uploadimg.'
 )
+ec2_job_message['properties']['imds_version'] = string_with_example(
+    'v2.0',
+    description='Set the protocol version to be used when instances are'
+                'launched from the image, supported values 2.0/v2.0. '
+)
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/database/migrations/versions/89a2cf1d3255_add_ec2_test_region_table.py
+++ b/mash/services/database/migrations/versions/89a2cf1d3255_add_ec2_test_region_table.py
@@ -1,4 +1,4 @@
-"""add ec2_subnet table
+"""add ec2_test_region table
 
 Revision ID: 89a2cf1d3255
 Revises: 15d8a6b81095

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -225,3 +225,25 @@ class BaseJob(object):
         Implementation in child class.
         """
         pass
+
+    def get_test_preparation_message(self):
+        """
+        Build test_preparation message.
+        """
+        raise NotImplementedError(
+            'This {0} class does not implement the '
+            'get_test_preparation_message method.'.format(
+                self.__class__.__name__
+            )
+        )
+
+    def get_test_cleanup_message(self):
+        """
+        Build test_cleanup message.
+        """
+        raise NotImplementedError(
+            'This {0} class does not implement the '
+            'get_test_cleanup_message method.'.format(
+                self.__class__.__name__
+            )
+        )

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -313,3 +313,55 @@ class EC2Job(BaseJob):
         upload_message['upload_job'].update(self.base_message)
 
         return JsonFormat.json_message(upload_message)
+
+    def get_test_preparation_message(self):
+        """
+        Build test_preparation message.
+        """
+        test_preparation_message = {
+            'test_preparation_job': {
+                'cloud': self.cloud,
+                'cloud_image_name': self.cloud_image_name,
+                'test_preparation_regions': self.get_test_preparation_regions()
+            }
+        }
+        test_preparation_message['test_preparation_job'].update(
+            self.base_message
+        )
+
+        return JsonFormat.json_message(test_preparation_message)
+
+    def get_test_preparation_regions(self):
+        """
+        Returns a dictionary of the regions where the test_preparation service
+        should replicate the image for the tests.
+        """
+        test_preparation_regions = {}
+
+        for source_region, value in self.target_account_info.items():
+            test_preparation_regions[source_region] = {
+                'account': value['account'],
+                'test_regions': [],
+                'partition': value['partition']
+            }
+            for test_region in value['test_regions']:
+                if test_region['region'] != source_region:
+                    test_preparation_regions[source_region]['test_regions']\
+                        .append(test_region['region'])
+
+        return test_preparation_regions
+
+    def get_test_cleanup_message(self):
+        """
+        Build test_cleanup message.
+        """
+        test_cleanup_message = {
+            'test_cleanup_job': {
+                'cloud': self.cloud,
+                'cloud_image_name': self.cloud_image_name,
+                'test_cleanup_regions': self.get_test_preparation_regions()
+            }
+        }
+        test_cleanup_message['test_cleanup_job'].update(self.base_message)
+
+        return JsonFormat.json_message(test_cleanup_message)

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -208,6 +208,14 @@ class JobCreatorService(MashService):
                 self.publish_job_doc(
                     'raw_image_upload', job.get_raw_image_upload_message()
                 )
+            elif service == 'test_preparation':
+                self.publish_job_doc(
+                    'test_preparation', job.get_test_preparation_message()
+                )
+            elif service == 'test_cleanup':
+                self.publish_job_doc(
+                    'test_cleanup', job.get_test_cleanup_message()
+                )
 
             if service == job.last_service:
                 break

--- a/mash/services/test_preparation/ec2_job.py
+++ b/mash/services/test_preparation/ec2_job.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import time
+
+from botocore.exceptions import ClientError
+from collections import defaultdict
+
+from mash.mash_exceptions import MashTestPreparationException
+from mash.services.mash_job import MashJob
+from mash.services.status_levels import FAILED, SUCCESS
+from mash.utils.ec2 import get_client, describe_images
+
+
+class EC2TestPreparationJob(MashJob):
+    """
+    Class for an EC2 test preparation job.
+    """
+
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        try:
+            self.test_preparation_regions = \
+                self.job_config['test_preparation_regions']
+        except KeyError as error:
+            raise MashTestPreparationException(
+                'EC2 test preparation jobs require a(n) {0} '
+                'key in the job doc.'.format(
+                    error
+                )
+            )
+
+        self.test_region_results = defaultdict(dict)
+
+    def run_job(self):
+        """
+        Replicate image to all target regions in each source region.
+        """
+        self.status = SUCCESS
+        self.status_msg['test_regions'] = {}
+        self.test_preparation_region_results = defaultdict(dict)
+        self.cloud_image_name = self.status_msg['cloud_image_name']
+
+        # Get all account credentials in one request
+        accounts = []
+        for source_region, reg_info in self.test_preparation_regions.items():
+            accounts.append(reg_info['account'])
+
+        self.request_credentials(accounts)
+
+        for source_region, reg_info in self.test_preparation_regions.items():
+            # Replicate image to all test regions
+            # for each source region
+            credential = self.credentials[reg_info['account']]
+
+            self.log_callback.info(
+                'Replicating source region: {0} to the following regions: {1}.'
+                .format(
+                    source_region, ', '.join(reg_info['test_regions'])
+                )
+            )
+
+            for test_region in reg_info['test_regions']:
+                image_id = self._replicate_to_region(
+                    credential,
+                    self.status_msg['source_regions'][source_region],
+                    source_region,
+                    test_region
+                )
+
+                self.log_callback.info(
+                    'Image  was replicated as {0} in {1} region.'
+                    'Image is not ready yet.'
+                    .format(image_id, test_region)
+                )
+
+                self.status_msg['test_regions'][test_region] = image_id
+                self.test_region_results[test_region]['image_id'] = \
+                    image_id
+
+                # Save account along with results to prevent searching dict
+                # twice to find associated credentials on each waiter.
+                self.test_region_results[test_region]['credential'] = \
+                    credential
+
+        if self.test_region_results:
+            self.log_callback.info('Waiting for images to replicate')
+            # Wait for images to replicate, this will take time.
+            # Only wait if at least one region was replicated.
+            time.sleep(300)
+
+        for test_region, reg_info in self.test_region_results.items():
+            credential = reg_info['credential']
+
+            if reg_info['image_id']:
+                try:
+                    self._wait_on_image(
+                        credential['access_key_id'],
+                        credential['secret_access_key'],
+                        reg_info['image_id'],
+                        test_region
+                    )
+                except Exception as error:
+                    self.status = FAILED
+                    msg = 'Replicate to {0} region failed: {1}'.format(
+                        test_region,
+                        error
+                    )
+                    self.add_error_msg(msg)
+                    self.log_callback.warning(msg)
+
+    def _replicate_to_region(
+        self, credential, image_id, source_region, target_region
+    ):
+        """
+        Replicate image to the target region from the source region.
+        """
+        client = get_client(
+            'ec2', credential['access_key_id'],
+            credential['secret_access_key'], target_region
+        )
+
+        try:
+            exists = self.image_exists(client, self.cloud_image_name)
+            if not exists:
+                description = (
+                    f'Image {image_id} replicated from {source_region} to '
+                    f'{target_region} for tests execution in this region.'
+                )
+                new_image = client.copy_image(
+                    Description=description,
+                    Name=self.cloud_image_name,
+                    SourceImageId=image_id,
+                    SourceRegion=source_region,
+                )
+            else:
+                new_image = {'ImageId': None}
+        except Exception as e:
+            raise MashTestPreparationException(
+                'There was an error replicating image to {0}. {1}'
+                .format(
+                    target_region, e
+                )
+            )
+
+        return new_image['ImageId']
+
+    @staticmethod
+    def _wait_on_image(access_key_id, secret_access_key, image_id, region):
+        """
+        Wait on image to finish replicating in the given region.
+        """
+        while True:
+            client = get_client(
+                'ec2',
+                access_key_id,
+                secret_access_key,
+                region
+            )
+
+            try:
+                images = describe_images(client, [image_id])
+                state = images[0]['State']
+            except (IndexError, KeyError, ClientError):
+                raise MashTestPreparationException(
+                    'The image with ID: {0} was not found.'.format(
+                        image_id
+                    )
+                )
+
+            if state == 'available':
+                break
+            elif state == 'failed':
+                raise MashTestPreparationException(
+                    'The image with ID: {0} reached a failed state.'.format(
+                        image_id
+                    )
+                )
+            elif state == 'pending':
+                time.sleep(60)
+
+    @staticmethod
+    def image_exists(client, cloud_image_name):
+        """
+        Determine if image exists given image name.
+        """
+        images = describe_images(client)
+        for image in images:
+            if cloud_image_name == image.get('Name'):
+                return True
+        return False

--- a/mash/services/test_preparation_service.py
+++ b/mash/services/test_preparation_service.py
@@ -25,6 +25,7 @@ from mash.mash_exceptions import MashException
 from mash.services.test_preparation.config import TestPreparationConfig
 from mash.services.listener_service import ListenerService
 from mash.services.job_factory import BaseJobFactory
+from mash.services.test_preparation.ec2_job import EC2TestPreparationJob
 
 
 def main():
@@ -43,6 +44,7 @@ def main():
         job_factory = BaseJobFactory(
             service_name=service_name,
             job_types={
+                'ec2': EC2TestPreparationJob
             }
         )
 

--- a/test/unit/services/test_preparation/ec2_job_test.py
+++ b/test/unit/services/test_preparation/ec2_job_test.py
@@ -1,0 +1,237 @@
+from pytest import raises
+from unittest.mock import Mock, patch, call
+
+from mash.mash_exceptions import MashTestPreparationException
+from mash.services.status_levels import FAILED
+from mash.services.test_preparation.ec2_job import EC2TestPreparationJob
+
+
+class TestEC2TestPreparationJob(object):
+    def setup_method(self):
+        self.job_config = {
+            'id': '1',
+            'image_description': 'My image',
+            'last_service': 'replicate',
+            'requesting_user': 'user1',
+            'cloud': 'ec2',
+            'utctime': 'now',
+            "test_preparation_regions": {
+                "us-east-1": {
+                    "account": "test-aws",
+                    "test_regions": [
+                        "us-east-2",
+                    ]
+                }
+            }
+        }
+
+        self.config = Mock()
+        self.job = EC2TestPreparationJob(self.job_config, self.config)
+        self.job._log_callback = Mock()
+
+        self.job.credentials = {
+            "test-aws": {
+                'access_key_id': '123456',
+                'secret_access_key': '654321'
+            }
+        }
+
+        self.job.status_msg['cloud_image_name'] = 'My image'
+        self.job.status_msg['source_regions'] = {'us-east-1': 'ami-12345'}
+
+    def test_replicate_ec2_missing_key(self):
+        del self.job_config['test_preparation_regions']
+
+        with raises(MashTestPreparationException):
+            EC2TestPreparationJob(self.job_config, self.config)
+
+    @patch('mash.services.test_preparation.ec2_job.time')
+    @patch.object(EC2TestPreparationJob, '_wait_on_image')
+    @patch.object(EC2TestPreparationJob, '_replicate_to_region')
+    def test_test_preparation(
+        self,
+        mock_replicate_to_region,
+        mock_wait_on_image,
+        mock_time
+    ):
+        mock_replicate_to_region.return_value = 'ami-54321'
+        mock_wait_on_image.side_effect = Exception('Broken!')
+
+        self.job.run_job()
+
+        self.job._log_callback.info.assert_has_calls([
+            call(
+                'Replicating source region: us-east-1 to the following '
+                'regions: us-east-2.'
+            ),
+            call(
+                'Image  was replicated as ami-54321 in us-east-2 region.'
+                'Image is not ready yet.'
+            ),
+            call('Waiting for images to replicate')
+        ])
+
+        self.job._log_callback.warning.assert_called_once_with(
+            'Replicate to us-east-2 region failed: Broken!'
+        )
+
+        mock_replicate_to_region.assert_called_once_with(
+            self.job.credentials['test-aws'], 'ami-12345',
+            'us-east-1', 'us-east-2'
+        )
+        mock_wait_on_image.assert_called_once_with(
+            self.job.credentials['test-aws']['access_key_id'],
+            self.job.credentials['test-aws']['secret_access_key'],
+            'ami-54321',
+            'us-east-2'
+        )
+        assert self.job.status == FAILED
+
+    @patch.object(EC2TestPreparationJob, 'image_exists')
+    @patch('mash.services.test_preparation.ec2_job.get_client')
+    def test_replicate_to_region(
+        self,
+        mock_get_client,
+        mock_image_exists
+    ):
+        client = Mock()
+        client.copy_image.return_value = {'ImageId': 'ami-12345'}
+        mock_get_client.return_value = client
+        mock_image_exists.return_value = False
+
+        self.job.cloud_image_name = 'My image'
+
+        self.job._replicate_to_region(
+            self.job.credentials['test-aws'],
+            'ami-12345',
+            'us-east-1',
+            'us-east-2'
+        )
+
+        mock_get_client.assert_called_once_with(
+            'ec2', '123456', '654321', 'us-east-2'
+        )
+        mock_image_exists.assert_called_once_with(
+            client,
+            'My image'
+        )
+        description = (
+            'Image ami-12345 replicated from us-east-1 to us-east-2 for '
+            'tests execution in this region.'
+        )
+        client.copy_image.assert_called_once_with(
+            Description=description,
+            Name='My image',
+            SourceImageId='ami-12345',
+            SourceRegion='us-east-1',
+        )
+
+    @patch.object(EC2TestPreparationJob, 'image_exists')
+    @patch('mash.services.test_preparation.ec2_job.get_client')
+    def test_test_preparation_replicate_to_region_exists(
+        self,
+        mock_get_client,
+        mock_image_exists
+    ):
+        client = Mock()
+        mock_get_client.return_value = client
+        mock_image_exists.return_value = True
+
+        result = self.job._replicate_to_region(
+            self.job.credentials['test-aws'],
+            'ami-12345', 'us-east-1', 'us-east-2'
+        )
+
+        assert result is None
+
+    @patch.object(EC2TestPreparationJob, 'image_exists')
+    @patch('mash.services.test_preparation.ec2_job.get_client')
+    def test_test_preparation_replicate_to_region_exception(
+        self,
+        mock_get_client,
+        mock_image_exists
+    ):
+        client = Mock()
+        client.copy_image.side_effect = Exception('Error copying image!')
+        mock_get_client.return_value = client
+        mock_image_exists.return_value = False
+
+        msg = 'There was an error replicating image to us-east-2. ' \
+            'Error copying image!'
+        with raises(MashTestPreparationException) as e:
+            self.job._replicate_to_region(
+                self.job.credentials['test-aws'],
+                'ami-12345',
+                'us-east-1',
+                'us-east-2'
+            )
+
+        assert msg == str(e.value)
+
+    @patch('mash.services.test_preparation.ec2_job.get_client')
+    def test_test_preparation_wait_on_image(self, mock_get_client):
+        client = Mock()
+        client.describe_images.return_value = {
+            'Images': [{'State': 'available'}]
+        }
+        mock_get_client.return_value = client
+
+        self.job._wait_on_image(
+            self.job.credentials['test-aws']['access_key_id'],
+            self.job.credentials['test-aws']['secret_access_key'],
+            'ami-54321',
+            'us-east-2'
+        )
+
+        mock_get_client.assert_called_once_with(
+            'ec2', '123456', '654321', 'us-east-2'
+        )
+        client.describe_images.assert_called_once_with(
+            Owners=['self'],
+            ImageIds=['ami-54321']
+        )
+
+    @patch('mash.services.test_preparation.ec2_job.time')
+    @patch('mash.services.test_preparation.ec2_job.get_client')
+    def test_test_preparation_wait_on_image_exception(
+        self,
+        mock_get_client,
+        mock_sleep
+    ):
+        client = Mock()
+        client.describe_images.side_effect = [
+            KeyError('Images'),
+            {'Images': [{'State': 'pending'}]},
+            {'Images': [{'State': 'failed'}]}
+        ]
+        mock_get_client.return_value = client
+
+        with raises(MashTestPreparationException):
+            self.job._wait_on_image(
+                self.job.credentials['test-aws']['access_key_id'],
+                self.job.credentials['test-aws']['secret_access_key'],
+                'ami-54321',
+                'us-east-2'
+            )
+
+        with raises(MashTestPreparationException):
+            self.job._wait_on_image(
+                self.job.credentials['test-aws']['access_key_id'],
+                self.job.credentials['test-aws']['secret_access_key'],
+                'ami-54321',
+                'us-east-2'
+            )
+
+    def test_test_preparation_image_exists(self):
+        images = {'Images': []}
+        client = Mock()
+        client.describe_images.return_value = images
+
+        result = self.job.image_exists(client, 'image name')
+
+        assert result is False
+
+        images['Images'].append({'Name': 'image name'})
+        result = self.job.image_exists(client, 'image name')
+
+        assert result


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR is part of the improvement effort in the test strategy. This PR implements the `test_preparation` service, which is the service that is executed right before the test service. The main goal for this test_preparation service is to copy the created image into the test_regions configured in the database for the account, so some tests (with different instance types/configurations) can be executed in these additional regions.

### How will these changes be tested?

The tests have been tested in a local development account against my aws personal account.

### How will this change be deployed? Any special considerations?
Nope

### Additional Information

This new service is really very similar to the replicate service.
Unit tests have been included for the service.
