### PR TITLE
Include the instance selection logic in test service

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -123,7 +123,9 @@ cloud:
       instance_names:
       - t4g.small
       - m6g.medium
-      boot_types: []
+      boot_types:
+      - uefi
+      - uefi-preferred
       cpu_options: []
 test:
   img_proof_timeout: 600

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -244,22 +244,28 @@ class EC2Job(BaseJob):
 
     def get_test_regions(self):
         """
-        Return a dictionary of target test regions.
+        Returns a dictionary of regions for the test service.
+        This dictionary will have as key the region name and as value a nested
+        dictionary with the following fields:
+          - account: which account has to be used for the tests in that region
+            This value is extracted from the target_account_info structure
+          - partition: which partition this region belongs to. Also extracted
+            from the target_account_info struct.
+          - subnet: what is the subnet that needs to be used in the tests for
+            that region. This data is extracted from the `test_regions` list
+            inside the target_account_info dictionary
         """
-        test_regions = {}
+        regions_for_tests = {}
 
-        for source_region, value in self.target_account_info.items():
-            account = value['account']
-            partition = value['partition']
-            for test_region in value.get('test_regions', []):
-                region = test_region['region']
-                subnet = test_region['subnet']
-                test_regions[region] = {
-                    'account': account,
-                    'partition': partition,
-                    'subnet': subnet
+        for source_region, account_info in self.target_account_info.items():
+            for test_region in account_info.get('test_regions', []):
+                region_name = test_region['region']
+                regions_for_tests[region_name] = {
+                    'account': account_info['account'],
+                    'partition': account_info['partition'],
+                    'subnet': test_region['subnet']
                 }
-        return test_regions
+        return regions_for_tests
 
     def get_create_message(self):
         """

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -249,12 +249,16 @@ class EC2Job(BaseJob):
         test_regions = {}
 
         for source_region, value in self.target_account_info.items():
-            test_regions[source_region] = {
-                'account': value['account'],
-                'subnet': value['subnet'],
-                'partition': value['partition']
-            }
-
+            account = value['account']
+            partition = value['partition']
+            for test_region in value.get('test_regions', []):
+                region = test_region['region']
+                subnet = test_region['subnet']
+                test_regions[region] = {
+                    'account': account,
+                    'partition': partition,
+                    'subnet': subnet
+                }
         return test_regions
 
     def get_create_message(self):
@@ -354,7 +358,7 @@ class EC2Job(BaseJob):
                 'target_regions': [],
                 'partition': value['partition']
             }
-            for test_region in value['test_regions']:
+            for test_region in value.get('test_regions', []):
                 if test_region['region'] != source_region:
                     test_preparation_regions[source_region]['target_regions']\
                         .append(test_region['region'])

--- a/mash/services/replicate/ec2_job.py
+++ b/mash/services/replicate/ec2_job.py
@@ -48,7 +48,7 @@ class EC2ReplicateJob(MashJob):
                 self.job_config['replicate_source_regions']
 
             if self.test_preparation:
-                self.status_msg_result_key = 'test_regions'
+                self.status_msg_result_key = 'test_replicated_regions'
             else:
                 self.status_msg_result_key = 'source_regions'
         except KeyError as error:

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -79,7 +79,7 @@ def remove_incompatible_feature_combinations(feature_combinations):
         sev_snp = feature_combination[2]
         if any([
             # aarch64 requires UEFI boot
-            (arch == 'aarch64' and boot_type != 'uefi'),
+            (arch == 'aarch64' and boot_type == 'bios'),
             # AmdSevSnp is not a aarch64 feature
             (arch == 'aarch64' and sev_snp == 'AmdSevSnp_enabled'),
             # AmdSevSnp enabled requires UEFI boot

--- a/mash/services/test_cleanup/ec2_job.py
+++ b/mash/services/test_cleanup/ec2_job.py
@@ -51,14 +51,16 @@ class EC2TestCleanupJob(MashJob):
         accounts = []
         region_accounts = {}
         for test_cleanup_region, reg_info in self.test_cleanup_regions.items():
-            accounts.append(reg_info['account'])
+            account = reg_info['account']
+            if account not in accounts:
+                accounts.append(account)
             if 'target_regions' in reg_info:
                 for target_region in reg_info['target_regions']:
-                    region_accounts[target_region] = reg_info['account']
+                    region_accounts[target_region] = account
 
         self.request_credentials(accounts)
 
-        regions_to_cleanup = self.status_msg.get('test_regions', {})
+        regions_to_cleanup = self.status_msg.get('test_replicated_regions', {})
         for region, image_id in regions_to_cleanup.items():
             account = region_accounts[region]
             credentials = self.credentials[account]

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -1,6 +1,10 @@
 import pytest
 
-from unittest.mock import call, Mock, patch
+from unittest.mock import (
+    # call,
+    Mock,
+    patch
+)
 
 from mash.services.test.ec2_job import EC2TestJob
 from mash.mash_exceptions import MashTestException
@@ -32,155 +36,155 @@ class TestEC2TestJob(object):
         with pytest.raises(MashTestException):
             EC2TestJob(self.job_config, self.config)
 
-    @patch('mash.services.test.ec2_job.cleanup_ec2_image')
-    @patch('mash.services.test.ec2_job.os')
-    @patch('mash.services.test.ec2_job.create_ssh_key_pair')
-    @patch('mash.services.test.ec2_job.random')
-    @patch('mash.utils.ec2.EC2Setup')
-    @patch('mash.utils.ec2.generate_name')
-    @patch('mash.utils.ec2.get_client')
-    @patch('mash.utils.ec2.get_key_from_file')
-    @patch('mash.utils.ec2.get_vpc_id_from_subnet')
-    @patch('mash.services.test.ec2_job.test_image')
-    def test_test_run_test(
-        self, mock_test_image, mock_get_vpc_id_from_subnet,
-        mock_get_key_from_file, mock_get_client, mock_generate_name,
-        mock_ec2_setup, mock_random, mock_create_ssh_key_pair, mock_os,
-        mock_cleanup_image
-    ):
-        client = Mock()
-        mock_get_client.return_value = client
-        mock_generate_name.return_value = 'random_name'
-        mock_get_key_from_file.return_value = 'fakekey'
-        mock_random.choice.return_value = 't2.micro'
-        mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
+    # @patch('mash.services.test.ec2_job.cleanup_ec2_image')
+    # @patch('mash.services.test.ec2_job.os')
+    # @patch('mash.services.test.ec2_job.create_ssh_key_pair')
+    # @patch('mash.services.test.ec2_job.random')
+    # @patch('mash.utils.ec2.EC2Setup')
+    # @patch('mash.utils.ec2.generate_name')
+    # @patch('mash.utils.ec2.get_client')
+    # @patch('mash.utils.ec2.get_key_from_file')
+    # @patch('mash.utils.ec2.get_vpc_id_from_subnet')
+    # @patch('mash.services.test.ec2_job.test_image')
+    # def test_test_run_test(
+    #     self, mock_test_image, mock_get_vpc_id_from_subnet,
+    #     mock_get_key_from_file, mock_get_client, mock_generate_name,
+    #     mock_ec2_setup, mock_random, mock_create_ssh_key_pair, mock_os,
+    #     mock_cleanup_image
+    # ):
+    #     client = Mock()
+    #     mock_get_client.return_value = client
+    #     mock_generate_name.return_value = 'random_name'
+    #     mock_get_key_from_file.return_value = 'fakekey'
+    #     mock_random.choice.return_value = 't2.micro'
+    #     mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
 
-        ec2_setup = Mock()
-        ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
-        ec2_setup.create_security_group.return_value = 'sg-123456789'
-        mock_ec2_setup.return_value = ec2_setup
+    #     ec2_setup = Mock()
+    #     ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
+    #     ec2_setup.create_security_group.return_value = 'sg-123456789'
+    #     mock_ec2_setup.return_value = ec2_setup
 
-        mock_test_image.return_value = (
-            0,
-            {
-                'tests': [
-                    {
-                        "outcome": "passed",
-                        "test_index": 0,
-                        "name": "test_sles_ec2_metadata.py::test_sles_ec2_metadata[paramiko://10.0.0.10]"
-                    }
-                ],
-                'summary': {
-                    "duration": 2.839970827102661,
-                    "passed": 1,
-                    "num_tests": 1
-                },
-                'info': {
-                    'log_file': 'test.log',
-                    'results_file': 'test.results',
-                    'instance': 'i-123456789'
-                }
-            }
-        )
-        mock_os.path.exists.return_value = False
+    #     mock_test_image.return_value = (
+    #         0,
+    #         {
+    #             'tests': [
+    #                 {
+    #                     "outcome": "passed",
+    #                     "test_index": 0,
+    #                     "name": "test_sles_ec2_metadata.py::test_sles_ec2_metadata[paramiko://10.0.0.10]"
+    #                 }
+    #             ],
+    #             'summary': {
+    #                 "duration": 2.839970827102661,
+    #                 "passed": 1,
+    #                 "num_tests": 1
+    #             },
+    #             'info': {
+    #                 'log_file': 'test.log',
+    #                 'results_file': 'test.results',
+    #                 'instance': 'i-123456789'
+    #             }
+    #         }
+    #     )
+    #     mock_os.path.exists.return_value = False
 
-        job = EC2TestJob(self.job_config, self.config)
-        job._log_callback = Mock()
-        mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
-        job.credentials = {
-            'test-aws': {
-                'access_key_id': '123',
-                'secret_access_key': '321'
-            }
-        }
-        job.status_msg['source_regions'] = {'us-east-1': 'ami-123'}
-        job.run_job()
+    #     job = EC2TestJob(self.job_config, self.config)
+    #     job._log_callback = Mock()
+    #     mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
+    #     job.credentials = {
+    #         'test-aws': {
+    #             'access_key_id': '123',
+    #             'secret_access_key': '321'
+    #         }
+    #     }
+    #     job.status_msg['source_regions'] = {'us-east-1': 'ami-123'}
+    #     job.run_job()
 
-        client.import_key_pair.asser_has_calls([
-            call(KeyName='random_name', PublicKeyMaterial='fakekey'),
-            call(KeyName='random_name', PublicKeyMaterial='fakekey')
-        ])
-        mock_call = call(
-            'ec2',
-            access_key_id='123',
-            cleanup=True,
-            description=job.description,
-            distro='sles',
-            image_id='ami-123',
-            instance_type='t2.micro',
-            log_level=10,
-            timeout=600,
-            region='us-east-1',
-            secret_access_key='321',
-            security_group_id='sg-123456789',
-            ssh_key_name='random_name',
-            ssh_private_key_file='private_ssh_key.file',
-            ssh_user='ec2-user',
-            subnet_id='subnet-123456789',
-            tests=['test_stuff'],
-            log_callback=job._log_callback,
-            prefix_name='mash'
-        )
-        mock_test_image.assert_has_calls([mock_call, mock_call])
-        client.delete_key_pair.assert_has_calls([
-            call(KeyName='random_name'),
-            call(KeyName='random_name')
-        ])
-        mock_cleanup_image.assert_called_once_with(
-            '123',
-            '321',
-            job._log_callback,
-            'us-east-1',
-            image_id='ami-123'
-        )
-        job._log_callback.warning.reset_mock()
+    #     client.import_key_pair.asser_has_calls([
+    #         call(KeyName='random_name', PublicKeyMaterial='fakekey'),
+    #         call(KeyName='random_name', PublicKeyMaterial='fakekey')
+    #     ])
+    #     mock_call = call(
+    #         'ec2',
+    #         access_key_id='123',
+    #         cleanup=True,
+    #         description=job.description,
+    #         distro='sles',
+    #         image_id='ami-123',
+    #         instance_type='t2.micro',
+    #         log_level=10,
+    #         timeout=600,
+    #         region='us-east-1',
+    #         secret_access_key='321',
+    #         security_group_id='sg-123456789',
+    #         ssh_key_name='random_name',
+    #         ssh_private_key_file='private_ssh_key.file',
+    #         ssh_user='ec2-user',
+    #         subnet_id='subnet-123456789',
+    #         tests=['test_stuff'],
+    #         log_callback=job._log_callback,
+    #         prefix_name='mash'
+    #     )
+    #     mock_test_image.assert_has_calls([mock_call, mock_call])
+    #     client.delete_key_pair.assert_has_calls([
+    #         call(KeyName='random_name'),
+    #         call(KeyName='random_name')
+    #     ])
+    #     mock_cleanup_image.assert_called_once_with(
+    #         '123',
+    #         '321',
+    #         job._log_callback,
+    #         'us-east-1',
+    #         image_id='ami-123'
+    #     )
+    #     job._log_callback.warning.reset_mock()
 
-        # Failed job test
-        mock_test_image.side_effect = Exception('Tests broken!')
-        job.run_job()
-        job._log_callback.warning.assert_has_calls([
-            call('Image tests failed in region: us-east-1.')
-        ])
-        assert 'Tests broken!' in job._log_callback.error.mock_calls[0][1][0]
-        assert ec2_setup.clean_up.call_count == 4
+    #     # Failed job test
+    #     mock_test_image.side_effect = Exception('Tests broken!')
+    #     job.run_job()
+    #     job._log_callback.warning.assert_has_calls([
+    #         call('Image tests failed in region: us-east-1.')
+    #     ])
+    #     assert 'Tests broken!' in job._log_callback.error.mock_calls[0][1][0]
+    #     assert ec2_setup.clean_up.call_count == 4
 
-        # Failed key cleanup
-        client.delete_key_pair.side_effect = Exception('Cannot delete key!')
-        job.run_job()
+    #     # Failed key cleanup
+    #     client.delete_key_pair.side_effect = Exception('Cannot delete key!')
+    #     job.run_job()
 
-    def test_test_run_test_subnet(self):
-        self.job_config['test_regions']['us-east-1']['subnet'] = 'subnet-123456789'
-        self.test_test_run_test()
+    # def test_test_run_test_subnet(self):
+    #     self.job_config['test_regions']['us-east-1']['subnet'] = 'subnet-123456789'
+    #     self.test_test_run_test()
 
-    @patch('mash.services.test.ec2_job.random')
-    @patch('mash.services.test.ec2_job.os')
-    def test_run_test_arm_skip(self, mock_os, mock_random):
-        mock_os.path.exists.return_value = True
-        mock_random.choice.return_value = 'a1.large'
+    # @patch('mash.services.test.ec2_job.random')
+    # @patch('mash.services.test.ec2_job.os')
+    # def test_run_test_arm_skip(self, mock_os, mock_random):
+    #     mock_os.path.exists.return_value = True
+    #     mock_random.choice.return_value = 'a1.large'
 
-        job_config = {
-            'id': '2',
-            'last_service': 'test',
-            'cloud': 'ec2',
-            'requesting_user': 'user1',
-            'ssh_private_key_file': 'private_ssh_key.file',
-            'test_regions': {
-                'cn-east-1': {'account': 'test-aws-cn', 'partition': 'aws-cn'}
-            },
-            'tests': ['test_stuff'],
-            'utctime': 'now',
-            'cloud_architecture': 'aarch64'
-        }
-        job = EC2TestJob(job_config, self.config)
-        job._log_callback = Mock()
-        job.credentials = {
-            'test-aws-cn': {
-                'access_key_id': '123',
-                'secret_access_key': '321'
-            }
-        }
-        job.status_msg['source_regions'] = {'cn-east-1': 'ami-123'}
-        job.run_job()
+    #     job_config = {
+    #         'id': '2',
+    #         'last_service': 'test',
+    #         'cloud': 'ec2',
+    #         'requesting_user': 'user1',
+    #         'ssh_private_key_file': 'private_ssh_key.file',
+    #         'test_regions': {
+    #             'cn-east-1': {'account': 'test-aws-cn', 'partition': 'aws-cn'}
+    #         },
+    #         'tests': ['test_stuff'],
+    #         'utctime': 'now',
+    #         'cloud_architecture': 'aarch64'
+    #     }
+    #     job = EC2TestJob(job_config, self.config)
+    #     job._log_callback = Mock()
+    #     job.credentials = {
+    #         'test-aws-cn': {
+    #             'access_key_id': '123',
+    #             'secret_access_key': '321'
+    #         }
+    #     }
+    #     job.status_msg['source_regions'] = {'cn-east-1': 'ami-123'}
+    #     job.run_job()
 
     @patch('mash.services.test.ec2_job.create_ssh_key_pair')
     def test_ec2_skip_test(

--- a/test/unit/services/test_cleanup/ec2_job_test.py
+++ b/test/unit/services/test_cleanup/ec2_job_test.py
@@ -48,7 +48,7 @@ class TestEC2TestJob(object):
                 'secret_access_key': '321'
             }
         }
-        job.status_msg['test_regions'] = {
+        job.status_msg['test_replicated_regions'] = {
             'us-east-2': 'ami-111111',
             'eu-central-1': 'ami-222222',
 

--- a/test/unit/services/test_preparation/ec2_job_test.py
+++ b/test/unit/services/test_preparation/ec2_job_test.py
@@ -96,5 +96,5 @@ class TestEC2ReplicateJob(object):
             )
         ])
         assert self.job.status == FAILED
-        assert 'us-east-2' in self.job.status_msg['test_regions']
-        assert 'us-east-3' in self.job.status_msg['test_regions']
+        assert 'us-east-2' in self.job.status_msg['test_replicated_regions']
+        assert 'us-east-3' in self.job.status_msg['test_replicated_regions']


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR includes some changes:
- Bug fix in 'mash/services/test/ec2_test_utils.py' for arm images boot mode.
- Changes the key  used in the `test_preparation` service to publish the AMI-IDs of the copied images. This key also used in the `test_cleanup` service.
- In the test service, includes the instance type selection mechanism. For now I left the code to execute the tests commented. It will implemented in following PRs.
- Fixed `job_creator` tests to include the new test services.
