### PR TITLE
Adds the code for the test_cleanup service for EC2 jobs

### DIFF
--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -195,3 +195,9 @@ class MashEc2UtilsException(MashException):
     """
     Exception raised if an error occurs in EC2 Utils.
     """
+
+
+class MashTestCleanupException(MashException):
+    """
+    Exception raised if an error occurs in EC2 test_cleanup service.
+    """

--- a/mash/services/test_cleanup/ec2_job.py
+++ b/mash/services/test_cleanup/ec2_job.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from mash.mash_exceptions import MashTestCleanupException
+from mash.services.mash_job import MashJob
+from mash.services.status_levels import SUCCESS
+from mash.utils.ec2 import cleanup_ec2_image
+
+
+class EC2TestCleanupJob(MashJob):
+    """
+    Class for an EC2 Cleanup job.
+    """
+
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        try:
+            self.test_cleanup_regions = self.job_config['test_cleanup_regions']
+
+        except KeyError as error:
+            raise MashTestCleanupException(
+                'EC2 Test cleanup job requires a(n) '
+                f'{0} key in the job doc.'.format(error)
+            )
+
+    def run_job(self):
+        """
+        Clean up the images that where replicated for testing purposes by the
+        test_preparation service.
+        """
+        self.status = SUCCESS
+
+        # Get all account credentials in one request
+        accounts = []
+        region_accounts = {}
+        for test_cleanup_region, reg_info in self.test_cleanup_regions.items():
+            accounts.append(reg_info['account'])
+            if 'target_regions' in reg_info:
+                for target_region in reg_info['target_regions']:
+                    region_accounts[target_region] = reg_info['account']
+
+        self.request_credentials(accounts)
+
+        regions_to_cleanup = self.status_msg.get('test_regions', {})
+        for region, image_id in regions_to_cleanup.items():
+            account = region_accounts[region]
+            credentials = self.credentials[account]
+
+            cleanup_ec2_image(
+                credentials['access_key_id'],
+                credentials['secret_access_key'],
+                self.log_callback,
+                region,
+                image_id=image_id
+            )

--- a/mash/services/test_cleanup/ec2_job.py
+++ b/mash/services/test_cleanup/ec2_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC.  All rights reserved.
+# Copyright (c) 2024 SUSE LLC.  All rights reserved.
 #
 # This file is part of mash.
 #

--- a/mash/services/test_cleanup_service.py
+++ b/mash/services/test_cleanup_service.py
@@ -20,12 +20,13 @@ import logging
 import sys
 import traceback
 
-
 # project
 from mash.mash_exceptions import MashException
+from mash.services.no_op_job import NoOpJob
 from mash.services.test_cleanup.config import TestCleanupConfig
 from mash.services.listener_service import ListenerService
 from mash.services.job_factory import BaseJobFactory
+from mash.services.test_cleanup.ec2_job import EC2TestCleanupJob
 
 
 def main():
@@ -44,6 +45,12 @@ def main():
         job_factory = BaseJobFactory(
             service_name=service_name,
             job_types={
+                'azure': NoOpJob,
+                'ec2': EC2TestCleanupJob,
+                'ec2_mp': EC2TestCleanupJob,
+                'gce': NoOpJob,
+                'oci': NoOpJob,
+                'aliyun': NoOpJob
             }
         )
 
@@ -70,3 +77,8 @@ def main():
         log.error('Unexpected error: {0}'.format(e))
         traceback.print_exc()
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    print('Ready to R&R')
+    main()

--- a/mash/services/test_cleanup_service.py
+++ b/mash/services/test_cleanup_service.py
@@ -77,8 +77,3 @@ def main():
         log.error('Unexpected error: {0}'.format(e))
         traceback.print_exc()
         sys.exit(1)
-
-
-if __name__ == '__main__':
-    print('Ready to R&R')
-    main()

--- a/test/unit/services/test_cleanup/ec2_job_test.py
+++ b/test/unit/services/test_cleanup/ec2_job_test.py
@@ -1,0 +1,74 @@
+import pytest
+
+from unittest.mock import call, Mock, patch
+
+from mash.services.test_cleanup.ec2_job import EC2TestCleanupJob
+from mash.mash_exceptions import MashTestCleanupException
+
+
+class TestEC2TestJob(object):
+    def setup_method(self):
+        self.job_config = {
+            'id': '1',
+            'last_service': 'test',
+            'cloud': 'ec2',
+            'requesting_user': 'user1',
+            'ssh_private_key_file': 'private_ssh_key.file',
+            'test_cleanup_regions': {
+                'us-east-1': {
+                    'account': 'test-aws',
+                    'partition': 'aws',
+                    'target_regions': ['us-east-2', 'eu-central-1']
+                }
+            },
+            'tests': ['test_stuff'],
+            'utctime': 'now',
+            'cleanup_images': True
+        }
+        self.config = Mock()
+
+    def test_test_cleanup_ec2_missing_key(self):
+        del self.job_config['test_cleanup_regions']
+
+        with pytest.raises(MashTestCleanupException):
+            EC2TestCleanupJob(self.job_config, self.config)
+
+    @patch('mash.services.test_cleanup.ec2_job.cleanup_ec2_image')
+    def test_test_run_test(
+        self,
+        mock_cleanup_image
+    ):
+
+        job = EC2TestCleanupJob(self.job_config, self.config)
+        job._log_callback = Mock()
+
+        job.credentials = {
+            'test-aws': {
+                'access_key_id': '123',
+                'secret_access_key': '321'
+            }
+        }
+        job.status_msg['test_regions'] = {
+            'us-east-2': 'ami-111111',
+            'eu-central-1': 'ami-222222',
+
+        }
+        job.run_job()
+
+        mock_cleanup_image.assert_has_calls([
+            call(
+                '123',
+                '321',
+                job._log_callback,
+                'us-east-2',
+                image_id='ami-111111'
+            ),
+            call(
+                '123',
+                '321',
+                job._log_callback,
+                'eu-central-1',
+                image_id='ami-222222'
+            )
+        ])
+        job._log_callback.warning.reset_mock()


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR includes the code for the new `test_cleanup` service. This service is responsible to remove the images that have been replicated in the configured test regions after tests are complete.

The job config document for the job has to include a `test_cleanup_regions` entry to get the account corresponding to the different new regions the images where replicated to by the `test_preparation` service.

Additionally gets the ami ids for the new images in those regions from the status_msg as published there by the `test_preparation` service.

### How will these changes be tested?

The tests have been locally tested with a mash development instance.

