### PR TITLE
Includes the option to add tests deppending on the features of the test

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -187,6 +187,9 @@ cloud:
       - uefi
       - uefi-preferred
       cpu_options: []
+    instance_feature_additional_tests:
+      AmdSevSnp_enabled:
+        - test_sles_sev_snp
 test:
   img_proof_timeout: 600
 upload:

--- a/mash/services/test/config.py
+++ b/mash/services/test/config.py
@@ -61,3 +61,15 @@ class TestConfig(BaseConfig):
                 'Ec2 test instance catalog must be provided in config file.'
             )
         return instance_catalog
+
+    def get_ec2_instance_feature_additional_tests(self):
+        """
+        Returns the additional tests configured for the different instance
+        features (if any).
+        """
+        ec2_cloud_info = self.get_cloud_data().get('ec2', {})
+        instance_feat_additional_tests = ec2_cloud_info.get(
+            'instance_feature_additional_tests',
+            {}
+        )
+        return instance_feat_additional_tests

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -209,3 +209,18 @@ def get_image_id_for_region(
     elif region in replicate_source_regions:
         return replicate_source_regions[region]
     return ''
+
+
+def get_additional_tests_for_instance(
+    arch,
+    boot_type,
+    cpu_option,
+    additional_tests
+):
+    """Provides a list of additional tests configured for each instance type"""
+    tests = []
+
+    tests.extend(additional_tests.get(arch, []))
+    tests.extend(additional_tests.get(boot_type, []))
+    tests.extend(additional_tests.get(cpu_option, []))
+    return tests

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -78,6 +78,9 @@ cloud:
       - m6g.medium
       boot_types: []
       cpu_options: []
+    instance_feature_additional_tests:
+      AmdSevSnp_enabled:
+        - test_sles_sev_snp
 test:
   img_proof_timeout: 600
 upload:

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -69,3 +69,12 @@ class TestTestConfig(object):
             }
         ]
         assert self.config.get_test_ec2_instance_catalog() == expected_catalog
+
+    def test_get_ec2_instance_feature_additional_tests(self):
+        expected_additional_tests = {
+            "AmdSevSnp_enabled": [
+                "test_sles_sev_snp"
+            ]
+        }
+        assert self.config.get_ec2_instance_feature_additional_tests() == \
+            expected_additional_tests


### PR DESCRIPTION
instance

### What does this PR do? Why are we making this change?

Includes an option to add tests to the test suite depending on the features of the instance used for the tests.
For example, if we are testing an instance that has SEV SNP active, we are able to include such test for that instance and verify the feature is actually active.

### How will these changes be tested?

Tested locally with a local mash instance using my aws account.

### How will this change be deployed? Any special considerations?

Mash config file has to be modified to add the new configured tests.

### Additional Information
