### PR TITLE
Adds support for a new `nvme_support` flag for aliyun jobs

### DIFF
--- a/mash/services/api/v1/schema/jobs/aliyun.py
+++ b/mash/services/api/v1/schema/jobs/aliyun.py
@@ -59,6 +59,10 @@ aliyun_job_message['properties']['disk_size'] = {
     'example': 20,
     'description': 'Size root disk in GB. Default is 20GB. '
 }
+aliyun_job_message['properties']['nvme_support'] = {
+    'type': 'boolean',
+    'description': 'Whether the image supports nvme storage or not.'
+}
 aliyun_job_message['required'].append('cloud_account')
 aliyun_job_message['required'].append('platform')
 aliyun_job_message['required'].append('launch_permission')

--- a/mash/services/create/aliyun_job.py
+++ b/mash/services/create/aliyun_job.py
@@ -41,6 +41,7 @@ class AliyunCreateJob(MashJob):
                 self.job_config['image_description']
             self.cloud_architecture = self.job_config['cloud_architecture']
             self.platform = self.job_config['platform']
+            self.nvme_support = self.job_config['nvme_support']
         except KeyError as error:
             raise MashCreateException(
                 'Aliyun create jobs require a(n) {0} '
@@ -92,6 +93,9 @@ class AliyunCreateJob(MashJob):
         kwargs = {}
         if self.disk_size:
             kwargs['disk_image_size'] = self.disk_size
+
+        if self.nvme_support:
+            kwargs['nvme_support'] = self.nvme_support
 
         image_id = aliyun_image.create_compute_image(
             self.cloud_image_name,

--- a/mash/services/jobcreator/aliyun_job.py
+++ b/mash/services/jobcreator/aliyun_job.py
@@ -36,6 +36,7 @@ class AliyunJob(BaseJob):
             self.bucket = self.kwargs['bucket']
             self.platform = self.kwargs['platform']
             self.launch_permission = self.kwargs['launch_permission']
+            self.nvme_support = self.kwargs.get('nvme_support', False)
         except KeyError as error:
             raise MashJobCreatorException(
                 'Aliyun jobs require a(n) {0} key in the job doc.'.format(
@@ -164,7 +165,8 @@ class AliyunJob(BaseJob):
                 'bucket': self.bucket,
                 'region': self.region,
                 'platform': self.platform,
-                'cloud_architecture': self.cloud_architecture
+                'cloud_architecture': self.cloud_architecture,
+                'nvme_support': self.nvme_support
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/test/unit/services/create/aliyun_job_test.py
+++ b/test/unit/services/create/aliyun_job_test.py
@@ -33,7 +33,8 @@ class TestAliyunCreateJob(object):
             'bucket': 'images',
             'cloud_image_name': 'sles-15-sp2-v20210316',
             'image_description': 'great image description',
-            'disk_size': 20
+            'disk_size': 20,
+            'nvme_support': True
         }
 
         self.job = AliyunCreateJob(job_doc, self.config)
@@ -70,7 +71,8 @@ class TestAliyunCreateJob(object):
             'sles-15-sp2-v20210316.qcow2',
             platform='SUSE',
             arch='x86_64',
-            disk_image_size=20
+            disk_image_size=20,
+            nvme_support=True
         )
 
         # Image doesnt exist


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR Includes a new flag in aliyun jobs called `nvme_support` that can be used to specify that the created  images support that feature in that cloud platform.

