### PR TITLE
Includes the cpu_options param in the img-proof invocation

### DIFF
--- a/mash/services/test/ec2_job.py
+++ b/mash/services/test/ec2_job.py
@@ -33,7 +33,8 @@ from mash.services.test.ec2_test_utils import (
     select_instances_for_tests,
     get_partition_test_regions,
     get_image_id_for_region,
-    get_additional_tests_for_instance
+    get_additional_tests_for_instance,
+    get_cpu_options
 )
 from mash.utils.mash_utils import create_ssh_key_pair
 from mash.utils.ec2 import (
@@ -122,6 +123,7 @@ class EC2TestJob(MashJob):
             self.boot_firmware,
             self.cpu_options
         )
+
         if self.log_callback:
             self.log_callback.info(
                 'The list of features combinations to be tested are:'
@@ -188,6 +190,9 @@ class EC2TestJob(MashJob):
                         additional_tests=self.config.get_ec2_instance_feature_additional_tests()  # NOQA
                     )
                 )
+                cpu_options = get_cpu_options(
+                    instance_type.get('cpu_option', '')
+                )
                 if self.log_callback:
                     self.log_callback.info(
                         'The tests that will be run for this instance type '
@@ -220,7 +225,8 @@ class EC2TestJob(MashJob):
                         ssh_user=self.ssh_user,
                         tests=tests,
                         log_callback=self.log_callback,
-                        network_details=network_details
+                        network_details=network_details,
+                        cpu_options=cpu_options
                     )
                     if status != SUCCESS:
                         self.status = status
@@ -264,7 +270,8 @@ class EC2TestJob(MashJob):
         ssh_user,
         tests,
         log_callback,
-        network_details
+        network_details,
+        cpu_options={}
     ):
         try:
             exit_status, result = test_image(
@@ -286,7 +293,8 @@ class EC2TestJob(MashJob):
                 subnet_id=network_details['subnet_id'],
                 tests=tests,
                 log_callback=log_callback,
-                prefix_name='mash'
+                prefix_name='mash',
+                cpu_options=cpu_options
             )
         except Exception as error:
             self.add_error_msg(str(error))

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -224,3 +224,16 @@ def get_additional_tests_for_instance(
     tests.extend(additional_tests.get(boot_type, []))
     tests.extend(additional_tests.get(cpu_option, []))
     return tests
+
+
+def get_cpu_options(
+    cpu_option=''
+):
+    """Provides the cpu_options dictionary as expected by img_utils"""
+    cpu_options = {}
+    for cpu_opt in cpu_option.split(',', maxsplit=-1):
+
+        if cpu_opt and 'disabled' not in cpu_opt.lower():
+            (key, value) = cpu_opt.split('_', 1)
+            cpu_options[key] = value
+    return cpu_options

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -1,9 +1,10 @@
 import pytest
 
 from unittest.mock import (
-    # call,
+    call,
     Mock,
-    patch
+    patch,
+    ANY
 )
 
 from mash.services.test.ec2_job import EC2TestJob
@@ -23,12 +24,61 @@ class TestEC2TestJob(object):
             },
             'tests': ['test_stuff'],
             'utctime': 'now',
-            'cleanup_images': True
+            'cleanup_images': True,
+            'cloud_architecture': 'x86_64',
+            'boot_firmware': ['uefi-preferred'],
+            'cpu_options': {
+                'AmdSevSnp': 'enabled'
+            }
         }
         self.config = Mock()
         self.config.get_ssh_private_key_file.return_value = \
             'private_ssh_key.file'
         self.config.get_img_proof_timeout.return_value = 600
