### PR TITLE
Includes `cpu_options` in ec2 job schema and includes it in test message for ec2 jobs

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -173,6 +173,22 @@ ec2_job_message['properties']['imds_version'] = string_with_example(
     description='Set the protocol version to be used when instances are'
                 'launched from the image, supported values 2.0/v2.0. '
 )
+
+ec2_job_message['properties']['cpu_options'] = {
+    'type': 'object',
+    'properties': {
+        'AmdSevSnp': string_with_example(
+            'enabled',
+            description='Indicates that the image supports the use of SEV-SNP '
+                        'feature.'
+        ),
+    },
+    'additionalProperties': False,
+    'required': [],
+    'description': 'Cpu options supported in the image for this job.'
+                   'These options are optional.'
+}
+
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -51,6 +51,7 @@ class EC2Job(BaseJob):
             False
         )
         self.launch_inst_type = self.kwargs.get('launch_inst_type')
+        self.cpu_options = self.kwargs.get('cpu_options', {})
 
     def _get_target_regions_list(self):
         """
@@ -233,6 +234,9 @@ class EC2Job(BaseJob):
 
         if self.boot_firmware:
             test_message['test_job']['boot_firmware'] = self.boot_firmware
+
+        if self.cpu_options:
+            test_message['test_job']['cpu_options'] = self.cpu_options
 
         test_message['test_job'].update(self.base_message)
 


### PR DESCRIPTION

This PR is part of the changes to improve testing strategy in mash.
Includes the `cpu_options`  in the ec2 job schema and includes that param to the job document for the test service.
