### PR TITLE
Removes exception raising if some feature combination cannot be tested

### DIFF
--- a/mash/services/test/ec2_job.py
+++ b/mash/services/test/ec2_job.py
@@ -145,7 +145,7 @@ class EC2TestJob(MashJob):
                     self.log_callback.error(msg)
                 raise MashTestException(msg)
 
-            for instance_type in self.instance_types:
+            for instance_type in instance_types:
                 if self.log_callback:
                     self.log_callback.info(
                         'Running img-proof tests for image in {part} with '

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -21,8 +21,6 @@ import itertools
 import logging
 import random
 
-from mash.mash_exceptions import MashTestException
-
 
 def get_instance_feature_combinations(
     arch: str,
@@ -122,13 +120,13 @@ def select_instances_for_tests(
                     f'Selected instance {instance} for {feature_combination}'
                 )
         else:
+            # Just writing in the log the issue for now
             msg = (
                 'Unable to find instance to test this feature combination: '
                 f'{feature_combination}'
             )
             if logger:
                 logger.error(msg)
-            raise MashTestException(msg)
     return instances
 
 

--- a/test/unit/services/test/ec2_test_utils_test.py
+++ b/test/unit/services/test/ec2_test_utils_test.py
@@ -1,8 +1,5 @@
-import pytest
-
 from unittest.mock import Mock
 
-from mash.mash_exceptions import MashTestException
 from mash.services.test.ec2_test_utils import (
     get_instance_feature_combinations,
     select_instances_for_tests,
@@ -188,14 +185,13 @@ class TestEC2TestUtils(object):
             'Unable to find instance to test this feature combination: '
             f'{feature_combination}'
         )
-        with pytest.raises(MashTestException) as error:
-            select_instances_for_tests(
-                test_regions=['us-gov-west-1'],
-                feature_combinations=[feature_combination],
-                instance_catalog=instance_catalog,
-                logger=logger
-            )
-            assert msg in str(error)
+        instance_types = select_instances_for_tests(
+            test_regions=['us-gov-west-1'],
+            feature_combinations=[feature_combination],
+            instance_catalog=instance_catalog,
+            logger=logger
+        )
+        assert instance_types == []
         logger.error.assert_called_once_with(msg)
 
     def test_get_partition_test_regions(self):


### PR DESCRIPTION
in a partition

### What does this PR do? Why are we making this change?
This is part of the improvement of the test strategy in AWS.

I think raising an exception if the configured test instance catalog is not able to cover some instance feature combination could be troublesome (at least in the first months after the deployment of this new feature).

This PR changes that behavior and just some error log is printed if it's not possible to test some feature combination in some AWS partition (with the test instance catalog configured)

### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