+        self.config.get_test_ec2_instance_catalog.return_value = [
+            {
+                "region": "us-east-2",
+                "arch": "x86_64",
+                "instance_names": [
+                    "m6a.large"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": [],
+                "partition": "aws"
+            },
+            {
+                "region": "us-east-2",
+                "arch": "x86_64",
+                "instance_names": [
+                    "m6a.large"
+                ],
+                "boot_types": [
+                    "uefi-preferred",
+                    "uefi"
+                ],
+                "cpu_options": [
+                    "AmdSevSnp_enabled"
+                ],
+                "partition": "aws"
+            },
+            {
+                "region": "us-east-1",
+                "arch": "aarch64",
+                "instance_names": [
+                    "t4g.small",
+                    "m6g.medium"
+                ],
+                "boot_types": [],
+                "cpu_options": [],
+                "partition": "aws"
+            }
+        ]
+        self.config.get_ec2_instance_feature_additional_tests.return_value = {
+            'AmdSevSnp_enabled': ['test_sev_snp']
+        }
 
     def test_test_ec2_missing_key(self):
         del self.job_config['test_regions']
@@ -36,155 +86,199 @@ class TestEC2TestJob(object):
         with pytest.raises(MashTestException):
             EC2TestJob(self.job_config, self.config)
 
-    # @patch('mash.services.test.ec2_job.cleanup_ec2_image')
-    # @patch('mash.services.test.ec2_job.os')
-    # @patch('mash.services.test.ec2_job.create_ssh_key_pair')
+    @patch('mash.services.test.ec2_job.cleanup_ec2_image')
+    @patch('mash.services.test.ec2_job.os')
     # @patch('mash.services.test.ec2_job.random')
-    # @patch('mash.utils.ec2.EC2Setup')
-    # @patch('mash.utils.ec2.generate_name')
-    # @patch('mash.utils.ec2.get_client')
-    # @patch('mash.utils.ec2.get_key_from_file')
-    # @patch('mash.utils.ec2.get_vpc_id_from_subnet')
-    # @patch('mash.services.test.ec2_job.test_image')
-    # def test_test_run_test(
-    #     self, mock_test_image, mock_get_vpc_id_from_subnet,
-    #     mock_get_key_from_file, mock_get_client, mock_generate_name,
-    #     mock_ec2_setup, mock_random, mock_create_ssh_key_pair, mock_os,
-    #     mock_cleanup_image
-    # ):
-    #     client = Mock()
-    #     mock_get_client.return_value = client
-    #     mock_generate_name.return_value = 'random_name'
-    #     mock_get_key_from_file.return_value = 'fakekey'
-    #     mock_random.choice.return_value = 't2.micro'
-    #     mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
+    @patch('mash.utils.ec2.EC2Setup')
+    @patch('mash.utils.ec2.generate_name')
+    @patch('mash.utils.ec2.get_client')
+    @patch('mash.utils.ec2.get_key_from_file')
+    @patch('mash.utils.ec2.get_vpc_id_from_subnet')
+    @patch('mash.services.test.ec2_job.test_image')
+    @patch('mash.services.test.ec2_job.create_ssh_key_pair')
+    def test_test_run_test(
+        self,
+        mock_create_ssh_key_pair,
+        mock_test_image,
+        mock_get_vpc_id_from_subnet,
+        mock_get_key_from_file,
+        mock_get_client,
+        mock_generate_name,
+        mock_ec2_setup,
+        mock_os,
+        mock_cleanup_image
+    ):
+        client = Mock()
+        mock_get_client.return_value = client
+        mock_generate_name.return_value = 'random_name'
+        mock_get_key_from_file.return_value = 'fakekey'
+        #     mock_random.choice.return_value = 't2.micro'
+        mock_get_vpc_id_from_subnet.return_value = 'vpc-123456789'
 
-    #     ec2_setup = Mock()
-    #     ec2_setup.create_vpc_subnet.return_value = 'subnet-123456789'
-    #     ec2_setup.create_security_group.return_value = 'sg-123456789'
-    #     mock_ec2_setup.return_value = ec2_setup
+        ec2_setup = Mock()
+        ec2_setup.create_vpc_subnet.return_value = 'subnet-1111111'
+        ec2_setup.create_security_group.return_value = 'sg-11111111'
+        mock_ec2_setup.return_value = ec2_setup
 
-    #     mock_test_image.return_value = (
-    #         0,
-    #         {
-    #             'tests': [
-    #                 {
-    #                     "outcome": "passed",
-    #                     "test_index": 0,
-    #                     "name": "test_sles_ec2_metadata.py::test_sles_ec2_metadata[paramiko://10.0.0.10]"
-    #                 }
-    #             ],
-    #             'summary': {
-    #                 "duration": 2.839970827102661,
-    #                 "passed": 1,
-    #                 "num_tests": 1
-    #             },
-    #             'info': {
-    #                 'log_file': 'test.log',
-    #                 'results_file': 'test.results',
-    #                 'instance': 'i-123456789'
-    #             }
-    #         }
-    #     )
-    #     mock_os.path.exists.return_value = False
+        mock_test_image.return_value = (
+            0,
+            {
+                'tests': [
+                    {
+                        "outcome": "passed",
+                        "test_index": 0,
+                        "name": "test_sles_ec2_metadata.py::test_sles_ec2_metadata[paramiko://10.0.0.10]"
+                    }
+                ],
+                'summary': {
+                    "duration": 2.839970827102661,
+                    "passed": 1,
+                    "num_tests": 1
+                },
+                'info': {
+                    'log_file': 'test.log',
+                    'results_file': 'test.results',
+                    'instance': 'i-11111111'
+                }
+            }
+        )
+        mock_os.path.exists.return_value = False
 
-    #     job = EC2TestJob(self.job_config, self.config)
-    #     job._log_callback = Mock()
-    #     mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
-    #     job.credentials = {
-    #         'test-aws': {
-    #             'access_key_id': '123',
-    #             'secret_access_key': '321'
-    #         }
-    #     }
-    #     job.status_msg['source_regions'] = {'us-east-1': 'ami-123'}
-    #     job.run_job()
+        job = EC2TestJob(self.job_config, self.config)
+        job._log_callback = Mock()
 
-    #     client.import_key_pair.asser_has_calls([
-    #         call(KeyName='random_name', PublicKeyMaterial='fakekey'),
-    #         call(KeyName='random_name', PublicKeyMaterial='fakekey')
-    #     ])
-    #     mock_call = call(
-    #         'ec2',
-    #         access_key_id='123',
-    #         cleanup=True,
-    #         description=job.description,
-    #         distro='sles',
-    #         image_id='ami-123',
-    #         instance_type='t2.micro',
-    #         log_level=10,
-    #         timeout=600,
-    #         region='us-east-1',
-    #         secret_access_key='321',
-    #         security_group_id='sg-123456789',
-    #         ssh_key_name='random_name',
-    #         ssh_private_key_file='private_ssh_key.file',
-    #         ssh_user='ec2-user',
-    #         subnet_id='subnet-123456789',
-    #         tests=['test_stuff'],
-    #         log_callback=job._log_callback,
-    #         prefix_name='mash'
-    #     )
-    #     mock_test_image.assert_has_calls([mock_call, mock_call])
-    #     client.delete_key_pair.assert_has_calls([
-    #         call(KeyName='random_name'),
-    #         call(KeyName='random_name')
-    #     ])
-    #     mock_cleanup_image.assert_called_once_with(
-    #         '123',
-    #         '321',
-    #         job._log_callback,
-    #         'us-east-1',
-    #         image_id='ami-123'
-    #     )
-    #     job._log_callback.warning.reset_mock()
+        mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
 
-    #     # Failed job test
-    #     mock_test_image.side_effect = Exception('Tests broken!')
-    #     job.run_job()
-    #     job._log_callback.warning.assert_has_calls([
-    #         call('Image tests failed in region: us-east-1.')
-    #     ])
-    #     assert 'Tests broken!' in job._log_callback.error.mock_calls[0][1][0]
-    #     assert ec2_setup.clean_up.call_count == 4
+        job.test_regions = {
+            'us-east-1': {
+                'partition': 'aws',
+                'account': 'us-east-1-test-account',
+                'subnet': 'subnet_east_1'
+            },
+            'us-east-2': {
+                'partition': 'aws',
+                'account': 'us-east-2-test-account',
+                'subnet': 'subnet_east_2'
+            },
+        }
+        job.credentials = {
+            'us-east-1-test-account': {
+                'access_key_id': '111_',
+                'secret_access_key': '_111'
+            },
+            'us-east-2-test-account': {
+                'access_key_id': '222_',
+                'secret_access_key': '_222'
+            }
+        }
+        job.status_msg['source_regions'] = {'us-east-1': 'ami-123'}
+        job.status_msg['test_replicated_regions'] = {'us-east-2': 'ami-321'}
+        job.run_job()
 
-    #     # Failed key cleanup
-    #     client.delete_key_pair.side_effect = Exception('Cannot delete key!')
-    #     job.run_job()
+        client.import_key_pair.asser_has_calls([
+            call(KeyName='random_name', PublicKeyMaterial='fakekey'),
+            call(KeyName='random_name', PublicKeyMaterial='fakekey')
+        ])
+        client.get_waiter.assert_has_calls([
+            call('instance_terminated'),
+            call().wait(InstanceIds=['i-11111111']),
+            call('instance_terminated'),
+            call().wait(InstanceIds=['i-11111111'])
+        ])
+        client.delete_key_pair.assert_has_calls([
+            call(KeyName='random_name')
+        ])
 
-    # def test_test_run_test_subnet(self):
-    #     self.job_config['test_regions']['us-east-1']['subnet'] = 'subnet-123456789'
-    #     self.test_test_run_test()
+        mock_call_1 = call(
+            'ec2',
+            access_key_id='222_',
+            cleanup=True,
+            description=None,
+            distro='sles',
+            image_id='ami-321',
+            instance_type='m6a.large',
+            timeout=600,
+            log_level=10,
+            region='us-east-2',
+            secret_access_key='_222',
+            security_group_id='sg-11111111',
+            ssh_key_name='random_name',
+            ssh_private_key_file='private_ssh_key.file',
+            ssh_user='ec2-user',
+            subnet_id='subnet_east_2',
+            tests=['test_stuff', 'test_sev_snp'],
+            log_callback=job.log_callback,
+            prefix_name='mash',
+            cpu_options={'AmdSevSnp': 'enabled'}
+        )
+        mock_call_2 = call(
+            'ec2',
+            access_key_id='222_',
+            cleanup=True,
+            description=None,
+            distro='sles',
+            image_id='ami-321',
+            instance_type='m6a.large',
+            timeout=600,
+            log_level=10,
+            region='us-east-2',
+            secret_access_key='_222',
+            security_group_id='sg-11111111',
+            ssh_key_name='random_name',
+            ssh_private_key_file='private_ssh_key.file',
+            ssh_user='ec2-user',
+            subnet_id='subnet_east_2',
+            tests=['test_stuff'],
+            log_callback=job.log_callback,
+            prefix_name='mash',
+            cpu_options={}
+        )
 
-    # @patch('mash.services.test.ec2_job.random')
-    # @patch('mash.services.test.ec2_job.os')
-    # def test_run_test_arm_skip(self, mock_os, mock_random):
-    #     mock_os.path.exists.return_value = True
-    #     mock_random.choice.return_value = 'a1.large'
+        # assert mock_test_image.mock_calls == [mock_call_1, mock_call_2]
+        assert mock_call_1 in mock_test_image.mock_calls
+        assert mock_call_2 in mock_test_image.mock_calls
 
-    #     job_config = {
-    #         'id': '2',
-    #         'last_service': 'test',
-    #         'cloud': 'ec2',
-    #         'requesting_user': 'user1',
-    #         'ssh_private_key_file': 'private_ssh_key.file',
-    #         'test_regions': {
-    #             'cn-east-1': {'account': 'test-aws-cn', 'partition': 'aws-cn'}
-    #         },
-    #         'tests': ['test_stuff'],
-    #         'utctime': 'now',
-    #         'cloud_architecture': 'aarch64'
-    #     }
-    #     job = EC2TestJob(job_config, self.config)
-    #     job._log_callback = Mock()
-    #     job.credentials = {
-    #         'test-aws-cn': {
-    #             'access_key_id': '123',
-    #             'secret_access_key': '321'
-    #         }
-    #     }
-    #     job.status_msg['source_regions'] = {'cn-east-1': 'ami-123'}
-    #     job.run_job()
+        mock_cleanup_image.assert_has_calls([
+            call(
+                '111_',
+                '_111',
+                ANY,
+                ANY,
+                image_id='ami-123'
+            ),
+            call(
+                '222_',
+                '_222',
+                ANY,
+                ANY,
+                image_id='ami-321'
+            )
+        ])
+        job._log_callback.warning.reset_mock()
+
+        # Exception in test
+        mock_test_image.side_effect = Exception('Tests broken!')
+        job.log_callback.reset_mock()
+        ec2_setup.reset_mock()
+        job.run_job()
+        job._log_callback.warning.assert_has_calls([
+            call('Image tests failed in region: us-east-2.')
+        ])
+        assert 'Tests broken!' in job._log_callback.error.mock_calls[1][1][0]
+        assert ec2_setup.clean_up.call_count == 1
+
+        # NO TEST REGIONS
+        mock_create_ssh_key_pair.reset_mock()
+        job = EC2TestJob(self.job_config, self.config)
+        job._log_callback = Mock()
+
+        mock_create_ssh_key_pair.assert_called_once_with('private_ssh_key.file')
+
+        job.test_regions = {}
+        with pytest.raises(MashTestException) as exc:
+            job.run_job()
+        assert 'At least one partition is required' in str(exc)
+        assert job._log_callback.error.called
 
     @patch('mash.services.test.ec2_job.create_ssh_key_pair')
     def test_ec2_skip_test(

--- a/test/unit/services/test/ec2_test_utils_test.py
+++ b/test/unit/services/test/ec2_test_utils_test.py
@@ -4,7 +4,8 @@ from mash.services.test.ec2_test_utils import (
     get_instance_feature_combinations,
     select_instances_for_tests,
     get_partition_test_regions,
-    get_image_id_for_region
+    get_image_id_for_region,
+    get_cpu_options
 )
 
 
@@ -246,3 +247,17 @@ class TestEC2TestUtils(object):
                 source_regions,
                 replicate_regions
             )
+
+    def test_get_cpu_options(self):
+        """tests the get_cpu_options"""
+
+        cpu_option = (
+            'cpu-option-1_value1,'
+            'cpu-option-2_disabled,'
+            'cpu-option-3_value3'
+        )
+        expected_result = {
+            'cpu-option-1': 'value1',
+            'cpu-option-3': 'value3'
+        }
+        assert expected_result == get_cpu_options(cpu_option)


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR includes the required cpu_options parameter when creating the test instance that will run the tests. This allows us to include the testing of instance features like the confidential compute ones.

### How will these changes be tested?

This change has been tested locally with a mash instance running against my aws account.

### How will this change be deployed? Any special considerations?


### Additional Information
