### PR TITLE
Changes alibaba test instance type for an existing one (as of 202411)

### DIFF
--- a/mash/services/test/aliyun_job.py
+++ b/mash/services/test/aliyun_job.py
@@ -32,7 +32,7 @@ from mash.utils.mash_utils import create_ssh_key_pair
 from img_proof.ipa_controller import test_image
 
 instance_types = [
-    'ecs.t5-lc1m1.small'
+    'ecs.t6-c4m1.large'
 ]
 
 


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

The previous instance type that was used for tests on alibaba cloud seems no longer available.
Changing the instance type to one @smarlowucf  verified that works with img-proof (Thanks!).
