### PR TITLE
Includes a section in the config  file to provide test instance catalog for ec2

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -88,6 +88,43 @@ cloud:
       us-gov-west-1: ami-0e8f52046c02613e9
       us-west-1: ami-0ee3e1e65adeef858
       us-west-2: ami-0ec021424fb596d6c
+    test_instance_catalog:
+    - region: us-east-1
+      arch: x86_64
+      instance_names:
+      - c5.large
+      - m5.large
+      - t3.small
+      boot_types:
+        - uefi-preferred
+        - uefi
+      cpu_options: []
+    - region: us-east-1
+      arch: x86_64
+      instance_names:
+      - i3.large
+      - t2.small
+      boot_types:
+        - bios
+      cpu_options: []
+    - region: us-east-2
+      arch: x86_64
+      instance_names:
+      - m6a.large
+      - c6a.large
+      - r6a.large
+      boot_types:
+      - uefi-preferred
+      - uefi
+      cpu_options:
+      - AmdSevSnp_enabled
+    - region: us-east-1
+      arch: aarch64
+      instance_names:
+      - t4g.small
+      - m6g.medium
+      boot_types: []
+      cpu_options: []
 test:
   img_proof_timeout: 600
 upload:

--- a/mash/services/test/config.py
+++ b/mash/services/test/config.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from mash.mash_exceptions import MashConfigException
 from mash.services.base_config import BaseConfig
 from mash.services.test.defaults import Defaults
 
@@ -46,3 +47,17 @@ class TestConfig(BaseConfig):
             element='test'
         )
         return img_proof_timeout or Defaults.get_img_proof_timeout()
+
+    def get_test_ec2_instance_catalog(self):
+        """
+        Return the instance catalog configured for ec2 tests
+        """
+
+        ec2_cloud_info = self.get_cloud_data().get('ec2', {})
+        instance_catalog = ec2_cloud_info.get('test_instance_catalog', [])
+
+        if not instance_catalog:
+            raise MashConfigException(
+                'Ec2 test instance catalog must be provided in config file.'
+            )
+        return instance_catalog

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -41,6 +41,43 @@ cloud:
       ap-northeast-2: ami-249b554a
       cn-north-1: ami-bcc45885
       us-gov-west-1: ami-c2b5d7e1
+    test_instance_catalog:
+    - region: us-east-1
+      arch: x86_64
+      instance_names:
+      - c5.large
+      - m5.large
+      - t3.small
+      boot_types:
+        - uefi-preferred
+        - uefi
+      cpu_options: []
+    - region: us-east-1
+      arch: x86_64
+      instance_names:
+      - i3.large
+      - t2.small
+      boot_types:
+        - bios
+      cpu_options: []
+    - region: us-east-2
+      arch: x86_64
+      instance_names:
+      - m6a.large
+      - c6a.large
+      - r6a.large
+      boot_types:
+      - uefi-preferred
+      - uefi
+      cpu_options:
+      - AmdSevSnp_enabled
+    - region: us-east-1
+      arch: aarch64
+      instance_names:
+      - t4g.small
+      - m6g.medium
+      boot_types: []
+      cpu_options: []
 test:
   img_proof_timeout: 600
 upload:

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -12,3 +12,60 @@ class TestTestConfig(object):
 
     def test_get_img_proof_timeout(self):
         assert self.empty_config.get_img_proof_timeout() == 600
+
+    def test_get_test_ec2_instance_catalog(self):
+        expected_catalog = [
+            {
+                "region": "us-east-1",
+                "arch": "x86_64",
+                "instance_names": [
+                    "c5.large",
+                    "m5.large",
+                    "t3.small"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": []
+            },
+            {
+                "region": "us-east-1",
+                "arch": "x86_64",
+                "instance_names": [
+                    "i3.large",
+                    "t2.small"
+                ],
+                "boot_types": [
+                    "bios"
+                ],
+                "cpu_options": []
+            },
+            {
+                "region": "us-east-2",
+                "arch": "x86_64",
+                "instance_names": [
+                    "m6a.large",
+                    "c6a.large",
+                    "r6a.large"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": [
+                    "AmdSevSnp_enabled"
+                ]
+            },
+            {
+                "region": "us-east-1",
+                "arch": "aarch64",
+                "instance_names": [
+                    "t4g.small",
+                    "m6g.medium"
+                ],
+                "boot_types": [],
+                "cpu_options": []
+            }
+        ]
+        assert self.config.get_test_ec2_instance_catalog() == expected_catalog


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR belongs to the change to improve the testing strategy to cover additional instance configurations.
It includes a  section in the configuration file that allows to specify a catalog of instance types that can be used to test.

The section contains a list of dictionaries with the following fields:

- *region*: which region contains the instance group
- *arch*: which architecture are these instances for.
- *instance_names*:  list of different instance names that match all these params.
- *boot_types*: which boot types are supported by these instances.
- *cpu_options*: which cpu options are supported by these instances

Example:
```
cloud:
  ec2:
...
    test_instance_catalog:
    - region: us-east-1
      arch: x86_64
      instance_names:
      - c5.large
      - m5.large
      - t3.small
      boot_types:
        - uefi-preferred
        - uefi
      cpu_options: []
...
```

The test service in mash, deppeding on the instance options supported by the image (boot type, cpu_options , arch, for now) will select which combinations will be used for the tests. The selection logic and the tests service modification will be implemented in following PRs.

The regions included in the instance catalog have to be aligned with the additional_test_regions configured in mash database for the account. The additional test regions determine the additional regions where the image will be available for tests and the logic that selects the instance configuration for each test will pick instances from the instance catalog in those additional test regions.