### PR TITLE
Includes the functionality to add tests depending on the instance features

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -255,6 +255,10 @@ cloud:
       nic:
         - gvnic_enabled
       confidential_compute: []
+    instance_feature_additional_tests:
+      AmdSev_enabled: []
+      AmdSevSnp_enabled: []
+      IntelTdx_enabled: []
 test:
   img_proof_timeout: 600
 upload:

--- a/mash/services/test/config.py
+++ b/mash/services/test/config.py
@@ -64,8 +64,8 @@ class TestConfig(BaseConfig):
 
     def get_ec2_instance_feature_additional_tests(self):
         """
-        Returns the additional tests configured for the different instance
-        features (if any).
+        Returns the additional tests configured for EC2 and the different
+        instance features (if any).
         """
         ec2_cloud_info = self.get_cloud_data().get('ec2', {})
         instance_feat_additional_tests = ec2_cloud_info.get(
@@ -87,3 +87,15 @@ class TestConfig(BaseConfig):
                 'GCE test instance catalog must be provided in config file.'
             )
         return instance_catalog
+
+    def get_gce_instance_feature_additional_tests(self):
+        """
+        Returns the additional tests configured for GCP and the different
+        instance features (if any).
+        """
+        gce_cloud_info = self.get_cloud_data().get('gce', {})
+        instance_feat_additional_tests = gce_cloud_info.get(
+            'instance_feature_additional_tests',
+            {}
+        )
+        return instance_feat_additional_tests

--- a/mash/services/test/gce_test_utils.py
+++ b/mash/services/test/gce_test_utils.py
@@ -252,3 +252,24 @@ def select_instance_config_for_feature_combination(
             'confidential_compute': confidential_compute
         }
     return instance_config
+
+
+def get_additional_tests_for_instance(
+    feature_combination,
+    additional_tests
+):
+    """Provides a list of additional tests configured for each instance type"""
+    tests = []
+
+    arch = feature_combination[0]
+    boot_type = feature_combination[1]
+    shielded_vm = feature_combination[2]
+    nic = feature_combination[3]
+    conf_compute = feature_combination[4]
+
+    tests.extend(additional_tests.get(arch, []))
+    tests.extend(additional_tests.get(boot_type, []))
+    tests.extend(additional_tests.get(shielded_vm, []))
+    tests.extend(additional_tests.get(nic, []))
+    tests.extend(additional_tests.get(conf_compute, []))
+    return tests

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -146,6 +146,11 @@ cloud:
       nic:
         - gvnic_enabled
       confidential_compute: []
+    instance_feature_additional_tests:
+      AmdSevSnp_enabled:
+        - test_sles_sev_snp
+      gvnic_enabled:
+        - test_gvnic
 test:
   img_proof_timeout: 600
 upload:

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -180,3 +180,15 @@ class TestTestConfig(object):
         ]
 
         assert self.config.get_test_gce_instance_catalog() == expected_catalog
+
+    def test_get_gce_instance_feature_additional_tests(self):
+        expected_additional_tests = {
+            "AmdSevSnp_enabled": [
+                "test_sles_sev_snp"
+            ],
+            "gvnic_enabled": [
+                "test_gvnic"
+            ]
+        }
+        assert self.config.get_ec2_instance_feature_additional_tests() == \
+            expected_additional_tests

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -190,5 +190,5 @@ class TestTestConfig(object):
                 "test_gvnic"
             ]
         }
-        assert self.config.get_ec2_instance_feature_additional_tests() == \
+        assert self.config.get_gce_instance_feature_additional_tests() == \
             expected_additional_tests

--- a/test/unit/services/test/gce_test_utils_test.py
+++ b/test/unit/services/test/gce_test_utils_test.py
@@ -2,7 +2,8 @@ from unittest.mock import Mock
 
 from mash.services.test.gce_test_utils import (
     get_instance_feature_combinations,
-    select_instance_configs_for_tests
+    select_instance_configs_for_tests,
+    get_additional_tests_for_instance
 )
 
 
@@ -326,3 +327,66 @@ class TestGCETestUtils(object):
         )
         assert instance_configs == []
         logger.error.assert_called_once_with(msg)
+
+    def test_get_additional_tests_for_instance(self):
+        """tests the select_instance_configs_for_tests"""
+
+        additional_tests = {
+            'AmdSev_enabled': [
+                'AmdSev_enabled_test_1',
+                'AmdSev_enabled_test_2',
+            ],
+            'AmdSevSnp_enabled': [
+                'AmdSevSnp_enabled_test_1'
+            ],
+            'IntelTdx_enabled': [],
+            'gvnic_enabled': [
+                'gvnic_enabled_test_1'
+            ]
+        }
+
+        test_cases = [
+            (
+                (
+                    'X86_64',
+                    'uefi',
+                    'securevm_disabled',
+                    'gvnic_enabled',
+                    'IntelTdx_enabled'
+                ),
+                [
+                    'gvnic_enabled_test_1'
+                ]
+            ),
+            (
+                (
+                    'X86_64',
+                    'uefi',
+                    'securevm_disabled',
+                    'gvnic_enabled',
+                    'AmdSev_enabled'
+                ),
+                [
+                    'gvnic_enabled_test_1',
+                    'AmdSev_enabled_test_1',
+                    'AmdSev_enabled_test_2',
+                ]
+            ),
+            (
+                (
+                    'X86_64',
+                    'uefi',
+                    'securevm_disabled',
+                    'gvnic_disabled',
+                    'confidentialcompute_disabled'
+                ),
+                []
+            )
+        ]
+
+        for feature_combination, expected_additional_tests in test_cases:
+            assert expected_additional_tests == \
+                get_additional_tests_for_instance(
+                    feature_combination=feature_combination,
+                    additional_tests=additional_tests
+                )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
This function and configuration option allows us to include additional tests to be run for some instances when some feature of the instance is activated (Sev or SevSnp for example).

### How will these changes be tested?
These changes will be tested with a local instance of mash running with personal cloud accounts.
