### PR TITLE
Additional log in test preparation service

### DIFF
--- a/mash/services/replicate/ec2_job.py
+++ b/mash/services/replicate/ec2_job.py
@@ -109,6 +109,15 @@ class EC2ReplicateJob(MashJob):
                     image_id
                 self.source_region_results[target_region]['image_id'] = \
                     image_id
+
+                if self.test_preparation:
+                    self.log_callback.info(
+                        'Replicated image to {0} region: {1}.'
+                        .format(
+                            target_region,
+                            image_id
+                        )
+                    )
                 # Save account along with results to prevent searching dict
                 # twice to find associated credentials on each waiter.
                 self.source_region_results[target_region]['account'] = \

--- a/test/unit/services/test_preparation/ec2_job_test.py
+++ b/test/unit/services/test_preparation/ec2_job_test.py
@@ -56,10 +56,14 @@ class TestEC2ReplicateJob(object):
 
         self.job.run_job()
 
-        self.job._log_callback.info.assert_called_once_with(
-            '(test-preparation=True) Replicating source region: us-east-1 to '
-            'the following regions: us-east-2, us-east-3.'
-        )
+        self.job._log_callback.info.assert_has_calls([
+            call(
+                '(test-preparation=True) Replicating source region: us-east-1 to '
+                'the following regions: us-east-2, us-east-3.'
+            ),
+            call('Replicated image to us-east-2 region: ami-54321.'),
+            call('Replicated image to us-east-3 region: ami-54321.')
+        ])
         self.job._log_callback.warning.assert_has_calls([
             call('Replicate to us-east-2 region failed: Broken!'),
             call('Replicate to us-east-3 region failed: Broken!')


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
This change includes an additional entry to the log to  register the ID of the image that is replicated to the test regions in order to ease cleanup in case of issues in later services.

