### PR TITLE
Implements the instance selector for the test service

### DIFF
--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -107,11 +107,6 @@ def select_instances_for_tests(
     """
     instances = []
     for feature_combination in feature_combinations:
-        if logger:
-            logger.debug(
-                'Selecting instance for feature combination: '
-                f'{feature_combination}'
-            )
         instance = select_instance_for_feature_combination(
             feature_combination=feature_combination,
             instance_catalog=instance_catalog,
@@ -120,7 +115,9 @@ def select_instances_for_tests(
         if instance:
             instances.append(instance)
             if logger:
-                logger.debug(f'The following instance was selected {instance}')
+                logger.debug(
+                    f'Selected instance {instance} for {feature_combination}'
+                )
         else:
             msg = (
                 'Unable to find instance to test this feature combination: '

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -17,6 +17,10 @@
 #
 
 import itertools
+import logging
+import random
+
+from mash.mash_exceptions import MashTestException
 
 
 def get_instance_feature_combinations(
@@ -86,3 +90,90 @@ def remove_incompatible_feature_combinations(feature_combinations):
     for incompatible_combination in incompatible_combinations:
         feature_combinations.remove(incompatible_combination)
     return feature_combinations
+
+
+def select_instances_for_tests(
+    instance_catalog: list,
+    feature_combinations: list,
+    logger: logging.Logger = None
+) -> list:
+    """
+    Selects the instance types and configurations used in the tests
+    Taking as input the instance catalog configured and the
+    feature_combinations that are required to be tested, chooses some intances
+    to cover the provided feature combinations.
+    Raises a MashTestException if there's some feature_combination that is not
+    possible to test with the instance_catalog.
+    """
+    instances = []
+    for feature_combination in feature_combinations:
+        if logger:
+            logger.debug(
+                'Selecting instance for feature combination: '
+                f'{feature_combination}'
+            )
+        instance = select_instance_for_feature_combination(
+            feature_combination=feature_combination,
+            instance_catalog=instance_catalog,
+            logger=logger
+        )
+        if instance:
+            instances.append(instance)
+            if logger:
+                logger.debug(f'The following instance was selected {instance}')
+        else:
+            msg = (
+                'Unable to find instance to test this feature combination: '
+                f'{feature_combination}'
+            )
+            if logger:
+                logger.error(msg)
+            raise MashTestException(msg)
+    return instances
+
+
+def select_instance_for_feature_combination(
+    feature_combination: tuple,
+    instance_catalog: list,
+    logger: logging.Logger = None
+):
+    """
+    selects from the instance_catalog one instance that covers the
+    feature_combination provided.
+    Returns None if there's is no instance in the catalog to test that
+    feature combination.
+    """
+
+    candidate_groups = []
+
+    arch = feature_combination[0]
+    boot_type = feature_combination[1]
+    cpu_option = feature_combination[2]
+
+    for instance_group in instance_catalog:
+        if arch != instance_group.get('arch'):
+            # arch not matching the group
+            continue
+
+        if boot_type not in instance_group.get('boot_types', []):
+            # required boot type not supported
+            continue
+
+        if 'enabled' in cpu_option and cpu_option not in instance_group.get(
+            'cpu_options', []
+        ):
+            # required cpu_option enabled not supported
+            continue
+        candidate_groups.append(instance_group)
+
+    instance = None
+    if candidate_groups:
+        selected_group = random.choice(candidate_groups)
+        instance = {
+            'arch': arch,
+            'instance_name': random.choice(selected_group['instance_names']),
+            'boot_type': boot_type,
+            'cpu_option': cpu_option,
+            'region': selected_group['region']
+        }
+    return instance

--- a/test/unit/services/test/ec2_test_utils_test.py
+++ b/test/unit/services/test/ec2_test_utils_test.py
@@ -1,6 +1,11 @@
+import pytest
 
+from unittest.mock import Mock
+
+from mash.mash_exceptions import MashTestException
 from mash.services.test.ec2_test_utils import (
-    get_instance_feature_combinations
+    get_instance_feature_combinations,
+    select_instances_for_tests
 )
 
 
@@ -43,3 +48,122 @@ class TestEC2TestUtils(object):
                     boot_types=boot_types,
                     cpu_options=cpu_options
                 ))
+
+    def test_select_instances_for_tests(self):
+        """tests the select_instances_for_tests"""
+
+        instance_catalog = [
+            {
+                "region": "us-east-1",
+                "arch": "x86_64",
+                "instance_names": [
+                        "c5.large"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": []
+            },
+            {
+                "region": "us-east-1",
+                "arch": "x86_64",
+                "instance_names": [
+                    "i3.large"
+                ],
+                "boot_types": [
+                    "bios"
+                ],
+                "cpu_options": []
+            },
+            {
+                "region": "us-east-2",
+                "arch": "x86_64",
+                "instance_names": [
+                    "m6a.large"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": [
+                    "AmdSevSnp_enabled"
+                ]
+            },
+            {
+                "region": "us-east-1",
+                "arch": "aarch64",
+                "instance_names": [
+                    "t4g.small",
+                    "m6g.medium"
+                ],
+                "boot_types": [],
+                "cpu_options": []
+            }
+        ]
+
+        test_cases = [
+            (
+                [('x86_64', 'bios', 'AmdSevSnp_disabled')],
+                [
+                    {
+                        'region': 'us-east-1',
+                        'instance_name': 'i3.large',
+                        'boot_type': 'bios',
+                        'cpu_option': 'AmdSevSnp_disabled',
+                        'arch': 'x86_64'
+                    }
+                ]
+            ),
+            (
+                [
+                    ('x86_64', 'bios', 'AmdSevSnp_disabled'),
+                    ('x86_64', 'uefi-preferred', 'AmdSevSnp_enabled')],
+                [
+                    {
+                        'region': 'us-east-1',
+                        'instance_name': 'i3.large',
+                        'boot_type': 'bios',
+                        'cpu_option': 'AmdSevSnp_disabled',
+                        'arch': 'x86_64'
+                    },
+                    {
+                        'region': 'us-east-2',
+                        'instance_name': 'm6a.large',
+                        'boot_type': 'uefi-preferred',
+                        'cpu_option': 'AmdSevSnp_enabled',
+                        'arch': 'x86_64'
+                    }
+                ]
+
+            )
+        ]
+        logger = Mock()
+        for feature_combinations, expected_instances in test_cases:
+            selected_instances = select_instances_for_tests(
+                feature_combinations=feature_combinations,
+                instance_catalog=instance_catalog,
+                logger=logger
+            )
+            for instance in selected_instances:
+                assert instance in expected_instances
+
+        # error case
+        logger.reset_mock()
+        feature_combination = (
+            'non_existing_arch',
+            'bios',
+            'AmdSevSnp_disabled'
+        )
+        msg = (
+            'Unable to find instance to test this feature combination: '
+            f'{feature_combination}'
+        )
+        with pytest.raises(MashTestException) as error:
+            select_instances_for_tests(
+                feature_combinations=[feature_combination],
+                instance_catalog=instance_catalog,
+                logger=logger
+            )
+            assert msg in str(error)
+        logger.error.assert_called_once_with(msg)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

Implements the instance selection from the catalog to cover the feature_combinations that are required to be tested.
