### PR TITLE
Feature combinations selection

### DIFF
--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -44,7 +44,7 @@ def get_instance_feature_combinations(
     return list(set(compatible_combinations))
 
 
-def extend_boot_types(boot_types: list[str]) -> list[str]:
+def extend_boot_types(boot_types):
     """Extends the list of boot types with the implicit options"""
     if 'uefi-preferred' in boot_types and 'bios' not in boot_types:
         # If uefi-preferred, add bios option
@@ -52,7 +52,7 @@ def extend_boot_types(boot_types: list[str]) -> list[str]:
     return boot_types
 
 
-def extend_cpu_options(cpu_options: dict) -> list[str]:
+def extend_cpu_options(cpu_options):
     """Extends the list of cpu_options with the implicit options"""
     extended_cpu_options = []
     if 'AmdSevSnp' in cpu_options:
@@ -67,7 +67,7 @@ def extend_cpu_options(cpu_options: dict) -> list[str]:
     return extended_cpu_options
 
 
-def remove_incompatible_feature_combinations(feature_combinations) -> list[str]:
+def remove_incompatible_feature_combinations(feature_combinations):
     incompatible_combinations = []
     for feature_combination in feature_combinations:
         arch = feature_combination[0]

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2024 SUSE LLC.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import itertools
+
+
+def get_instance_feature_combinations(
+    arch: str,
+    boot_types: list,
+    cpu_options: dict
+):
+    """
+    Provides a list of tuples containing the instance feature combinations
+    that will be used for the tests.
+    """
+    archs = [arch]
+    boot_types = extend_boot_types(boot_types)
+    cpu_options = extend_cpu_options(cpu_options)
+    feature_combinations = list(
+        itertools.product(
+            archs,
+            boot_types,
+            cpu_options
+        )
+    )
+    compatible_combinations = remove_incompatible_feature_combinations(
+        feature_combinations
+    )
+    return list(set(compatible_combinations))
+
+
+def extend_boot_types(boot_types: list[str]) -> list[str]:
+    """Extends the list of boot types with the implicit options"""
+    if 'uefi-preferred' in boot_types and 'bios' not in boot_types:
+        # If uefi-preferred, add bios option
+        boot_types.append('bios')
+    return boot_types
+
+
+def extend_cpu_options(cpu_options: dict) -> list[str]:
+    """Extends the list of cpu_options with the implicit options"""
+    extended_cpu_options = []
+    if 'AmdSevSnp' in cpu_options:
+        extended_cpu_options.append(
+            f'AmdSevSnp_{cpu_options["AmdSevSnp"]}'
+        )
+
+    if 'AmdSevSnp_disabled' not in extended_cpu_options:
+        # Always add the sev_snp disabled option
+        extended_cpu_options.append('AmdSevSnp_disabled')
+
+    return extended_cpu_options
+
+
+def remove_incompatible_feature_combinations(feature_combinations) -> list[str]:
+    incompatible_combinations = []
+    for feature_combination in feature_combinations:
+        arch = feature_combination[0]
+        boot_type = feature_combination[1]
+        sev_snp = feature_combination[2]
+        if any([
+            # aarch64 requires UEFI boot
+            (arch == 'aarch64' and boot_type != 'uefi'),
+            # AmdSevSnp is not a aarch64 feature
+            (arch == 'aarch64' and sev_snp == 'AmdSevSnp_enabled'),
+            # AmdSevSnp enabled requires UEFI boot
+            (boot_type == 'bios' and sev_snp == 'AmdSevSnp_enabled')
+        ]):
+            incompatible_combinations.append(feature_combination)
+
+    for incompatible_combination in incompatible_combinations:
+        feature_combinations.remove(incompatible_combination)
+    return feature_combinations

--- a/test/unit/services/test/ec2_test_utils_test.py
+++ b/test/unit/services/test/ec2_test_utils_test.py
@@ -1,0 +1,45 @@
+
+from mash.services.test.ec2_test_utils import (
+    get_instance_feature_combinations
+)
+
+
+class TestEC2TestUtils(object):
+
+    def test_get_instance_feature_combinations(self):
+        """tests get_instance_feature_combinations function"""
+        test_cases = [
+            (
+                (
+                    'x86_64',
+                    ['uefi-preferred'],
+                    {
+                        'AmdSevSnp': 'enabled'
+                    }
+                ),
+                [
+                    ('x86_64', 'bios', 'AmdSevSnp_disabled'),
+                    ('x86_64', 'uefi-preferred', 'AmdSevSnp_disabled'),
+                    ('x86_64', 'uefi-preferred', 'AmdSevSnp_enabled'),
+                ]
+            ),
+            (
+                (
+                    'aarch64',
+                    ['uefi'],
+                    {}
+                ),
+                [
+                    ('aarch64', 'uefi', 'AmdSevSnp_disabled')
+                ]
+            )
+        ]
+
+        for features, expected_combinations in test_cases:
+            (arch, boot_types, cpu_options) = features
+            assert sorted(expected_combinations) == \
+                sorted(get_instance_feature_combinations(
+                    arch=arch,
+                    boot_types=boot_types,
+                    cpu_options=cpu_options
+                ))


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR includes the code that selects which instance features will be tested for EC2 jobs.
It takes into account the following fields:
  - architecture for the job
  - Boot type
  - Cpu options supported in the image (AmdSevSnp for the moment)

...and returns a list of the feature combinations that will be used for the instance configuration for the tests.

A following PR will select the instance types from the instance catalog (included in [the previous PR](https://github.com/SUSE-Enceladus/mash/pull/928)) taking the selected combinations of features that will be tested. 

